### PR TITLE
[main] chore: clean up lint issues in source

### DIFF
--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -5,6 +5,7 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
+// eslint-disable-next-line no-redeclare
 const crypto = require('crypto');
 const {
 	defaultSettings,

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -214,13 +214,3 @@ declare global {
 }
 
 export {};
-
-declare namespace svelteHTML {
-	interface IntrinsicElements {
-		webview: import('svelte/elements').HTMLAttributes<HTMLElement> & {
-			src?: string;
-			sandbox?: string;
-			partition?: string;
-		};
-	}
-}

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -29,7 +29,7 @@
 	});
 
 	$effect(() => {
-		activeSessionId;
+		void activeSessionId;
 		shellStore.onActiveSessionChange();
 	});
 

--- a/cometline/src/lib/components/ChatThread.svelte
+++ b/cometline/src/lib/components/ChatThread.svelte
@@ -274,7 +274,7 @@
 	}
 
 	$effect(() => {
-		sessionId;
+		void sessionId;
 		followStream = true;
 		if (sessionHasCachedTranscript(sessionId)) {
 			isInitialTranscriptPaint = false;

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -117,12 +117,12 @@
 	}
 
 	$effect(() => {
-		sessionStore.sessions;
+		void sessionStore.sessions;
 		syncSessionFromStore();
 	});
 
 	$effect(() => {
-		sessionId;
+		void sessionId;
 		firstTurnActive = false;
 		firstTurnFlightDone = false;
 		heroFrameExiting = false;

--- a/cometline/src/lib/components/Composer.svelte
+++ b/cometline/src/lib/components/Composer.svelte
@@ -237,7 +237,7 @@
 
 	$effect(() => {
 		if (!autofocus) return;
-		sessionId;
+		void sessionId;
 		void focusInput();
 	});
 

--- a/cometline/src/lib/components/RichComposerInput.svelte
+++ b/cometline/src/lib/components/RichComposerInput.svelte
@@ -391,7 +391,7 @@
 		return chip;
 	}
 
-	const mentionQueryChars = /^[a-zA-Z0-9_/\.\-]*$/;
+	const mentionQueryChars = /^[a-zA-Z0-9_/.-]*$/;
 
 	interface ActiveMention {
 		query: string;

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -293,12 +293,11 @@ describe('chatStore session switching', () => {
 		).toBe(false);
 	});
 
-	it('surfaces an error item when streamMessage throws before any output', async () => {
-		vi.mocked(streamMessage).mockImplementation(async function* () {
-			throw new Error('cometsdk: openai: authentication failed (HTTP 401)');
-			// eslint-disable-next-line no-unreachable
-			yield { type: 'done' };
-		});
+		it('surfaces an error item when streamMessage throws before any output', async () => {
+			vi.mocked(streamMessage).mockImplementation(async function* () {
+				throw new Error('cometsdk: openai: authentication failed (HTTP 401)');
+				yield { type: 'done' };
+			});
 
 		chatStore.bindSession('sess-a');
 		await chatStore.send('sess-a', 'hi');

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -11,7 +11,6 @@ import {
 	parseAndNormalizeSettings,
 	runtimeProviders,
 	runtimeSlice,
-	validateSettings,
 	type CometMindSettings,
 	type RuntimeSettingsSlice
 } from '$lib/settings/schema';
@@ -19,7 +18,6 @@ import type { MemorySettings } from '$lib/client/cometmind';
 import type { ProviderConfig, ProviderSettings } from '$lib/types';
 import { defaultKeyboardShortcuts } from '$lib/keyboard-shortcuts';
 import { modelStore } from './model.svelte';
-import { connectionState } from './runtime.svelte';
 import { persistSettings } from '$lib/settings/persist';
 
 const LOCAL_SETTINGS_KEY = 'cometline-settings';


### PR DESCRIPTION
## Background

`pnpm run lint` reported a number of pre-existing lint issues across source files. With `electron/settings-schema.cjs` now ignored, this PR addresses the remaining real source-code problems.

[16ae62e](https://github.com/Cometline/cometline/commit/16ae62efe3614731af6f81aa16ac123bea6cacd6): the changes silence the false-positive `no-redeclare` for the Node `crypto` module in `electron/main.cjs`, remove the unused `svelteHTML` namespace from `src/app.d.ts`, drop two unused imports in `src/lib/stores/settings.svelte.ts`, switch bare variable reads to `void` expression statements in Svelte 5 effects (`AppShell.svelte`, `ChatThread.svelte`, `ChatView.svelte`, `Composer.svelte`), simplify the mention query regex in `RichComposerInput.svelte`, and remove a stale `eslint-disable` comment in `src/lib/stores/chat.svelte.test.ts`.