### PR TITLE
[main] feat: add hotkey mini window

### DIFF
--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -620,6 +620,23 @@ function showMainWindow() {
 	}
 }
 
+async function openSessionInMainWindow(sessionId) {
+	const cleanSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+	if (!cleanSessionId) return false;
+	if (!windowCanShow(mainWindow)) {
+		await createWindow();
+	}
+	if (!windowCanShow(mainWindow)) return false;
+	if (mainWindow.isMinimized()) {
+		mainWindow.restore();
+	}
+	await loadAppRoute(mainWindow, `/session/${encodeURIComponent(cleanSessionId)}`);
+	mainWindow.show();
+	mainWindow.focus();
+	hideMiniWindow();
+	return true;
+}
+
 function hideMainWindow() {
 	if (!mainWindow || mainWindow.isDestroyed()) return;
 	if (mainWindow.isFullScreen()) {
@@ -2477,6 +2494,10 @@ ipcMain.handle('cometline:get-fullscreen', () =>
 );
 
 ipcMain.handle('cometline:get-workspace-path', () => getWorkspacePath());
+
+ipcMain.handle('cometline:open-session-in-main-window', (_event, sessionId) =>
+	openSessionInMainWindow(sessionId)
+);
 
 ipcMain.handle('cometline:select-workspace-path', selectWorkspacePath);
 

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -2,6 +2,7 @@ const {
 	app,
 	BrowserWindow,
 	dialog,
+	globalShortcut,
 	ipcMain,
 	protocol,
 	net,
@@ -9,7 +10,8 @@ const {
 	Tray,
 	Menu,
 	nativeImage,
-	Notification: ElectronNotification
+	Notification: ElectronNotification,
+	screen
 } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
@@ -48,6 +50,11 @@ const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
 /** Minimum window size — chat-only layout works below the sidebar breakpoint (900px). */
 const MIN_WINDOW_WIDTH = 400;
 const MIN_WINDOW_HEIGHT = 480;
+const MINI_WINDOW_WIDTH = 460;
+const MINI_WINDOW_HEIGHT = 640;
+const MINI_WINDOW_MIN_WIDTH = 360;
+const MINI_WINDOW_MIN_HEIGHT = 440;
+const MINI_WINDOW_SCREEN_MARGIN = 18;
 const HEALTH_URL = `http://127.0.0.1:${COMETMIND_PORT}/api/v1/health`;
 const MAX_RETRIES = 50;
 const POLL_MS = 100;
@@ -128,6 +135,7 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 let mainWindow = null;
+let miniWindow = null;
 let tray = null;
 let cometMindProcess = null;
 let cometMindGatewayProcess = null;
@@ -137,6 +145,7 @@ let relaunchForUpdate = false;
 let updateCheckTimer = null;
 let windowButtonAnimationTimer = null;
 let windowButtonPosition = { x: 16, y: 17 };
+let registeredMiniWindowShortcut = '';
 
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 
@@ -372,6 +381,41 @@ function matchesInputShortcut(input, binding) {
 	return true;
 }
 
+function acceleratorKeyForShortcut(key) {
+	const normalized = String(key || '').trim();
+	if (!normalized) return '';
+	const named = {
+		ArrowUp: 'Up',
+		ArrowDown: 'Down',
+		ArrowLeft: 'Left',
+		ArrowRight: 'Right',
+		',': 'Comma',
+		'.': 'Period',
+		Escape: 'Escape',
+		Esc: 'Escape',
+		Enter: 'Enter',
+		Space: 'Space',
+		' ': 'Space'
+	};
+	if (named[normalized]) return named[normalized];
+	if (/^F\d{1,2}$/i.test(normalized)) return normalized.toUpperCase();
+	if (normalized.length === 1) return normalized.toUpperCase();
+	return normalized;
+}
+
+function shortcutBindingToAccelerator(binding) {
+	if (!binding?.key) return '';
+	const modifiers = [];
+	if (binding.command) modifiers.push('CommandOrControl');
+	if (binding.ctrl) modifiers.push('Control');
+	if (binding.meta) modifiers.push('Meta');
+	if (binding.alt) modifiers.push('Alt');
+	if (binding.shift) modifiers.push('Shift');
+	const key = acceleratorKeyForShortcut(binding.key);
+	if (!key) return '';
+	return [...modifiers, key].join('+');
+}
+
 let shortcutCaptureActive = false;
 let sessionNavigationSuspended = false;
 let webPanelOpen = false;
@@ -392,6 +436,42 @@ function sendOpenWebPanel() {
 	if (mainWindow && !mainWindow.isDestroyed()) {
 		mainWindow.webContents.send('cometline:open-web-panel');
 	}
+}
+
+function loadAppRoute(window, route = '/') {
+	const cleanRoute = String(route || '/').startsWith('/') ? String(route || '/') : `/${route}`;
+	if (app.isPackaged) {
+		return window.loadURL(`${APP_ORIGIN}${cleanRoute}`);
+	}
+	return window.loadURL(`http://127.0.0.1:5173${cleanRoute}`);
+}
+
+function attachExternalNavigationGuards(window) {
+	window.webContents.setWindowOpenHandler(({ url }) => {
+		if (isExternallyOpenableUrl(url)) void shell.openExternal(url);
+		return { action: 'deny' };
+	});
+	window.webContents.on('will-navigate', (event, url) => {
+		const allowed = url.startsWith(`${APP_ORIGIN}/`) || url.startsWith('http://127.0.0.1:5173');
+		if (!allowed) {
+			event.preventDefault();
+			if (isExternallyOpenableUrl(url)) void shell.openExternal(url);
+		}
+	});
+}
+
+function windowCanShow(window) {
+	return Boolean(window && !window.isDestroyed());
+}
+
+function positionMiniWindowBottomRight() {
+	if (!windowCanShow(miniWindow)) return;
+	const cursorPoint = screen.getCursorScreenPoint();
+	const display = screen.getDisplayNearestPoint(cursorPoint);
+	const { width, height } = miniWindow.getBounds();
+	const x = Math.round(display.workArea.x + display.workArea.width - width - MINI_WINDOW_SCREEN_MARGIN);
+	const y = Math.round(display.workArea.y + display.workArea.height - height - MINI_WINDOW_SCREEN_MARGIN);
+	miniWindow.setPosition(x, y, false);
 }
 
 // macOS menu bar icons are 16pt. Ship trayIcon.png (16px) + trayIcon@2x.png (32px);
@@ -558,6 +638,36 @@ function hideMainWindow() {
 	}
 }
 
+async function showMiniWindow() {
+	if (!windowCanShow(miniWindow)) {
+		await createMiniWindow();
+		return;
+	}
+	if (miniWindow.isMinimized()) {
+		miniWindow.restore();
+	}
+	miniWindow.show();
+	miniWindow.focus();
+}
+
+function hideMiniWindow() {
+	if (!windowCanShow(miniWindow)) return;
+	writeMiniWindowState({ lastActiveAt: Date.now() });
+	miniWindow.hide();
+}
+
+async function toggleMiniWindow() {
+	if (!windowCanShow(miniWindow) || !miniWindow.isVisible()) {
+		await showMiniWindow();
+		return;
+	}
+	if (miniWindow.isFocused()) {
+		hideMiniWindow();
+		return;
+	}
+	miniWindow.focus();
+}
+
 function isDarwinCloseWindowShortcut(input) {
 	return (
 		process.platform === 'darwin' &&
@@ -570,23 +680,24 @@ function isDarwinCloseWindowShortcut(input) {
 	);
 }
 
-function handleDarwinCloseWindowShortcut(event, input) {
+function handleDarwinCloseWindowShortcut(event, input, onCloseWindow) {
 	if (!isDarwinCloseWindowShortcut(input)) return false;
 	event.preventDefault();
-	if (webPanelOpen) {
+	if (onCloseWindow === hideMainWindow && webPanelOpen) {
 		sendCloseWebPanel();
 	} else {
-		hideMainWindow();
+		onCloseWindow();
 	}
 	return true;
 }
 
-function attachMainWindowShortcuts(webContents) {
+function attachWindowShortcuts(webContents, { onCloseWindow, includeSessionNavigation = false }) {
 	webContents.on('before-input-event', (event, input) => {
-		if (handleDarwinCloseWindowShortcut(event, input)) {
+		if (handleDarwinCloseWindowShortcut(event, input, onCloseWindow)) {
 			return;
 		}
 
+		if (!includeSessionNavigation) return;
 		if (shortcutCaptureActive || sessionNavigationSuspended) return;
 		const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
 		if (matchesInputShortcut(input, shortcuts.previousSession)) {
@@ -601,8 +712,21 @@ function attachMainWindowShortcuts(webContents) {
 	});
 }
 
+function attachMainWindowShortcuts(webContents) {
+	attachWindowShortcuts(webContents, {
+		onCloseWindow: hideMainWindow,
+		includeSessionNavigation: true
+	});
+}
+
+function attachMiniWindowShortcuts(webContents) {
+	attachWindowShortcuts(webContents, {
+		onCloseWindow: hideMiniWindow
+	});
+}
+
 function handleWebPanelGuestShortcuts(event, input) {
-	if (handleDarwinCloseWindowShortcut(event, input)) {
+	if (handleDarwinCloseWindowShortcut(event, input, hideMainWindow)) {
 		return true;
 	}
 	if (shortcutCaptureActive || sessionNavigationSuspended) return false;
@@ -714,6 +838,54 @@ function writeProviderSettings(settings) {
 		/* ignore */
 	}
 	return next;
+}
+
+function readMiniWindowState() {
+	const settings = readProviderSettings();
+	return {
+		sessionId: String(settings.app?.miniWindowSessionId || ''),
+		lastActiveAt: Number(settings.app?.miniWindowLastActiveAt || 0),
+		inactivityTimeoutMinutes: Number(settings.app?.miniWindowInactivityTimeoutMinutes || 30)
+	};
+}
+
+function writeMiniWindowState(partial) {
+	const settings = readProviderSettings();
+	settings.app = {
+		...settings.app,
+		...(typeof partial?.sessionId === 'string'
+			? { miniWindowSessionId: partial.sessionId }
+			: {}),
+		...(Number.isFinite(partial?.lastActiveAt)
+			? { miniWindowLastActiveAt: Math.max(0, Math.floor(partial.lastActiveAt)) }
+			: {})
+	};
+	const saved = writeProviderSettings(settings);
+	return {
+		sessionId: String(saved.app?.miniWindowSessionId || ''),
+		lastActiveAt: Number(saved.app?.miniWindowLastActiveAt || 0),
+		inactivityTimeoutMinutes: Number(saved.app?.miniWindowInactivityTimeoutMinutes || 30)
+	};
+}
+
+function refreshGlobalShortcuts() {
+	if (!app.isReady()) return;
+	if (registeredMiniWindowShortcut) {
+		globalShortcut.unregister(registeredMiniWindowShortcut);
+		registeredMiniWindowShortcut = '';
+	}
+	const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
+	const accelerator = shortcutBindingToAccelerator(shortcuts.toggleMiniWindow);
+	if (!accelerator) return;
+	const registered = globalShortcut.register(accelerator, () => {
+		if (shortcutCaptureActive) return;
+		void toggleMiniWindow();
+	});
+	if (!registered) {
+		console.warn(`Failed to register mini window shortcut: ${accelerator}`);
+		return;
+	}
+	registeredMiniWindowShortcut = accelerator;
 }
 
 async function exportProviderSettings() {
@@ -1424,31 +1596,13 @@ async function createWindow() {
 		if (!dockIcon.isEmpty()) app.dock?.setIcon(dockIcon);
 	}
 
-	// Defense in depth: untrusted markdown links must never navigate the app
-	// window or spawn Electron child windows. External links are routed through
-	// the validated cometline:open-external IPC handler instead.
-	mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-		if (isExternallyOpenableUrl(url)) void shell.openExternal(url);
-		return { action: 'deny' };
-	});
-	mainWindow.webContents.on('will-navigate', (event, url) => {
-		// Allow the app's own origin (dev server or app:// bundle); block the rest.
-		const allowed = url.startsWith(`${APP_ORIGIN}/`) || url.startsWith('http://127.0.0.1:5173');
-		if (!allowed) {
-			event.preventDefault();
-			if (isExternallyOpenableUrl(url)) void shell.openExternal(url);
-		}
-	});
+	attachExternalNavigationGuards(mainWindow);
 	attachMainWindowShortcuts(mainWindow.webContents);
 	mainWindow.webContents.on('did-attach-webview', (_event, webContents) => {
 		attachWebviewPanelShortcuts(webContents);
 	});
 
-	if (app.isPackaged) {
-		await mainWindow.loadURL(`${APP_ORIGIN}/`);
-	} else {
-		await mainWindow.loadURL('http://127.0.0.1:5173');
-	}
+	await loadAppRoute(mainWindow, '/');
 
 	mainWindow.once('ready-to-show', () => {
 		mainWindow.show();
@@ -1483,6 +1637,55 @@ async function createWindow() {
 		}
 		mainWindow = null;
 	});
+}
+
+async function createMiniWindow() {
+	const iconPath = getAppIconPath(getIconVariant());
+	miniWindow = new BrowserWindow({
+		width: MINI_WINDOW_WIDTH,
+		height: MINI_WINDOW_HEIGHT,
+		minWidth: MINI_WINDOW_MIN_WIDTH,
+		minHeight: MINI_WINDOW_MIN_HEIGHT,
+		resizable: false,
+		titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
+		...(process.platform === 'darwin'
+			? {
+				backgroundColor: '#111111',
+				trafficLightPosition: { x: 14, y: 14 }
+			}
+			: {}),
+		...(iconPath ? { icon: iconPath } : {}),
+		show: false,
+		webPreferences: {
+			preload: path.join(__dirname, 'preload.cjs'),
+			contextIsolation: true,
+			nodeIntegration: false,
+			allowRunningInsecureContent: false,
+			webviewTag: true
+		}
+	});
+	attachExternalNavigationGuards(miniWindow);
+	attachMiniWindowShortcuts(miniWindow.webContents);
+	positionMiniWindowBottomRight();
+	await loadAppRoute(miniWindow, '/mini');
+	miniWindow.once('ready-to-show', () => {
+		positionMiniWindowBottomRight();
+		miniWindow?.show();
+		miniWindow?.focus();
+	});
+	miniWindow.on('hide', () => {
+		writeMiniWindowState({ lastActiveAt: Date.now() });
+	});
+	miniWindow.on('close', (event) => {
+		if (!stoppingForQuit && !stoppedForQuit) {
+			event.preventDefault();
+			hideMiniWindow();
+		}
+	});
+	miniWindow.on('closed', () => {
+		miniWindow = null;
+	});
+	return miniWindow;
 }
 
 const FETCH_MODELS_TIMEOUT_MS = 30_000;
@@ -2148,6 +2351,7 @@ app.whenReady().then(async () => {
 	installCometMindCliShim();
 	const startupSettings = readProviderSettings();
 	applyOpenAtLoginSetting(startupSettings.app?.openAtLogin);
+	refreshGlobalShortcuts();
 	startCometMind();
 	// Create the window immediately and let the sidecar warm up in parallel.
 	// The renderer shows its own connecting/loading state until the health
@@ -2209,6 +2413,7 @@ app.on('before-quit', async (event) => {
 	}
 	await stopDiscordGateway();
 	await stopCometMind();
+	globalShortcut.unregisterAll();
 	stoppedForQuit = true;
 	app.quit();
 });
@@ -2318,6 +2523,7 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	const iconVariantChanged =
 		(previous.app?.iconVariant ?? 'default') !== (saved.app?.iconVariant ?? 'default');
 	const shouldRestartCometMind = options.restartCometMind !== false || iconVariantChanged;
+	refreshGlobalShortcuts();
 	if (shouldRestartCometMind) {
 		await stopCometMind();
 		startCometMind();
@@ -2328,6 +2534,10 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	applyIconVariant(saved.app?.iconVariant);
 	return saved;
 });
+
+ipcMain.handle('cometline:get-mini-window-state', () => readMiniWindowState());
+
+ipcMain.handle('cometline:save-mini-window-state', (_event, state) => writeMiniWindowState(state));
 
 ipcMain.handle('cometline:export-provider-settings', () => exportProviderSettings());
 
@@ -2370,10 +2580,10 @@ ipcMain.handle('cometline:get-open-at-login', () => {
 
 ipcMain.handle('cometline:set-open-at-login', (_event, openAtLogin) => {
 	const settings = readProviderSettings();
-	settings.app = normalizeAppSettings({
+	settings.app = {
 		...settings.app,
 		openAtLogin: Boolean(openAtLogin)
-	});
+	};
 	const saved = writeProviderSettings(settings);
 	const result = applyOpenAtLoginSetting(saved.app.openAtLogin);
 	return {

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -11,7 +11,7 @@ const {
 	Menu,
 	nativeImage,
 	Notification: ElectronNotification,
-	screen
+	screen: electronScreen
 } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
@@ -466,8 +466,8 @@ function windowCanShow(window) {
 
 function positionMiniWindowBottomRight() {
 	if (!windowCanShow(miniWindow)) return;
-	const cursorPoint = screen.getCursorScreenPoint();
-	const display = screen.getDisplayNearestPoint(cursorPoint);
+	const cursorPoint = electronScreen.getCursorScreenPoint();
+	const display = electronScreen.getDisplayNearestPoint(cursorPoint);
 	const { width, height } = miniWindow.getBounds();
 	const x = Math.round(display.workArea.x + display.workArea.width - width - MINI_WINDOW_SCREEN_MARGIN);
 	const y = Math.round(display.workArea.y + display.workArea.height - height - MINI_WINDOW_SCREEN_MARGIN);

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 		ipcRenderer.invoke('cometline:set-discord-gateway-enabled', enabled),
 	getOpenAtLogin: () => ipcRenderer.invoke('cometline:get-open-at-login'),
 	setOpenAtLogin: (enabled) => ipcRenderer.invoke('cometline:set-open-at-login', enabled),
+	openSessionInMainWindow: (sessionId) =>
+		ipcRenderer.invoke('cometline:open-session-in-main-window', sessionId),
 	getMiniWindowState: () => ipcRenderer.invoke('cometline:get-mini-window-state'),
 	saveMiniWindowState: (state) => ipcRenderer.invoke('cometline:save-mini-window-state', state),
 	fetchProviderModels: (config) => ipcRenderer.invoke('cometline:fetch-provider-models', config),

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 		ipcRenderer.invoke('cometline:set-discord-gateway-enabled', enabled),
 	getOpenAtLogin: () => ipcRenderer.invoke('cometline:get-open-at-login'),
 	setOpenAtLogin: (enabled) => ipcRenderer.invoke('cometline:set-open-at-login', enabled),
+	getMiniWindowState: () => ipcRenderer.invoke('cometline:get-mini-window-state'),
+	saveMiniWindowState: (state) => ipcRenderer.invoke('cometline:save-mini-window-state', state),
 	fetchProviderModels: (config) => ipcRenderer.invoke('cometline:fetch-provider-models', config),
 	saveProviderSettings: (settings, options) =>
 		ipcRenderer.invoke('cometline:save-provider-settings', settings, options),

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -4125,6 +4125,12 @@ var SHORTCUT_DEFINITIONS = [
     defaultBinding: { command: true, key: "t" }
   },
   {
+    id: "toggleMiniWindow",
+    label: "Toggle mini window",
+    category: "chats",
+    defaultBinding: { command: true, shift: true, key: "k" }
+  },
+  {
     id: "previousSession",
     label: "Previous chat",
     category: "chats",
@@ -4719,11 +4725,24 @@ function defaultAppSettings() {
     hasSeenIntro: false,
     hasCompletedSetup: false,
     hasDismissedSetupWizard: false,
-    iconVariant: "default"
+    iconVariant: "default",
+    miniWindowSessionId: "",
+    miniWindowLastActiveAt: 0,
+    miniWindowInactivityTimeoutMinutes: 30
   };
 }
 function normalizeIconVariant(value) {
   return value === "man" ? "man" : "default";
+}
+function normalizeMiniWindowLastActiveAt(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+function normalizeMiniWindowInactivityTimeoutMinutes(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return defaultAppSettings().miniWindowInactivityTimeoutMinutes;
+  }
+  return Math.min(24 * 60, Math.max(1, Math.floor(value)));
 }
 function cloneProvider(provider) {
   return {
@@ -4845,7 +4864,12 @@ function normalizeSettings(next, options = {}) {
       hasSeenIntro: typeof next.app?.hasSeenIntro === "boolean" ? next.app.hasSeenIntro : defaultAppSettings().hasSeenIntro,
       hasCompletedSetup: typeof next.app?.hasCompletedSetup === "boolean" ? next.app.hasCompletedSetup : defaultAppSettings().hasCompletedSetup,
       hasDismissedSetupWizard: typeof next.app?.hasDismissedSetupWizard === "boolean" ? next.app.hasDismissedSetupWizard : defaultAppSettings().hasDismissedSetupWizard,
-      iconVariant: normalizeIconVariant(next.app?.iconVariant)
+      iconVariant: normalizeIconVariant(next.app?.iconVariant),
+      miniWindowSessionId: String(next.app?.miniWindowSessionId ?? "").trim(),
+      miniWindowLastActiveAt: normalizeMiniWindowLastActiveAt(next.app?.miniWindowLastActiveAt),
+      miniWindowInactivityTimeoutMinutes: normalizeMiniWindowInactivityTimeoutMinutes(
+        next.app?.miniWindowInactivityTimeoutMinutes
+      )
     },
     cometmind
   };
@@ -4919,7 +4943,10 @@ var providerSettingsSchema = external_exports.object({
     hasSeenIntro: external_exports.boolean(),
     hasCompletedSetup: external_exports.boolean(),
     hasDismissedSetupWizard: external_exports.boolean(),
-    iconVariant: external_exports.enum(["default", "man"])
+    iconVariant: external_exports.enum(["default", "man"]),
+    miniWindowSessionId: external_exports.string(),
+    miniWindowLastActiveAt: external_exports.number().int().min(0),
+    miniWindowInactivityTimeoutMinutes: external_exports.number().int().min(1).max(24 * 60)
   }),
   cometmind: external_exports.object({
     systemPromptPath: external_exports.string(),

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -37,8 +37,10 @@ declare global {
 		| 'toggleSidebar'
 		| 'openSettings'
 		| 'newChat'
+		| 'toggleMiniWindow'
 		| 'stopResponse'
 		| 'sendMessage'
+		| 'insertNewline'
 		| 'closeSettings'
 		| 'focusSearch'
 		| 'previousSession'
@@ -65,6 +67,15 @@ declare global {
 		hasCompletedSetup: boolean;
 		hasDismissedSetupWizard: boolean;
 		iconVariant: 'default' | 'man';
+		miniWindowSessionId: string;
+		miniWindowLastActiveAt: number;
+		miniWindowInactivityTimeoutMinutes: number;
+	}
+
+	interface MiniWindowState {
+		sessionId: string;
+		lastActiveAt: number;
+		inactivityTimeoutMinutes: number;
 	}
 
 	interface OpenAtLoginState {
@@ -288,6 +299,11 @@ declare global {
 			onToggleWebPanel?: (callback: () => void) => () => void;
 			onOpenWebPanel?: (callback: () => void) => () => void;
 			onNavigateSession?: (callback: (direction: 'prev' | 'next') => void) => () => void;
+			getMiniWindowState?: () => Promise<MiniWindowState>;
+			saveMiniWindowState?: (state: {
+				sessionId?: string;
+				lastActiveAt?: number;
+			}) => Promise<MiniWindowState>;
 			notifyJob?: (payload: { title: string; body: string }) => void;
 		};
 	}

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -264,6 +264,7 @@ declare global {
 			) => Promise<{ running: boolean; enabled: boolean }>;
 			getOpenAtLogin?: () => Promise<OpenAtLoginState>;
 			setOpenAtLogin?: (enabled: boolean) => Promise<OpenAtLoginState>;
+			openSessionInMainWindow?: (sessionId: string) => Promise<boolean>;
 			fetchProviderModels?: (
 				config: ProviderConfig
 			) => Promise<FetchProviderModelsResult | string[]>;

--- a/cometline/src/lib/active-session.ts
+++ b/cometline/src/lib/active-session.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { currentPathname } from '$lib/routes/session-route';
 import { sessionStore } from '$lib/stores/session.svelte';
 
 export function sessionIdFromPathname(pathname: string): string | null {
@@ -10,5 +11,5 @@ export function sessionIdFromPathname(pathname: string): string | null {
 export function getActiveSessionId(): string | null {
 	if (sessionStore.current?.id) return sessionStore.current.id;
 	if (!browser) return null;
-	return sessionIdFromPathname(window.location.pathname);
+	return sessionIdFromPathname(currentPathname());
 }

--- a/cometline/src/lib/active-session.ts
+++ b/cometline/src/lib/active-session.ts
@@ -2,7 +2,7 @@ import { browser } from '$app/environment';
 import { sessionStore } from '$lib/stores/session.svelte';
 
 export function sessionIdFromPathname(pathname: string): string | null {
-	const match = pathname.match(/^\/session\/([^/?#]+)/);
+	const match = pathname.match(/^\/(?:mini\/)?session\/([^/?#]+)/);
 	return match?.[1] ?? null;
 }
 

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -302,7 +302,9 @@
 	bind:this={chatHome}
 >
 	{#if compact}
-		<div class="mini-drag-region" aria-hidden="true"></div>
+		<div class="mini-titlebar" aria-label="Mini window drag area">
+			<span>Mini Chat</span>
+		</div>
 	{/if}
 
 	{#if !compact && !hasVisibleConversation && !firstTurnActive}
@@ -411,7 +413,7 @@
 		flex: none;
 		height: 100vh;
 		min-height: 100vh;
-		-webkit-app-region: drag;
+		--mini-titlebar-height: 46px;
 		background:
 			radial-gradient(
 				circle at top,
@@ -421,14 +423,34 @@
 			var(--app-bg);
 	}
 
-	.mini-drag-region {
+	.mini-titlebar {
 		position: absolute;
 		top: 0;
-		left: 82px;
+		left: 0;
 		right: 0;
-		height: 42px;
-		z-index: 30;
+		height: var(--mini-titlebar-height);
+		z-index: 40;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		padding: 0 96px;
+		border-bottom: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+		background: color-mix(in srgb, var(--panel-bg) 82%, transparent);
+		color: var(--text-muted);
+		font-size: 11px;
+		font-weight: 650;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		user-select: none;
 		-webkit-app-region: drag;
+	}
+
+	.mini-grabber {
+		width: 28px;
+		height: 4px;
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--text-muted) 42%, transparent);
 	}
 
 	.chat-home.compact .thread-shell,
@@ -488,6 +510,7 @@
 	}
 
 	.chat-home.compact .thread-shell.docked {
+		top: var(--mini-titlebar-height);
 		bottom: calc(var(--thread-dock-inset) - 18px);
 	}
 

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -49,6 +49,14 @@
 			onUserMessageFlight: (payloadOrText, { firstTurn, stageUser, revealStagedUser }) => {
 				const payload =
 					typeof payloadOrText === 'string' ? { text: payloadOrText } : payloadOrText;
+				if (compact && firstTurn) {
+					awaitingFirstAssistant = true;
+					firstTurnFlightDone = true;
+					firstTurnHandoffPending = false;
+					stageUser(payload.text, payload.images);
+					revealStagedUser();
+					return;
+				}
 				if (firstTurn) {
 					awaitingFirstAssistant = true;
 					firstTurnFlightDone = false;

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -30,7 +30,11 @@
 
 	const THREAD_IN = { duration: 140 };
 
-	let { sessionId, bootMessage = '' }: { sessionId: string; bootMessage?: string } = $props();
+	let {
+		sessionId,
+		bootMessage = '',
+		compact = false
+	}: { sessionId: string; bootMessage?: string; compact?: boolean } = $props();
 
 	const conversation = createConversationController({
 		getSessionId: () => sessionId,
@@ -123,6 +127,8 @@
 		getFirstTurnActive: () => firstTurnActive,
 		getFirstTurnFlightDone: () => firstTurnFlightDone,
 		getAwaitingFirstAssistant: () => awaitingFirstAssistant,
+		getStreaming: () => chatStore.isStreamingFor(sessionId),
+		getForceDocked: () => compact,
 		enqueue: (payload) => {
 			void conversation.enqueue(payload);
 		},
@@ -292,9 +298,14 @@
 	class="chat-home"
 	class:hero-layout={heroLayout}
 	class:first-turn-active={firstTurnActive}
+	class:compact
 	bind:this={chatHome}
 >
-	{#if !hasVisibleConversation && !firstTurnActive}
+	{#if compact}
+		<div class="mini-drag-region" aria-hidden="true"></div>
+	{/if}
+
+	{#if !compact && !hasVisibleConversation && !firstTurnActive}
 		<div class="empty-region">
 			<EmptyChatState />
 			{#if bootMessage}
@@ -344,7 +355,7 @@
 
 	<div
 		class="composer-wrapper"
-		class:centered={shellStore.composerPhase === 'centered'}
+		class:centered={!compact && shellStore.composerPhase === 'centered'}
 		class:snap={composerSnap}
 	>
 		<HeroComposerFrame
@@ -396,6 +407,41 @@
 		overflow: hidden;
 	}
 
+	.chat-home.compact {
+		flex: none;
+		height: 100vh;
+		min-height: 100vh;
+		-webkit-app-region: drag;
+		background:
+			radial-gradient(
+				circle at top,
+				color-mix(in srgb, var(--hero-composer-glow-color) 16%, transparent),
+				transparent 42%
+			),
+			var(--app-bg);
+	}
+
+	.mini-drag-region {
+		position: absolute;
+		top: 0;
+		left: 82px;
+		right: 0;
+		height: 42px;
+		z-index: 30;
+		-webkit-app-region: drag;
+	}
+
+	.chat-home.compact .thread-shell,
+	.chat-home.compact .composer-wrapper,
+	.chat-home.compact :global(button),
+	.chat-home.compact :global(input),
+	.chat-home.compact :global(textarea),
+	.chat-home.compact :global(select),
+	.chat-home.compact :global(a),
+	.chat-home.compact :global([role='button']) {
+		-webkit-app-region: no-drag;
+	}
+
 	.chat-home.hero-layout {
 		display: grid;
 		place-items: center;
@@ -441,6 +487,10 @@
 		bottom: var(--thread-dock-inset);
 	}
 
+	.chat-home.compact .thread-shell.docked {
+		bottom: calc(var(--thread-dock-inset) - 18px);
+	}
+
 	.boot-error {
 		margin: 18px 0 0;
 		max-width: 520px;
@@ -476,6 +526,10 @@
 	.composer-wrapper:not(.centered) {
 		bottom: var(--composer-dock-bottom);
 		transform: none;
+	}
+
+	.chat-home.compact .composer-wrapper {
+		padding-inline: 14px;
 	}
 
 	.composer-wrapper :global(.hero-composer-frame) {

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -298,6 +298,11 @@
 		pendingSwitch = null;
 		revertModelSelection();
 	}
+
+	async function openInMainWindow() {
+		if (!sessionId) return;
+		await window.electronAPI?.openSessionInMainWindow?.(sessionId);
+	}
 </script>
 
 <svelte:window onkeydown={onWindowKeydown} />
@@ -312,6 +317,19 @@
 	{#if compact}
 		<div class="mini-titlebar" aria-label="Mini window drag area">
 			<span>Mini Chat</span>
+			<button
+				class="mini-open-main"
+				type="button"
+				title="Open this chat in the main window"
+				aria-label="Open this chat in the main window"
+				onclick={openInMainWindow}
+			>
+				<svg viewBox="0 0 16 16" aria-hidden="true">
+					<path d="M5 3.5h7.5V11" />
+					<path d="M12.5 3.5 6.25 9.75" />
+					<path d="M10.5 12.5h-7v-7" />
+				</svg>
+			</button>
 		</div>
 	{/if}
 
@@ -454,11 +472,37 @@
 		-webkit-app-region: drag;
 	}
 
-	.mini-grabber {
+	.mini-open-main {
+		position: absolute;
+		right: 12px;
+		top: 50%;
+		transform: translateY(-50%);
 		width: 28px;
-		height: 4px;
+		height: 28px;
+		display: grid;
+		place-items: center;
+		padding: 0;
+		border: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
 		border-radius: 999px;
-		background: color-mix(in srgb, var(--text-muted) 42%, transparent);
+		background: color-mix(in srgb, var(--panel-bg) 88%, var(--text-main) 6%);
+		color: var(--text-main);
+		cursor: pointer;
+		-webkit-app-region: no-drag;
+	}
+
+	.mini-open-main svg {
+		width: 14px;
+		height: 14px;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 1.7;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+	}
+
+	.mini-open-main:hover {
+		border-color: color-mix(in srgb, var(--hero-composer-glow-color) 54%, var(--border-soft));
+		background: color-mix(in srgb, var(--hero-composer-glow-color) 18%, var(--panel-bg));
 	}
 
 	.chat-home.compact .thread-shell,

--- a/cometline/src/lib/components/composer/composer-slash.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-slash.svelte.ts
@@ -13,6 +13,7 @@ import {
 } from '$lib/client/cometmind';
 import { jobUserDisplayText } from '$lib/jobs/format-job-label';
 import { listJobsUserDisplayText } from '$lib/jobs/format-ready-jobs-list';
+import { sessionRouteFor } from '$lib/routes/session-route';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { chatStore } from '$lib/stores/chat.svelte';
 import { modelStore, type ModelOption } from '$lib/stores/model.svelte';
@@ -327,12 +328,6 @@ export function createComposerSlashController(deps: {
 		} catch (err) {
 			deps.setDropMessage(err instanceof Error ? err.message : 'Failed to fork session');
 		}
-	}
-
-	function sessionRouteFor(sessionId: string) {
-		return window.location.pathname.startsWith('/mini')
-			? `/mini/session/${sessionId}`
-			: `/session/${sessionId}`;
 	}
 
 	async function removeWorkspaceFromList(path: string, event: Event) {

--- a/cometline/src/lib/components/composer/composer-slash.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-slash.svelte.ts
@@ -318,7 +318,7 @@ export function createComposerSlashController(deps: {
 			workspaceHighlight = 0;
 			if (forkedId) {
 				deps.setDropMessage(`Forked session into ${clean}`);
-				await goto(`/session/${forkedId}`);
+				await goto(sessionRouteFor(forkedId));
 			} else {
 				deps.setDropMessage(`Switched workspace to ${clean}`);
 				await deps.onWorkspaceChanged?.();
@@ -327,6 +327,12 @@ export function createComposerSlashController(deps: {
 		} catch (err) {
 			deps.setDropMessage(err instanceof Error ? err.message : 'Failed to fork session');
 		}
+	}
+
+	function sessionRouteFor(sessionId: string) {
+		return window.location.pathname.startsWith('/mini')
+			? `/mini/session/${sessionId}`
+			: `/session/${sessionId}`;
 	}
 
 	async function removeWorkspaceFromList(path: string, event: Event) {

--- a/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
@@ -5,13 +5,22 @@
 
 	let {
 		openAtLogin = $bindable(false),
+		miniWindowInactivityTimeoutMinutes = $bindable(30),
 		storage = $bindable<CometMindStorageSettings>(),
 		onOpenAtLoginChange
 	}: {
 		openAtLogin: boolean;
+		miniWindowInactivityTimeoutMinutes: number;
 		storage: CometMindStorageSettings;
 		onOpenAtLoginChange?: (enabled: boolean) => void | Promise<void>;
 	} = $props();
+
+	function onMiniWindowTimeoutInput(event: Event) {
+		const value = Number((event.currentTarget as HTMLInputElement).value);
+		miniWindowInactivityTimeoutMinutes = Number.isFinite(value)
+			? Math.min(24 * 60, Math.max(1, Math.floor(value)))
+			: 30;
+	}
 
 	function patchStorage(patch: Partial<CometMindStorageSettings>) {
 		storage = { ...storage, ...patch };
@@ -61,6 +70,31 @@
 				onchange={onOpenAtLoginChange}
 			/>
 			<SettingsPersistenceHint tier="instant" />
+		</div>
+
+		<div class="settings-section">
+			<div class="settings-section-heading">
+				<h3>Storage & retention</h3>
+				<p>Control how long CometMind keeps archived sessions and memory before purging.</p>
+			</div>
+			<SettingsPersistenceHint tier="pending" detail="Included in Save changes" />
+			<label class="field">
+				<span>Mini window reset timeout (minutes)</span>
+				<input
+					type="number"
+					min="1"
+					max="1440"
+					step="1"
+					value={miniWindowInactivityTimeoutMinutes}
+					oninput={onMiniWindowTimeoutInput}
+				/>
+				<small>
+					After the mini window stays hidden long enough, the next hotkey open starts a new
+					rolling session. Current setting: {miniWindowInactivityTimeoutMinutes} minute{miniWindowInactivityTimeoutMinutes === 1
+						? ''
+						: 's'}.
+				</small>
+			</label>
 		</div>
 
 		<div class="settings-section">

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -314,6 +314,7 @@
 					<div class="settings-panel-stack">
 						<SettingsGeneralPanel
 							bind:openAtLogin={draft.app.openAtLogin}
+							bind:miniWindowInactivityTimeoutMinutes={draft.app.miniWindowInactivityTimeoutMinutes}
 							bind:storage={draft.cometmind.storage}
 							onOpenAtLoginChange={panelController.setOpenAtLogin}
 						/>

--- a/cometline/src/lib/conversation/chat-view-controller.svelte.ts
+++ b/cometline/src/lib/conversation/chat-view-controller.svelte.ts
@@ -8,16 +8,19 @@ export function createChatViewController(deps: {
 	getFirstTurnActive: () => boolean;
 	getFirstTurnFlightDone: () => boolean;
 	getAwaitingFirstAssistant: () => boolean;
+	getStreaming: () => boolean;
+	getForceDocked?: () => boolean;
 	enqueue: (payload: ChatTurnPayload | string) => void | Promise<void>;
 	cancelTurn: () => void;
 }) {
-	const canSend = $derived(connectionState.status === 'ready');
+	const canSend = $derived(connectionState.status === 'ready' && !deps.getStreaming());
 
 	const composerVariant = $derived<'hero' | 'dock'>(
-		shellStore.composerPhase === 'centered' ? 'hero' : 'dock'
+		deps.getForceDocked?.() || shellStore.composerPhase !== 'centered' ? 'dock' : 'hero'
 	);
 
 	const heroLayout = $derived(
+		!deps.getForceDocked?.() &&
 		shellStore.composerPhase === 'centered' &&
 			((!deps.getHasVisibleConversation() && !deps.getFirstTurnActive()) ||
 				(deps.getFirstTurnActive() && !deps.getFirstTurnFlightDone()))

--- a/cometline/src/lib/jobs/start-job-in-chat.ts
+++ b/cometline/src/lib/jobs/start-job-in-chat.ts
@@ -32,7 +32,13 @@ async function sendViaQueue(sessionId: string, payload: ChatTurnPayload): Promis
 		payload.filePaths,
 		payload.displayText
 	);
-	await goto(`/session/${sessionId}`);
+	await goto(sessionRouteFor(sessionId));
+}
+
+function sessionRouteFor(sessionId: string) {
+	return window.location.pathname.startsWith('/mini')
+		? `/mini/session/${sessionId}`
+		: `/session/${sessionId}`;
 }
 
 /** Claim and start a job in-session, forking when the job workspace differs. */
@@ -57,7 +63,7 @@ export async function startJobInSession(
 			undefined,
 			jobUserDisplayText(claimed)
 		);
-		await goto(`/session/${forked.id}`);
+		await goto(sessionRouteFor(forked.id));
 		return;
 	}
 

--- a/cometline/src/lib/jobs/start-job-in-chat.ts
+++ b/cometline/src/lib/jobs/start-job-in-chat.ts
@@ -11,6 +11,7 @@ import { modelStore } from '$lib/stores/model.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { shellStore } from '$lib/stores/shell.svelte';
 import { jobUserDisplayText } from '$lib/jobs/format-job-label';
+import { sessionRouteFor } from '$lib/routes/session-route';
 
 export type JobStartSender = (payload: ChatTurnPayload) => void | Promise<void>;
 
@@ -33,12 +34,6 @@ async function sendViaQueue(sessionId: string, payload: ChatTurnPayload): Promis
 		payload.displayText
 	);
 	await goto(sessionRouteFor(sessionId));
-}
-
-function sessionRouteFor(sessionId: string) {
-	return window.location.pathname.startsWith('/mini')
-		? `/mini/session/${sessionId}`
-		: `/session/${sessionId}`;
 }
 
 /** Claim and start a job in-session, forking when the job workspace differs. */

--- a/cometline/src/lib/keyboard-shortcuts.test.ts
+++ b/cometline/src/lib/keyboard-shortcuts.test.ts
@@ -96,4 +96,9 @@ describe('keyboard-shortcuts', () => {
 		const normalized = normalizeKeyboardShortcuts({});
 		expect(normalized.openWebPanel).toEqual({ command: true, key: 'o' });
 	});
+
+	it('includes toggleMiniWindow default shortcut', () => {
+		const normalized = normalizeKeyboardShortcuts({});
+		expect(normalized.toggleMiniWindow).toEqual({ command: true, shift: true, key: 'k' });
+	});
 });

--- a/cometline/src/lib/keyboard-shortcuts.ts
+++ b/cometline/src/lib/keyboard-shortcuts.ts
@@ -2,6 +2,7 @@ export type ShortcutAction =
 	| 'toggleSidebar'
 	| 'openSettings'
 	| 'newChat'
+	| 'toggleMiniWindow'
 	| 'stopResponse'
 	| 'sendMessage'
 	| 'insertNewline'
@@ -67,6 +68,12 @@ export const SHORTCUT_DEFINITIONS: KeyboardShortcutDefinition[] = [
 		label: 'New chat',
 		category: 'chats',
 		defaultBinding: { command: true, key: 't' }
+	},
+	{
+		id: 'toggleMiniWindow',
+		label: 'Toggle mini window',
+		category: 'chats',
+		defaultBinding: { command: true, shift: true, key: 'k' }
 	},
 	{
 		id: 'previousSession',

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -1,0 +1,55 @@
+import { createSession, listSessions } from '$lib/client/cometmind';
+import { modelStore } from '$lib/stores/model.svelte';
+import { sessionStore } from '$lib/stores/session.svelte';
+import { settingsStore } from '$lib/stores/settings.svelte';
+
+async function resolveSelectedModel() {
+	if (modelStore.options.length === 0) {
+		await settingsStore.load();
+	}
+	if (!modelStore.selected) {
+		modelStore.selectDefault();
+	}
+	const selected = modelStore.selected;
+	if (!selected) {
+		throw new Error('Select a model in Settings before opening the mini window.');
+	}
+	return selected;
+}
+
+function isMiniWindowSessionExpired(state: MiniWindowState) {
+	if (!state.sessionId) return true;
+	if (state.lastActiveAt <= 0) return false;
+	return Date.now() - state.lastActiveAt >= state.inactivityTimeoutMinutes * 60_000;
+}
+
+export async function ensureMiniWindowSession(preferredSessionId = '') {
+	const state =
+		(await window.electronAPI?.getMiniWindowState?.()) ??
+		({ sessionId: '', lastActiveAt: 0, inactivityTimeoutMinutes: 30 } satisfies MiniWindowState);
+	const sessionId = preferredSessionId || state.sessionId;
+	const shouldReuseSession = preferredSessionId || !isMiniWindowSessionExpired(state);
+	const workspacePath = (await window.electronAPI?.getWorkspacePath?.()) ?? '/';
+
+	if (sessionId && shouldReuseSession) {
+		const sessions = await listSessions(workspacePath);
+		const session = sessions.sessions.find((item) => item.id === sessionId);
+		if (session) {
+			sessionStore.upsertSession(session);
+			if (session.id !== state.sessionId) {
+				await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
+			}
+			return session.id;
+		}
+	}
+
+	const selected = await resolveSelectedModel();
+	const session = await createSession({
+		workspace_path: workspacePath,
+		provider_id: selected.providerId,
+		model_id: selected.modelId
+	});
+	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
+	sessionStore.appendSession(session);
+	return session.id;
+}

--- a/cometline/src/lib/routes/session-route.ts
+++ b/cometline/src/lib/routes/session-route.ts
@@ -1,0 +1,15 @@
+export function currentPathname(): string {
+	return typeof globalThis.location?.pathname === 'string' ? globalThis.location.pathname : '/';
+}
+
+export function isMiniRoutePath(pathname: string = currentPathname()): boolean {
+	return pathname === '/mini' || pathname.startsWith('/mini/');
+}
+
+export function sessionRouteFor(sessionId: string, pathname: string = currentPathname()): string {
+	return isMiniRoutePath(pathname) ? `/mini/session/${sessionId}` : `/session/${sessionId}`;
+}
+
+export function homeRouteFor(pathname: string = currentPathname()): string {
+	return isMiniRoutePath(pathname) ? '/mini' : '/';
+}

--- a/cometline/src/lib/settings/pending-settings.ts
+++ b/cometline/src/lib/settings/pending-settings.ts
@@ -26,7 +26,8 @@ export function pendingSettingsSnapshot(settings: ProviderSettings): string {
 			caretTrail: { ...settings.appearance.caretTrail }
 		},
 		app: {
-			iconVariant: settings.app?.iconVariant ?? 'default'
+			iconVariant: settings.app?.iconVariant ?? 'default',
+			miniWindowInactivityTimeoutMinutes: settings.app?.miniWindowInactivityTimeoutMinutes ?? 30
 		},
 		cometmind: {
 			...cometmind,
@@ -82,7 +83,10 @@ function appearanceSectionSnapshot(settings: ProviderSettings): string {
 
 function appSectionSnapshot(settings: ProviderSettings): string {
 	const cometmind = cloneCometMindSettings(normalizeCometMindSettings(settings.cometmind));
-	return JSON.stringify({ storage: cometmind.storage });
+	return JSON.stringify({
+		storage: cometmind.storage,
+		miniWindowInactivityTimeoutMinutes: settings.app?.miniWindowInactivityTimeoutMinutes ?? 30
+	});
 }
 
 export function sectionPendingDirty(
@@ -133,7 +137,7 @@ export const SECTION_PERSISTENCE_HINTS: Record<
 		instant: 'Every shortcut binding'
 	},
 	app: {
-		pending: 'Session storage and retention',
+		pending: 'Session storage, retention, and mini window timeout',
 		instant: 'Open at login',
 		action: 'Export, import, workspace, and updates'
 	}

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -674,12 +674,27 @@ function defaultAppSettings(): AppSettings {
 		hasSeenIntro: false,
 		hasCompletedSetup: false,
 		hasDismissedSetupWizard: false,
-		iconVariant: 'default'
+		iconVariant: 'default',
+		miniWindowSessionId: '',
+		miniWindowLastActiveAt: 0,
+		miniWindowInactivityTimeoutMinutes: 30
 	};
 }
 
 function normalizeIconVariant(value: unknown): IconVariant {
 	return value === 'man' ? 'man' : 'default';
+}
+
+function normalizeMiniWindowLastActiveAt(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+	return Math.max(0, Math.floor(value));
+}
+
+function normalizeMiniWindowInactivityTimeoutMinutes(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return defaultAppSettings().miniWindowInactivityTimeoutMinutes;
+	}
+	return Math.min(24 * 60, Math.max(1, Math.floor(value)));
 }
 
 export function cloneProvider(provider: ProviderConfig): ProviderConfig {
@@ -861,7 +876,12 @@ export function normalizeSettings(
 				typeof next.app?.hasDismissedSetupWizard === 'boolean'
 					? next.app.hasDismissedSetupWizard
 					: defaultAppSettings().hasDismissedSetupWizard,
-			iconVariant: normalizeIconVariant(next.app?.iconVariant)
+			iconVariant: normalizeIconVariant(next.app?.iconVariant),
+			miniWindowSessionId: String(next.app?.miniWindowSessionId ?? '').trim(),
+			miniWindowLastActiveAt: normalizeMiniWindowLastActiveAt(next.app?.miniWindowLastActiveAt),
+			miniWindowInactivityTimeoutMinutes: normalizeMiniWindowInactivityTimeoutMinutes(
+				next.app?.miniWindowInactivityTimeoutMinutes
+			)
 		},
 		cometmind
 	};
@@ -942,7 +962,10 @@ const providerSettingsSchema = z.object({
 		hasSeenIntro: z.boolean(),
 		hasCompletedSetup: z.boolean(),
 		hasDismissedSetupWizard: z.boolean(),
-		iconVariant: z.enum(['default', 'man'])
+		iconVariant: z.enum(['default', 'man']),
+		miniWindowSessionId: z.string(),
+		miniWindowLastActiveAt: z.number().int().min(0),
+		miniWindowInactivityTimeoutMinutes: z.number().int().min(1).max(24 * 60)
 	}),
 	cometmind: z.object({
 		systemPromptPath: z.string(),

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -35,7 +35,11 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 			hasSeenIntro: settings.app?.hasSeenIntro ?? false,
 			hasCompletedSetup: settings.app?.hasCompletedSetup ?? false,
 			hasDismissedSetupWizard: settings.app?.hasDismissedSetupWizard ?? false,
-			iconVariant: settings.app?.iconVariant ?? 'default'
+			iconVariant: settings.app?.iconVariant ?? 'default',
+			miniWindowSessionId: settings.app?.miniWindowSessionId ?? '',
+			miniWindowLastActiveAt: settings.app?.miniWindowLastActiveAt ?? 0,
+			miniWindowInactivityTimeoutMinutes:
+				settings.app?.miniWindowInactivityTimeoutMinutes ?? 30
 		},
 		cometmind: cloneCometMindSettings(normalizeCometMindSettings(settings.cometmind))
 	};

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -15,6 +15,7 @@ import { sessionStore } from '$lib/stores/session.svelte';
 import { chatDebug, summarizeChatItems, summarizeStreamEvent } from '../debug/chat';
 import { playResponseCompleteSound } from '$lib/sound/response-complete';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
+import { homeRouteFor } from '$lib/routes/session-route';
 
 import { itemsFromTranscript, localID, mergeSubagents } from '$lib/stores/chat-transcript';
 import {
@@ -96,8 +97,7 @@ function createChatStore() {
 			isLoading = false;
 		}
 		if (browser) {
-			const target = window.location.pathname.startsWith('/mini') ? '/mini' : '/';
-			void goto(target);
+			void goto(homeRouteFor());
 		}
 	}
 

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -14,6 +14,7 @@ import { anyReasoningPending, hasReasoning } from '$lib/conversation/reasoning';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { chatDebug, summarizeChatItems, summarizeStreamEvent } from '../debug/chat';
 import { playResponseCompleteSound } from '$lib/sound/response-complete';
+import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 
 import { itemsFromTranscript, localID, mergeSubagents } from '$lib/stores/chat-transcript';
 import {
@@ -40,6 +41,8 @@ function createChatStore() {
 	const sessionCache = new Map<string, ChatItem[]>();
 	const sessionErrors = new Map<string, string>();
 	const streamHandles = new Map<string, SessionStream>();
+	const localStreamingSessionIds = new Set<string>();
+	const remoteStreamingSessionIds = new Set<string>();
 	let streamingSessionIds = $state.raw<Set<string>>(new Set());
 
 	const BATCHABLE_EVENTS = BATCHABLE_STREAM_EVENTS;
@@ -60,10 +63,22 @@ function createChatStore() {
 		return sessionCache.get(targetSessionID) ?? [];
 	}
 
-	function writeSessionItems(targetSessionID: string, nextItems: ChatItem[]) {
+	function refreshStreamingState() {
+		streamingSessionIds = new Set([...localStreamingSessionIds, ...remoteStreamingSessionIds]);
+	}
+
+	function writeSessionItems(
+		targetSessionID: string,
+		nextItems: ChatItem[],
+		options: { broadcast?: boolean } = {}
+	) {
+		const { broadcast = true } = options;
 		sessionCache.set(targetSessionID, nextItems);
 		if (sessionID === targetSessionID) {
 			items = nextItems;
+		}
+		if (broadcast) {
+			publishWindowSync({ type: 'chat-items', sessionId: targetSessionID, items: nextItems });
 		}
 	}
 
@@ -85,15 +100,26 @@ function createChatStore() {
 
 	function markStreaming(targetSessionID: string, handle: SessionStream) {
 		streamHandles.set(targetSessionID, handle);
-		streamingSessionIds.add(targetSessionID);
-		streamingSessionIds = new Set(streamingSessionIds);
+		localStreamingSessionIds.add(targetSessionID);
+		refreshStreamingState();
+		publishWindowSync({ type: 'chat-streaming', sessionId: targetSessionID, streaming: true });
 	}
 
 	function unmarkStreaming(targetSessionID: string) {
 		streamHandles.delete(targetSessionID);
-		if (streamingSessionIds.delete(targetSessionID)) {
-			streamingSessionIds = new Set(streamingSessionIds);
+		if (localStreamingSessionIds.delete(targetSessionID)) {
+			refreshStreamingState();
 		}
+		publishWindowSync({ type: 'chat-streaming', sessionId: targetSessionID, streaming: false });
+	}
+
+	function setRemoteStreamingState(targetSessionID: string, streaming: boolean) {
+		if (streaming) {
+			remoteStreamingSessionIds.add(targetSessionID);
+		} else {
+			remoteStreamingSessionIds.delete(targetSessionID);
+		}
+		refreshStreamingState();
 	}
 
 	function isStreamingFor(targetSessionID: string) {
@@ -130,7 +156,8 @@ function createChatStore() {
 			handle.abort.abort();
 		}
 		streamHandles.clear();
-		streamingSessionIds = new Set();
+		localStreamingSessionIds.clear();
+		refreshStreamingState();
 		globalStreamRun += 1;
 	}
 
@@ -576,10 +603,10 @@ function createChatStore() {
 		const id = targetSessionID ?? sessionID;
 		if (!id) return;
 		const handle = streamHandles.get(id);
-		if (!handle) return;
+		if (!handle && !isStreamingFor(id)) return;
 
 		chatDebug('store:cancel-start', { sessionID: id });
-		handle.abort.abort();
+		handle?.abort.abort();
 		try {
 			await abortSession(id);
 		} catch (err) {
@@ -618,6 +645,18 @@ function createChatStore() {
 
 	function appendLocalUserMessage(targetSessionID: string, text: string) {
 		addUserToSession(targetSessionID, text);
+	}
+
+	if (browser) {
+		subscribeWindowSync((message) => {
+			if (message.type === 'chat-items') {
+				writeSessionItems(message.sessionId, message.items, { broadcast: false });
+				return;
+			}
+			if (message.type === 'chat-streaming') {
+				setRemoteStreamingState(message.sessionId, message.streaming);
+			}
+		});
 	}
 
 	return {

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -95,7 +95,10 @@ function createChatStore() {
 			error = '';
 			isLoading = false;
 		}
-		if (browser) void goto('/');
+		if (browser) {
+			const target = window.location.pathname.startsWith('/mini') ? '/mini' : '/';
+			void goto(target);
+		}
 	}
 
 	function markStreaming(targetSessionID: string, handle: SessionStream) {

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -1,4 +1,6 @@
+import { browser } from '$app/environment';
 import type { ImageAttachment, Session } from '$lib/types';
+import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 
 export interface PendingMessage {
 	sessionId: string;
@@ -13,6 +15,25 @@ function createSessionStore() {
 	let current = $state<Session | null>(null);
 	let pendingMessages = $state.raw(new Map<string, Omit<PendingMessage, 'sessionId'>>());
 
+	function upsertSession(
+		session: Session,
+		options: { selectCurrent?: boolean; prepend?: boolean; broadcast?: boolean } = {}
+	) {
+		const { selectCurrent = false, prepend = false, broadcast = true } = options;
+		const existingIndex = sessions.findIndex((item) => item.id === session.id);
+		if (existingIndex === -1) {
+			sessions = prepend ? [session, ...sessions] : [...sessions, session];
+		} else if (prepend) {
+			sessions = [session, ...sessions.filter((item) => item.id !== session.id)];
+		} else {
+			sessions = sessions.map((item) => (item.id === session.id ? session : item));
+		}
+		if (selectCurrent || current?.id === session.id) current = session;
+		if (broadcast) {
+			publishWindowSync({ type: 'session-upsert', session });
+		}
+	}
+
 	function selectSession(session: Session | null) {
 		current = session;
 	}
@@ -22,22 +43,24 @@ function createSessionStore() {
 	}
 
 	function appendSession(session: Session) {
-		sessions = [session, ...sessions];
-		current = session;
+		upsertSession(session, { selectCurrent: true, prepend: true });
 	}
 
 	function updateSession(session: Session) {
-		sessions = sessions.map((item) => (item.id === session.id ? session : item));
-		if (current?.id === session.id) current = session;
+		upsertSession(session, { prepend: true });
 	}
 
-	function removeSession(id: string) {
+	function removeSession(id: string, options: { broadcast?: boolean } = {}) {
+		const { broadcast = true } = options;
 		sessions = sessions.filter((item) => item.id !== id);
 		if (current?.id === id) current = null;
+		if (broadcast) {
+			publishWindowSync({ type: 'session-remove', sessionId: id });
+		}
 	}
 
-	function discardSession(id: string) {
-		removeSession(id);
+	function discardSession(id: string, options: { broadcast?: boolean } = {}) {
+		removeSession(id, options);
 		if (pendingMessages.has(id)) {
 			const next = new Map(pendingMessages);
 			next.delete(id);
@@ -73,6 +96,18 @@ function createSessionStore() {
 		return message;
 	}
 
+	if (browser) {
+		subscribeWindowSync((message) => {
+			if (message.type === 'session-upsert') {
+				upsertSession(message.session, { prepend: true, broadcast: false });
+				return;
+			}
+			if (message.type === 'session-remove') {
+				removeSession(message.sessionId, { broadcast: false });
+			}
+		});
+	}
+
 	return {
 		get sessions() {
 			return sessions;
@@ -82,6 +117,7 @@ function createSessionStore() {
 		},
 		selectSession,
 		setSessions,
+		upsertSession,
 		appendSession,
 		updateSession,
 		removeSession,

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -57,6 +57,7 @@ export type ShortcutAction =
 	| 'toggleSidebar'
 	| 'openSettings'
 	| 'newChat'
+	| 'toggleMiniWindow'
 	| 'stopResponse'
 	| 'sendMessage'
 	| 'insertNewline'
@@ -88,6 +89,9 @@ export interface AppSettings {
 	hasCompletedSetup: boolean;
 	hasDismissedSetupWizard: boolean;
 	iconVariant: IconVariant;
+	miniWindowSessionId: string;
+	miniWindowLastActiveAt: number;
+	miniWindowInactivityTimeoutMinutes: number;
 }
 
 export interface ProviderSettings {

--- a/cometline/src/lib/window-sync.ts
+++ b/cometline/src/lib/window-sync.ts
@@ -1,0 +1,52 @@
+import { browser } from '$app/environment';
+import type { ChatItem, Session } from '$lib/types';
+
+type SyncPayload =
+	| { type: 'session-upsert'; session: Session }
+	| { type: 'session-remove'; sessionId: string }
+	| { type: 'chat-items'; sessionId: string; items: ChatItem[] }
+	| { type: 'chat-streaming'; sessionId: string; streaming: boolean };
+
+type SyncMessage = SyncPayload & { source: string };
+
+const source =
+	typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+		? crypto.randomUUID()
+		: `window-${Math.random().toString(36).slice(2)}`;
+
+const listeners = new Set<(message: SyncMessage) => void>();
+
+const channel = browser && 'BroadcastChannel' in globalThis
+	? new BroadcastChannel('cometline-window-sync')
+	: null;
+
+if (channel) {
+	channel.addEventListener('message', (event) => {
+		const message = event.data as SyncMessage | undefined;
+		if (!message || message.source === source) return;
+		for (const listener of listeners) {
+			listener(message);
+		}
+	});
+}
+
+export function publishWindowSync(message: SyncPayload) {
+	if (!channel) return;
+	const syncMessage = cloneForWindowSync({ source, ...message });
+	if (!syncMessage) return;
+	channel.postMessage(syncMessage);
+}
+
+function cloneForWindowSync(message: SyncMessage): SyncMessage | null {
+	try {
+		return JSON.parse(JSON.stringify(message)) as SyncMessage;
+	} catch (err) {
+		console.warn('Failed to publish window sync message', err);
+		return null;
+	}
+}
+
+export function subscribeWindowSync(listener: (message: SyncMessage) => void) {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../app.css';
+	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import AppShell from '$lib/components/AppShell.svelte';
 	import { connectionState } from '$lib/stores/runtime.svelte';
@@ -13,6 +14,9 @@
 	let { children } = $props();
 
 	let settingsLoaded = $state(false);
+	let isMiniRoute = $derived(
+		page.url.pathname === '/mini' || page.url.pathname.startsWith('/mini/')
+	);
 	// Prevents the setup wizard from re-opening after the user skips it
 	// within the same session (in-memory guard). The durable guard is
 	// hasDismissedSetupWizard persisted in settings.
@@ -136,6 +140,10 @@
 	}
 </script>
 
-<AppShell>
+{#if isMiniRoute}
 	{@render children()}
-</AppShell>
+{:else}
+	<AppShell>
+		{@render children()}
+	</AppShell>
+{/if}

--- a/cometline/src/routes/mini/+page.svelte
+++ b/cometline/src/routes/mini/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+
+	let error = $state('');
+
+	onMount(() => {
+		void (async () => {
+			try {
+				const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
+				const sessionId = await ensureMiniWindowSession();
+				await goto(`/mini/session/${sessionId}`, { replaceState: true });
+			} catch (err) {
+				error = err instanceof Error ? err.message : 'Failed to open mini chat';
+			}
+		})();
+	});
+</script>
+
+<div class="mini-loading-shell">
+	<div class="mini-loading-card">
+		<p>{error || 'Opening mini chat...'}</p>
+	</div>
+</div>
+
+<style>
+	.mini-loading-shell {
+		display: grid;
+		place-items: center;
+		min-height: 100vh;
+		padding: 24px;
+		background: var(--app-bg);
+		color: var(--text-main);
+		-webkit-app-region: drag;
+	}
+
+	.mini-loading-card {
+		width: min(100%, 320px);
+		padding: 18px 20px;
+		border-radius: 16px;
+		background: color-mix(in srgb, var(--panel-bg) 90%, transparent);
+		border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+		box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+	}
+
+	p {
+		margin: 0;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+</style>

--- a/cometline/src/routes/mini/session/[id]/+page.svelte
+++ b/cometline/src/routes/mini/session/[id]/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import ChatView from '$lib/components/ChatView.svelte';
+
+	let sessionId = $derived(page.params.id ?? '');
+	let resolvedSessionId = $state('');
+	let resolvingRun = 0;
+	let error = $state('');
+
+	async function resolveSession(id: string, run: number) {
+		try {
+			const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
+			const ensuredSessionId = await ensureMiniWindowSession(id);
+			if (run !== resolvingRun) return;
+			if (ensuredSessionId !== id) {
+				await goto(`/mini/session/${ensuredSessionId}`, { replaceState: true });
+				return;
+			}
+			resolvedSessionId = ensuredSessionId;
+			error = '';
+		} catch (err) {
+			if (run !== resolvingRun) return;
+			error = err instanceof Error ? err.message : 'Failed to open mini chat';
+			resolvedSessionId = '';
+		}
+	}
+
+	$effect(() => {
+		if (!sessionId) return;
+		resolvedSessionId = '';
+		error = '';
+		const run = ++resolvingRun;
+		void resolveSession(sessionId, run);
+	});
+</script>
+
+{#if resolvedSessionId}
+	<ChatView sessionId={resolvedSessionId} compact />
+{:else}
+	<div class="mini-session-loading">
+		<p>{error || 'Opening mini chat...'}</p>
+	</div>
+{/if}
+
+<style>
+	.mini-session-loading {
+		display: grid;
+		place-items: center;
+		min-height: 100vh;
+		padding: 24px;
+		background: var(--app-bg);
+		color: var(--text-main);
+		-webkit-app-region: drag;
+	}
+
+	p {
+		margin: 0;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+</style>


### PR DESCRIPTION
## Background

Issue #11 asks for a lightweight chat window that can be opened from a hotkey without bringing up the full desktop app. This branch adds the mini window flow, keeps it aligned with the main chat experience, and lets users jump back into the main window when they need the full UI. Closes #11.

[1121709](https://github.com/Cometline/cometline/commit/11217099aa1f61531ae535e202acdc5ae27fbd6e): Added the Electron mini window, the global shortcut plumbing, the mini route, and the settings needed to remember mini window state and inactivity handling.

[7b39cd8](https://github.com/Cometline/cometline/commit/7b39cd83e59de1b381c47ba699cc8fd95043b9c7): Tightened the compact chat UI so the mini window has its own draggable header and stays on the mini route when a session disappears instead of falling back to the full app home state.

[a2ba228](https://github.com/Cometline/cometline/commit/a2ba22831689c79b0b5962b70a0aab8f318689d9): Fixed mini-route navigation for session forks and queued jobs, and skipped the full-window first-turn hero transition when the compact chat sends its first message.

[504c5c9](https://github.com/Cometline/cometline/commit/504c5c9c0851d8e3be66d9db992cba791e966c49): Added the compact titlebar affordance that opens the current session in the main window, together with the Electron bridge for routing the main window to the same chat.

### Reference

[Issue #11](https://github.com/Cometline/cometline/issues/11)