### PR TITLE
[main] fix: preserve scroll position while streaming

### DIFF
--- a/cometline/src/lib/components/ChatThread.svelte
+++ b/cometline/src/lib/components/ChatThread.svelte
@@ -286,7 +286,10 @@
 	$effect(() => {
 		const streaming = sessionStreaming;
 		if (streaming && !wasStreaming) {
-			followStream = true;
+			followStream =
+				isInitialTranscriptPaint ||
+				chatStore.isLoading ||
+				(scroller ? isNearBottom(scroller) : followStream);
 		}
 		wasStreaming = streaming;
 	});


### PR DESCRIPTION
## Background

Streaming responses were re-enabling follow mode as soon as a stream started, which forced the transcript back to the bottom even when the user had scrolled upward. The thread now only follows a new stream when it is already near the bottom or still in initial loading.

[e0f6f90](https://github.com/Cometline/cometline/commit/e0f6f90d31de8c51effbe3e6d21a7cbe9231e6f5): The chat thread preserves manual scroll position on stream start while keeping bottom-follow behavior for users who are already at the bottom.

Validated with `cd cometline && pnpm run check`.