### PR TITLE
[main] chore: ignore generated settings schema in eslint

### DIFF
--- a/cometline/eslint.config.js
+++ b/cometline/eslint.config.js
@@ -14,6 +14,7 @@ export default [
 			'build/',
 			'buildResources/',
 			'dist/',
+			'electron/settings-schema.cjs',
 			'node_modules/',
 			'pnpm-lock.yaml',
 			'static/',


### PR DESCRIPTION
## Background

`electron/settings-schema.cjs` is produced by `scripts/build-settings-schema.mjs` (esbuild bundle of `src/lib/settings/schema.ts`) and was previously linted, surfacing eight false-positive errors from the generated output. The file is auto-generated, so the eslint config now ignores it.

[2679cfe](https://github.com/Cometline/cometline/commit/2679cfe0d3490e34d84d0f61a3bdbdcc383e457f): add `electron/settings-schema.cjs` to the eslint ignore list.