### PR TITLE
[main] feat: add settings import export

### DIFF
--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -576,18 +576,7 @@ function readProviderSettings() {
 		selectedModel: process.env.COMETMIND_MODEL
 	};
 
-	let saved = {};
-	const settingsPath = getSettingsPath();
-	if (fs.existsSync(settingsPath)) {
-		try {
-			saved = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-		} catch {
-			saved = {};
-		}
-	}
-
-	const iconVariant = readSavedIconVariant(saved);
-	const base = parseAndNormalizeSettings(saved, settingsNormalizeOptions(iconVariant));
+	const base = readSavedProviderSettings();
 
 	// Allow env overrides for the active provider only. Apply provider first so
 	// key/baseURL/model attach to the provider selected by COMETMIND_PROVIDER.
@@ -609,8 +598,23 @@ function readProviderSettings() {
 	return base;
 }
 
+function readSavedProviderSettings() {
+	let saved = {};
+	const settingsPath = getSettingsPath();
+	if (fs.existsSync(settingsPath)) {
+		try {
+			saved = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+		} catch {
+			saved = {};
+		}
+	}
+
+	const iconVariant = readSavedIconVariant(saved);
+	return parseAndNormalizeSettings(saved, settingsNormalizeOptions(iconVariant));
+}
+
 function writeProviderSettings(settings) {
-	const current = readProviderSettings();
+	const current = readSavedProviderSettings();
 	const nextProviders = Array.isArray(settings.providers)
 		? normalizeProviders(settings.providers)
 		: current.providers;
@@ -649,6 +653,53 @@ function writeProviderSettings(settings) {
 		/* ignore */
 	}
 	return next;
+}
+
+async function exportProviderSettings() {
+	const settings = readSavedProviderSettings();
+	const result = await dialog.showSaveDialog(mainWindow, {
+		title: 'Export Cometline settings',
+		defaultPath: 'cometline-settings.json',
+		filters: [{ name: 'JSON', extensions: ['json'] }]
+	});
+	if (result.canceled || !result.filePath) {
+		return { canceled: true };
+	}
+
+	fs.writeFileSync(result.filePath, JSON.stringify(settings, null, 2));
+	try {
+		fs.chmodSync(result.filePath, 0o600);
+	} catch {
+		/* ignore */
+	}
+	return { canceled: false, path: result.filePath };
+}
+
+async function importProviderSettings() {
+	const result = await dialog.showOpenDialog(mainWindow, {
+		title: 'Import Cometline settings',
+		properties: ['openFile'],
+		filters: [{ name: 'JSON', extensions: ['json'] }]
+	});
+	if (result.canceled || result.filePaths.length === 0) {
+		return { canceled: true };
+	}
+
+	const filePath = result.filePaths[0];
+	const raw = fs.readFileSync(filePath, 'utf8');
+	const parsed = JSON.parse(raw);
+	const iconVariant = readSavedIconVariant(parsed);
+	const imported = validateSettings(
+		parseAndNormalizeSettings(parsed, settingsNormalizeOptions(iconVariant))
+	);
+	const saved = writeProviderSettings(imported);
+	await stopCometMind();
+	startCometMind();
+	void waitForHealth();
+	await syncDiscordGatewayFromSettings(saved);
+	applyOpenAtLoginSetting(saved.app?.openAtLogin);
+	applyIconVariant(saved.app?.iconVariant);
+	return { canceled: false, path: filePath, settings: saved };
 }
 
 function providerEnv() {
@@ -1932,6 +1983,10 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	applyIconVariant(saved.app?.iconVariant);
 	return saved;
 });
