### PR TITLE
[main] fix: guard login items in dev builds

### DIFF
--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -138,6 +138,12 @@ let updateCheckTimer = null;
 let windowButtonAnimationTimer = null;
 let windowButtonPosition = { x: 16, y: 17 };
 
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
+
+if (!hasSingleInstanceLock) {
+	app.quit();
+}
+
 // Vertically center the native buttons on the sidebar search bar. The titlebar
 // row now sits flush against the window top, so the search input center is:
 // titlebar row top padding (10px) + half the 28px search input (14px) = 24px.
@@ -1051,6 +1057,12 @@ function openMacLoginItemsSettings() {
 }
 
 function readLoginItemState() {
+	if (!app.isPackaged) {
+		return {
+			openAtLogin: false,
+			status: 'unsupported'
+		};
+	}
 	const query =
 		process.platform === 'darwin' && isMacOS13OrLater()
 			? { type: 'mainAppService' }
@@ -1067,6 +1079,17 @@ function applyOpenAtLoginSetting(openAtLogin) {
 	const wantsLogin = Boolean(openAtLogin);
 	if (process.platform !== 'darwin' && process.platform !== 'win32') {
 		return { openAtLogin: false, status: 'unsupported' };
+	}
+	if (!app.isPackaged) {
+		if (wantsLogin) {
+			console.warn('Open at login is only supported in packaged builds.');
+		}
+		return {
+			openAtLogin: false,
+			status: 'unsupported',
+			isDev: wantsLogin && process.platform === 'darwin',
+			message: 'Open at login is only supported in packaged builds.'
+		};
 	}
 
 	const settings = { openAtLogin: wantsLogin };
@@ -2108,6 +2131,9 @@ async function fetchProviderModels(config) {
 }
 
 app.whenReady().then(async () => {
+	if (!hasSingleInstanceLock) {
+		return;
+	}
 	// Serve the packaged bundle over the custom app:// scheme.
 	if (app.isPackaged) registerAppProtocol();
 
@@ -2139,6 +2165,10 @@ app.whenReady().then(async () => {
 	await windowReady;
 	applyIconVariant(startupSettings.app?.iconVariant);
 	configureAutoUpdater();
+
+	app.on('second-instance', () => {
+		showMainWindow();
+	});
 
 	app.on('activate', () => {
 		// Reopening from the Dock: re-show the warm, hidden window if it still


### PR DESCRIPTION
## Background

macOS login items could launch the raw Electron binary from `node_modules` when open at login was enabled in a dev build, which opened Electron's default welcome window alongside the real app. The app also had no single-instance guard, so duplicate launches stayed alive.

[654022b](https://github.com/Cometline/cometline/commit/654022b71c4140be6ad8dd873e6696454d497134): Added a single-instance lock and second-instance activation flow in the Electron main process, and made login item state and registration unsupported outside packaged builds so dev mode no longer registers the wrong executable.