### PR TITLE
[main] feat: support discord clear command

### DIFF
--- a/cometmind/cmd/gateway.go
+++ b/cometmind/cmd/gateway.go
@@ -89,6 +89,9 @@ func runGateway(_ *cobra.Command, _ []string) error {
 		adapter.SetChangeWorkspaceHandler(func(ctx context.Context, msg gateway.InboundMessage, path string) (string, error) {
 			return router.ChangeWorkspace(ctx, msg, path)
 		})
+		adapter.SetClearHandler(func(ctx context.Context, msg gateway.InboundMessage) (string, error) {
+			return router.HandleClearSlash(ctx, msg)
+		})
 		adapter.SetWorkspaceSuggestHandler(func(ctx context.Context, query string) ([]string, error) {
 			return router.SuggestWorkspacePaths(ctx, query, 25)
 		})

--- a/cometmind/internal/gateway/discord/adapter.go
+++ b/cometmind/internal/gateway/discord/adapter.go
@@ -20,18 +20,19 @@ const PlatformName = "discord"
 
 // Adapter connects CometMind to Discord via discordgo.
 type Adapter struct {
-	Config    config.DiscordGatewayConfig
-	Session   *discordgo.Session
-	onInbound func(context.Context, gateway.InboundMessage)
-	onThread  func(context.Context, string, string, string) error
-	onChange  func(context.Context, gateway.InboundMessage, string) (string, error)
-	onSuggest func(context.Context, string) ([]string, error)
-	onJobs    func(context.Context, gateway.InboundMessage, string) (string, string, error)
-	jobSuggest func(context.Context, string) ([]jobs.Job, error)
-	onCreateJob func(context.Context, gateway.InboundMessage, string, string, string) (string, error)
-	onJobProposalSelect func(string, string) (string, error)
+	Config               config.DiscordGatewayConfig
+	Session              *discordgo.Session
+	onInbound            func(context.Context, gateway.InboundMessage)
+	onThread             func(context.Context, string, string, string) error
+	onChange             func(context.Context, gateway.InboundMessage, string) (string, error)
+	onClear              func(context.Context, gateway.InboundMessage) (string, error)
+	onSuggest            func(context.Context, string) ([]string, error)
+	onJobs               func(context.Context, gateway.InboundMessage, string) (string, string, error)
+	jobSuggest           func(context.Context, string) ([]jobs.Job, error)
+	onCreateJob          func(context.Context, gateway.InboundMessage, string, string, string) (string, error)
+	onJobProposalSelect  func(string, string) (string, error)
 	onJobProposalConfirm func(context.Context, gateway.InboundMessage, string) (string, error)
-	onJobProposalCancel func(string) error
+	onJobProposalCancel  func(string) error
 
 	mu sync.Mutex
 }
@@ -96,6 +97,11 @@ func (a *Adapter) SetThreadCreatedHandler(fn func(context.Context, string, strin
 // SetChangeWorkspaceHandler registers the callback used for /change slash commands.
 func (a *Adapter) SetChangeWorkspaceHandler(fn func(context.Context, gateway.InboundMessage, string) (string, error)) {
 	a.onChange = fn
+}
+
+// SetClearHandler registers the callback used for /clear slash commands.
+func (a *Adapter) SetClearHandler(fn func(context.Context, gateway.InboundMessage) (string, error)) {
+	a.onClear = fn
 }
 
 // SetWorkspaceSuggestHandler registers autocomplete suggestions for /change path.
@@ -195,6 +201,10 @@ func applicationCommands() []*discordgo.ApplicationCommand {
 					Required:    false,
 				},
 			},
+		},
+		{
+			Name:        "clear",
+			Description: "Clear this channel's CometMind conversation transcript",
 		},
 		{
 			Name:        "change",

--- a/cometmind/internal/gateway/discord/commands.go
+++ b/cometmind/internal/gateway/discord/commands.go
@@ -163,6 +163,22 @@ func (a *Adapter) handleChangeCommand(s *discordgo.Session, i *discordgo.Interac
 	})
 }
 