+
+ipcMain.handle('cometline:export-provider-settings', () => exportProviderSettings());
+
+ipcMain.handle('cometline:import-provider-settings', () => importProviderSettings());
 
 ipcMain.handle('cometline:get-discord-gateway-status', () => {
 	const settings = readProviderSettings();

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -23,6 +23,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 	fetchProviderModels: (config) => ipcRenderer.invoke('cometline:fetch-provider-models', config),
 	saveProviderSettings: (settings, options) =>
 		ipcRenderer.invoke('cometline:save-provider-settings', settings, options),
+	exportProviderSettings: () => ipcRenderer.invoke('cometline:export-provider-settings'),
+	importProviderSettings: () => ipcRenderer.invoke('cometline:import-provider-settings'),
 	setSidebarOpen: (payload) => ipcRenderer.send('cometline:set-sidebar-open', payload),
 	getFullScreen: () => ipcRenderer.invoke('cometline:get-fullscreen'),
 	onFullScreenChange: (callback) => {

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -81,6 +81,10 @@ declare global {
 		cometmind: CometMindSettings;
 	}
 
+	type SettingsFileResult =
+		| { canceled: true }
+		| { canceled: false; path: string; settings?: ProviderSettings };
+
 	interface CometMindACPSettings {
 		command: string;
 		args: string[];
@@ -184,6 +188,8 @@ declare global {
 				settings: ProviderSettings,
 				options?: { restartCometMind?: boolean }
 			) => Promise<ProviderSettings>;
+			exportProviderSettings?: () => Promise<SettingsFileResult>;
+			importProviderSettings?: () => Promise<SettingsFileResult>;
 			setSidebarOpen?: (state: SidebarChromeState) => void;
 			getFullScreen?: () => Promise<boolean>;
 			onFullScreenChange?: (callback: (isFullScreen: boolean) => void) => () => void;

--- a/cometline/src/lib/components/SettingsPanel.svelte
+++ b/cometline/src/lib/components/SettingsPanel.svelte
@@ -13,6 +13,7 @@
 		RefreshCw,
 		Settings,
 		Trash2,
+		Upload,
 		Workflow,
 		X,
 		Brain,
@@ -117,6 +118,8 @@
 	let updateState = $state<UpdateState>({ status: 'idle' });
 	let checkingUpdates = $state(false);
 	let installingUpdate = $state(false);
+	let exportingSettings = $state(false);
+	let importingSettings = $state(false);
 	let cometmindPanelKey = $state(0);
 	let cometmindPanel = $state<SettingsCometMindPanel | undefined>();
 	let memoryPanelKey = $state(0);
@@ -259,6 +262,53 @@
 				error instanceof Error ? error.message : 'Failed to clean up workspaces.';
 		} finally {
 			workspacePruning = false;
+		}
+	}
+
+	async function exportSettings() {
+		if (exportingSettings) return;
+		const api = window.electronAPI;
+		if (!api?.exportProviderSettings) {
+			status = 'Settings export is only available in the desktop app.';
+			return;
+		}
+		exportingSettings = true;
+		status = '';
+		try {
+			const result = await api.exportProviderSettings();
+			if (!result.canceled) {
+				status = `Settings exported to ${result.path}. Keep this file private because it may include API keys.`;
+			}
+		} catch (error) {
+			status = error instanceof Error ? error.message : 'Failed to export settings.';
+		} finally {
+			exportingSettings = false;
+		}
+	}
+
+	async function importSettings() {
+		if (importingSettings) return;
+		const api = window.electronAPI;
+		if (!api?.importProviderSettings) {
+			status = 'Settings import is only available in the desktop app.';
+			return;
+		}
+		importingSettings = true;
+		status = '';
+		try {
+			const result = await api.importProviderSettings();
+			if (!result.canceled && result.settings) {
+				settingsStore.apply(result.settings);
+				draft = cloneSettings(result.settings);
+				selectedProviderId = result.settings.activeProviderId || result.settings.providers[0]?.id || '';
+				cometmindPanelKey += 1;
+				memoryPanelKey += 1;
+				status = 'Settings imported. CometMind is restarting with the imported configuration.';
+			}
+		} catch (error) {
+			status = error instanceof Error ? error.message : 'Failed to import settings.';
+		} finally {
+			importingSettings = false;
 		}
 	}
 
@@ -1058,6 +1108,32 @@
 							onOpenAtLoginChange={setOpenAtLogin}
 						/>
 						<div class="about-pane">
+						<div class="about-row settings-file-row">
+							<div class="workspace-info">
+								<span class="about-label">Settings backup</span>
+								<span class="about-hint">
+									Export or import all Cometline settings. Exports may include provider API keys.
+								</span>
+							</div>
+							<div class="settings-file-actions">
+								<button class="secondary" onclick={exportSettings} disabled={exportingSettings}>
+									{#if exportingSettings}
+										<span class="spin small"><LoaderCircle size={14} /></span>
+									{:else}
+										<Download size={14} />
+									{/if}
+									Export
+								</button>
+								<button class="secondary" onclick={importSettings} disabled={importingSettings}>
+									{#if importingSettings}
+										<span class="spin small"><LoaderCircle size={14} /></span>
+									{:else}
+										<Upload size={14} />
+									{/if}
+									Import
+								</button>
+							</div>
+						</div>
 						<div class="about-row">
 							<span class="about-label">Version</span>
 							<span class="about-value">{appVersion || '—'}</span>
@@ -1774,6 +1850,17 @@
 		align-items: flex-start;
 	}
 
+	.settings-file-row {
+		align-items: flex-start;
+	}
+
+	.settings-file-actions {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+
 	.workspace-info {
 		display: grid;
 		gap: 6px;
@@ -1854,6 +1941,14 @@
 		.provider-shell,
 		.form-grid {
 			grid-template-columns: 1fr;
+		}
+
+		.settings-file-row {
+			flex-direction: column;
+		}
+
+		.settings-file-actions {
+			justify-content: flex-start;
 		}
 
 		.modal {


### PR DESCRIPTION
## Background

Users need a safe way to back up and restore Cometline settings, including provider configuration. The desktop settings panel now exposes JSON export and import through Electron dialogs, while keeping exports based on the saved settings file rather than environment-overridden runtime settings.

[5e4d051](https://github.com/Cometline/cometline/commit/5e4d051): Settings import and export now use Electron IPC, preload bindings, and typed renderer APIs. The App settings page adds backup controls with a warning that exported files may include provider API keys, and imported settings are validated, persisted, applied to the running store, and followed by a CometMind restart.

### Reference

Validation: Loading svelte-check in workspace: /Users/tomlord/workspace/personal-project/cometline/cometline
Getting Svelte diagnostics...

svelte-check found 0 errors and 0 warnings
Validation: 
Validation: 