### PR TITLE
[main] feat: add bundled setup skill

### DIFF
--- a/cometmind/internal/skills/builtin.go
+++ b/cometmind/internal/skills/builtin.go
@@ -1,0 +1,52 @@
+package skills
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed builtin/*/SKILL.md
+var builtinSkills embed.FS
+
+// BuiltinRoot returns the materialized root for bundled skills.
+func BuiltinRoot() (string, error) {
+	return expandPath("~/.cometmind/builtin-skills")
+}
+
+func ensureBuiltinSkills() (string, error) {
+	root, err := BuiltinRoot()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", err
+	}
+	err = fs.WalkDir(builtinSkills, "builtin", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || filepath.Base(path) != "SKILL.md" {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, "builtin/")
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		raw, err := builtinSkills.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if existing, err := os.ReadFile(target); err == nil && string(existing) == string(raw) {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return err
+		}
+		return os.WriteFile(target, raw, 0o644)
+	})
+	if err != nil {
+		return "", err
+	}
+	return root, nil
+}

--- a/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
+++ b/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: setup-cometline
+description: Help configure Cometline providers, model defaults, skills, delegation, memory, storage, and gateways.
+---
+
+# Setup Cometline
+
+Use this skill when the user wants help configuring Cometline or CometMind. This includes initial setup, provider API keys, model selection, default model roles, Agent Skills, ACP delegation, Discord gateway settings, memory, storage, import/export, or troubleshooting a broken local setup.
+
+## Workflow
+
+1. Identify what the user wants to configure before changing anything. If the request is ambiguous, ask one focused question.
+2. Prefer the Settings UI for user-facing configuration instructions. Mention exact sections such as Settings -> Providers, Settings -> CometMind -> Skills, Settings -> CometMind -> ACP, Settings -> CometMind -> Discord, or Settings -> CometMind -> Storage.
+3. Prefer CLI commands when the user wants the agent to inspect or modify settings directly. Use `cometmind settings path`, `cometmind settings show`, `cometmind settings export`, and `cometmind settings import` when available.
+4. Treat provider API keys and exported settings as secrets. Warn the user before printing, exporting, or moving files that may contain API keys.
+5. After changing runtime settings that affect CometMind, tell the user whether a sidecar restart is expected. The desktop app restarts CometMind automatically for Settings UI saves.
+
+## Provider Setup
+
+Help the user choose a provider method, base URL, API key, enabled models, selected model, and default model roles. Environment variables such as `COMETMIND_PROVIDER`, `COMETMIND_BASE_URL`, `COMETMIND_API_KEY`, `COMETMIND_MODEL`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY` can override runtime behavior, so check them when settings appear correct but runtime behavior differs.
+
+## Skills Setup
+
+CometMind discovers skills from configured roots, `~/.cometmind/skills`, workspace `.agents/skills`, workspace `.claude/skills`, and optional OpenCode or Claude skill roots. User-created skills should normally live under `~/.cometmind/skills/{skill-name}/SKILL.md` or the workspace `.agents/skills` directory.
+
+Use `/create-skill` when the user wants the agent to create a reusable skill. The agent should use the `write_skill` tool rather than editing skill files manually when possible.
+
+## Delegation Setup
+
+ACP delegation is configured under Settings -> CometMind -> ACP. Use it when the user wants CometMind to hand coding work to OpenCode, Claude Code, or another ACP-compatible coding agent. Confirm the configured command, arguments, working directory behavior, and whether interactive mode is enabled.
+
+## Discord Gateway
+
+Discord gateway configuration lives under Settings -> CometMind -> Discord. Confirm the bot token environment variable name, workspace path, allowed user IDs, and mention requirements. Do not ask the user to paste bot tokens into chat unless there is no safer option.
+
+## Memory And Storage
+
+Memory and storage settings live under Settings -> CometMind. Explain what will be stored locally, what may be archived, and how provider/model choices affect extraction or summarization if the user is tuning memory behavior.
+
+## Troubleshooting
+
+If settings do not persist, check `~/.cometmind/cometline-settings.json` and file permissions. If the sidecar will not start, check `~/.cometmind/cometline.log`, port `7700`, and the packaged or development CometMind binary path.

--- a/cometmind/internal/skills/skills.go
+++ b/cometmind/internal/skills/skills.go
@@ -43,7 +43,7 @@ type frontmatter struct {
 	} `yaml:"metadata"`
 }
 
-// DefaultRoots returns the CometMind/OpenCode/Claude roots plus workspace-local roots.
+// DefaultRoots returns configured, CometMind, workspace-local, OpenCode, and Claude roots.
 func DefaultRoots(workspaceRoot string, cfg Config) []string {
 	roots := make([]string, 0, 5+len(cfg.Roots))
 	roots = append(roots, cfg.Roots...)
@@ -68,7 +68,13 @@ func Discover(workspaceRoot string, cfg Config) Registry {
 	}
 	reg := Registry{byName: map[string]Skill{}}
 	seenRoot := map[string]bool{}
-	for _, root := range DefaultRoots(workspaceRoot, cfg) {
+	roots := DefaultRoots(workspaceRoot, cfg)
+	if builtinRoot, err := ensureBuiltinSkills(); err != nil {
+		reg.Errors = append(reg.Errors, err.Error())
+	} else if builtinRoot != "" {
+		roots = append(roots, builtinRoot)
+	}
+	for _, root := range roots {
 		expanded, err := expandPath(root)
 		if err != nil {
 			reg.Errors = append(reg.Errors, err.Error())

--- a/cometmind/internal/skills/skills_test.go
+++ b/cometmind/internal/skills/skills_test.go
@@ -22,15 +22,45 @@ func TestDiscoverFindsSkillsAndDeduplicatesByRootOrder(t *testing.T) {
 
 	reg := Discover("", Config{Enabled: true, Roots: []string{rootA, rootB}})
 
-	if len(reg.Skills) != 2 {
-		t.Fatalf("len(Skills) = %d, want 2; errors=%v", len(reg.Skills), reg.Errors)
-	}
 	alpha, ok := reg.Find("alpha")
 	if !ok {
 		t.Fatal("alpha not found")
 	}
 	if alpha.Description != "first" {
 		t.Fatalf("alpha description = %q, want first", alpha.Description)
+	}
+}
+
+func TestDiscoverIncludesBundledSetupSkill(t *testing.T) {
+	isolatedSkillsHome(t)
+
+	reg := Discover("", Config{Enabled: true})
+
+	skill, ok := reg.Find("setup-cometline")
+	if !ok {
+		t.Fatalf("setup-cometline not found; errors=%v", reg.Errors)
+	}
+	if skill.Internal {
+		t.Fatal("setup-cometline should be visible to users")
+	}
+	if !strings.Contains(reg.PromptIndex(), "setup-cometline") {
+		t.Fatal("prompt index should include setup-cometline")
+	}
+}
+
+func TestDiscoverLetsUserSkillOverrideBundledSkill(t *testing.T) {
+	isolatedSkillsHome(t)
+	root := t.TempDir()
+	writeSkill(t, root, "setup-cometline", "custom setup guidance")
+
+	reg := Discover("", Config{Enabled: true, Roots: []string{root}})
+
+	skill, ok := reg.Find("setup-cometline")
+	if !ok {
+		t.Fatal("setup-cometline not found")
+	}
+	if skill.Description != "custom setup guidance" {
+		t.Fatalf("description = %q, want custom setup guidance", skill.Description)
 	}
 }
 
@@ -46,8 +76,8 @@ func TestDiscoverSkipsMalformedSkills(t *testing.T) {
 	}
 
 	reg := Discover("", Config{Enabled: true, Roots: []string{root}})
-	if len(reg.Skills) != 0 {
-		t.Fatalf("len(Skills) = %d, want 0", len(reg.Skills))
+	if _, ok := reg.Find("bad"); ok {
+		t.Fatal("malformed skill should not be discovered")
 	}
 	if len(reg.Errors) == 0 {
 		t.Fatal("expected parse error")
@@ -65,7 +95,7 @@ func TestSyncMirrorCreatesSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(created) != 1 || created[0] != "alpha" || len(skipped) != 0 {
+	if !containsString(created, "alpha") || len(skipped) != 0 {
 		t.Fatalf("created=%v skipped=%v", created, skipped)
 	}
 	info, err := os.Lstat(filepath.Join(mirror, "alpha"))
@@ -75,6 +105,15 @@ func TestSyncMirrorCreatesSymlinks(t *testing.T) {
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Fatal("mirror entry is not a symlink")
 	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func writeSkill(t *testing.T, root, name, desc string) {


### PR DESCRIPTION
## Background

Cometline needs a default skill that helps users and agents configure providers, skills, delegation, memory, storage, and gateways without requiring a separate install. Bundled skills are materialized into the CometMind data directory after user roots, so user-managed skills keep precedence.

[78e1d9e](https://github.com/Cometline/cometline/commit/78e1d9eae97229a4dd1ad8fa5c94fb17dbf89ea3): Bundled skill discovery now adds the visible `setup-cometline` skill while preserving user override behavior and existing file-based skill loading.

Validated with `cd cometmind && go test ./internal/skills` and `cd cometmind && go test ./...`.