+func (a *Adapter) handleClearCommand(s *discordgo.Session, i *discordgo.InteractionCreate, _ discordgo.ApplicationCommandInteractionData) {
+	if a.onClear == nil {
+		respondEphemeral(s, i, "Session clearing is not configured.")
+		return
+	}
+
+	msg := routingInboundMessage(s, i)
+	text, err := a.onClear(context.Background(), msg)
+	if err != nil {
+		respondEphemeral(s, i, fmt.Sprintf("Failed to clear session: %v", err))
+		return
+	}
+
+	respondEphemeral(s, i, text)
+}
+
 func (a *Adapter) handleJobsCommand(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) {
 	jobID := ""
 	for _, opt := range data.Options {

--- a/cometmind/internal/gateway/discord/interactions.go
+++ b/cometmind/internal/gateway/discord/interactions.go
@@ -19,6 +19,8 @@ func (a *Adapter) onInteractionCreate(s *discordgo.Session, i *discordgo.Interac
 			a.handleThreadCommand(s, i, data)
 		case "create-skill":
 			a.handleCreateSkillCommand(s, i, data)
+		case "clear":
+			a.handleClearCommand(s, i, data)
 		case "change":
 			a.handleChangeCommand(s, i, data)
 		case "jobs":

--- a/cometmind/internal/gateway/router.go
+++ b/cometmind/internal/gateway/router.go
@@ -290,6 +290,32 @@ func (r *Router) ChangeWorkspace(ctx context.Context, msg InboundMessage, worksp
 	return fmt.Sprintf("Switched workspace to `%s`.", runPath), nil
 }
 
+// HandleClearSlash clears the transcript for the session mapped to the current
+// platform channel or thread while preserving the session identity.
+func (r *Router) HandleClearSlash(ctx context.Context, msg InboundMessage) (string, error) {
+	if r == nil || r.Sessions == nil {
+		return "", fmt.Errorf("gateway router is not configured")
+	}
+	if !r.allowed(msg) {
+		return "", fmt.Errorf("not allowed")
+	}
+
+	mapped, err := r.Sessions.LookupGatewaySession(ctx, msg.Platform, msg.UserID, msg.ChannelID, msg.ThreadID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("no active session in this channel; send a message first")
+	}
+	if err != nil {
+		return "", err
+	}
+	if r.Turns != nil && r.Turns.Running(mapped.CometmindSessionID) {
+		return "", fmt.Errorf("session is running")
+	}
+	if err := r.Sessions.ClearSessionTranscript(ctx, mapped.CometmindSessionID); err != nil {
+		return "", err
+	}
+	return "Cleared this CometMind conversation transcript.", nil
+}
+
 // SuggestWorkspacePaths returns workspace roots matching query for autocomplete UIs.
 func (r *Router) SuggestWorkspacePaths(ctx context.Context, query string, limit int) ([]string, error) {
 	if r == nil || r.Sessions == nil {

--- a/cometmind/internal/gateway/router_test.go
+++ b/cometmind/internal/gateway/router_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cometline/cometmind/internal/config"
@@ -181,6 +182,174 @@ func TestChangeWorkspaceUpdatesSessionPath(t *testing.T) {
 	}
 	if updated.WorkspaceID != ws2.ID {
 		t.Fatalf("workspace_id = %q, want %q", updated.WorkspaceID, ws2.ID)
+	}
+}
+
+func TestHandleClearSlashClearsMappedSessionTranscript(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cometmind.db")
+	sqlDB, err := store.OpenSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	svc := session.New(sqlDB)
+	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+
+	r := &Router{
+		Sessions: svc,
+		Config: &config.Config{
+			Gateway: config.GatewayConfig{
+				Discord: config.DiscordGatewayConfig{
+					WorkspacePath: ws.Path,
+				},
+			},
+		},
+	}
+
+	sess, err := svc.NewSession(ctx, ws.ID, "test-model", "test-provider")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if _, err := svc.UpsertGatewaySession(ctx, "discord", "user-1", "chan-1", "", sess.ID, ws.ID); err != nil {
+		t.Fatalf("UpsertGatewaySession() error = %v", err)
+	}
+	if _, err := svc.AppendUserMessageContent(ctx, sess.ID, []session.ContentBlock{{Type: "text", Text: "hello"}}, ""); err != nil {
+		t.Fatalf("AppendUserMessageContent() error = %v", err)
+	}
+	if err := svc.SetTitleIfEmpty(ctx, sess.ID, "hello"); err != nil {
+		t.Fatalf("SetTitleIfEmpty() error = %v", err)
+	}
+
+	msg, err := r.HandleClearSlash(ctx, InboundMessage{
+		Platform:  "discord",
+		UserID:    "user-1",
+		ChannelID: "chan-1",
+		Mentioned: true,
+	})
+	if err != nil {
+		t.Fatalf("HandleClearSlash() error = %v", err)
+	}
+	if msg != "Cleared this CometMind conversation transcript." {
+		t.Fatalf("confirmation = %q", msg)
+	}
+
+	transcript, err := svc.LoadTranscript(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("LoadTranscript() error = %v", err)
+	}
+	if len(transcript) != 0 {
+		t.Fatalf("transcript len = %d, want 0", len(transcript))
+	}
+	updated, err := svc.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if updated.Title != "" {
+		t.Fatalf("title = %q, want empty", updated.Title)
+	}
+	if updated.TokenUsage != "{}" {
+		t.Fatalf("token_usage = %q, want {}", updated.TokenUsage)
+	}
+}
+
+func TestHandleClearSlashRequiresExistingSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cometmind.db")
+	sqlDB, err := store.OpenSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	svc := session.New(sqlDB)
+	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+
+	r := &Router{
+		Sessions: svc,
+		Config: &config.Config{
+			Gateway: config.GatewayConfig{
+				Discord: config.DiscordGatewayConfig{
+					WorkspacePath: ws.Path,
+				},
+			},
+		},
+	}
+
+	_, err = r.HandleClearSlash(ctx, InboundMessage{
+		Platform:  "discord",
+		UserID:    "user-1",
+		ChannelID: "chan-1",
+		Mentioned: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no active session in this channel") {
+		t.Fatalf("HandleClearSlash() error = %v, want no active session", err)
+	}
+}
+
+func TestHandleClearSlashRejectsRunningSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cometmind.db")
+	sqlDB, err := store.OpenSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	svc := session.New(sqlDB)
+	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+
+	turns := NewTurnRunTracker()
+	r := &Router{
+		Sessions: svc,
+		Turns:    turns,
+		Config: &config.Config{
+			Gateway: config.GatewayConfig{
+				Discord: config.DiscordGatewayConfig{
+					WorkspacePath: ws.Path,
+				},
+			},
+		},
+	}
+
+	sess, err := svc.NewSession(ctx, ws.ID, "test-model", "test-provider")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if _, err := svc.UpsertGatewaySession(ctx, "discord", "user-1", "chan-1", "", sess.ID, ws.ID); err != nil {
+		t.Fatalf("UpsertGatewaySession() error = %v", err)
+	}
+
+	_, finish, err := turns.Start(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer finish()
+
+	_, err = r.HandleClearSlash(ctx, InboundMessage{
+		Platform:  "discord",
+		UserID:    "user-1",
+		ChannelID: "chan-1",
+		Mentioned: true,
+	})
+	if err == nil || err.Error() != "session is running" {
+		t.Fatalf("HandleClearSlash() error = %v, want session is running", err)
 	}
 }
 


### PR DESCRIPTION
## Background

Discord should support the same clear-session behavior as the Cometline composer so users can reset the CometMind transcript for the current channel or thread without deleting the session mapping.

[899574d](https://github.com/Cometline/cometline/commit/899574dc7d99595406371be287a882d843a1cb92): Wired a new `/clear` slash command through the Discord adapter and gateway router, then reused `ClearSessionTranscript` so the command matches the existing composer behavior and rejects missing or running sessions.

### Reference

[Issue #10](https://github.com/Cometline/cometline/issues/10)