### PR TITLE
[main] feat: refine web panel focus and layout limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             VERSION="${LATEST#v}"
             IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
             PATCH=$((PATCH + 1))
-            if [ "$PATCH" -gt 999 ]; then
+            if [ "$PATCH" -gt 99 ]; then
               PATCH=0
               MINOR=$((MINOR + 1))
             fi

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -426,15 +426,9 @@ function sendCloseWebPanel() {
 	}
 }
 
-function sendToggleWebPanel() {
+function sendShortcutAction(action) {
 	if (mainWindow && !mainWindow.isDestroyed()) {
-		mainWindow.webContents.send('cometline:toggle-web-panel');
-	}
-}
-
-function sendOpenWebPanel() {
-	if (mainWindow && !mainWindow.isDestroyed()) {
-		mainWindow.webContents.send('cometline:open-web-panel');
+		mainWindow.webContents.send('cometline:shortcut-action', action);
 	}
 }
 
@@ -746,16 +740,36 @@ function handleWebPanelGuestShortcuts(event, input) {
 	if (handleDarwinCloseWindowShortcut(event, input, hideMainWindow)) {
 		return true;
 	}
-	if (shortcutCaptureActive || sessionNavigationSuspended) return false;
+	if (shortcutCaptureActive) return false;
 	const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
-	if (matchesInputShortcut(input, shortcuts.toggleWebPanel)) {
+
+	// Forward the full set of global app shortcuts to the main renderer so they
+	// keep working while the webview guest holds DOM focus.
+	const forwardActions = [
+		'toggleSidebar',
+		'openWebPanel',
+		'toggleWebPanel',
+		'openSettings',
+		'newChat',
+		'focusSearch'
+	];
+	for (const action of forwardActions) {
+		if (matchesInputShortcut(input, shortcuts[action])) {
+			event.preventDefault();
+			sendShortcutAction(action);
+			return true;
+		}
+	}
+
+	if (sessionNavigationSuspended) return false;
+	if (matchesInputShortcut(input, shortcuts.previousSession)) {
 		event.preventDefault();
-		sendToggleWebPanel();
+		sendShortcutAction('previousSession');
 		return true;
 	}
-	if (matchesInputShortcut(input, shortcuts.openWebPanel)) {
+	if (matchesInputShortcut(input, shortcuts.nextSession)) {
 		event.preventDefault();
-		sendOpenWebPanel();
+		sendShortcutAction('nextSession');
 		return true;
 	}
 	return false;

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -47,9 +47,9 @@ const COMETMIND_PORT = 7700;
 const APP_SCHEME = 'app';
 const APP_HOST = 'bundle';
 const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
-/** Minimum window size — chat-only layout works below the sidebar breakpoint (900px). */
-const MIN_WINDOW_WIDTH = 400;
-const MIN_WINDOW_HEIGHT = 480;
+/** Minimum width sized for sidebar + chat pane + web panel all being open. */
+const MIN_WINDOW_WIDTH = 1320;
+const MIN_WINDOW_HEIGHT = 620;
 const MINI_WINDOW_WIDTH = 460;
 const MINI_WINDOW_HEIGHT = 640;
 const MINI_WINDOW_MIN_WIDTH = 360;

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -78,5 +78,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 		ipcRenderer.on('cometline:navigate-session', handler);
 		return () => ipcRenderer.removeListener('cometline:navigate-session', handler);
 	},
+	onShortcutAction: (callback) => {
+		const handler = (_event, action) => {
+			if (typeof action === 'string') callback(action);
+		};
+		ipcRenderer.on('cometline:shortcut-action', handler);
+		return () => ipcRenderer.removeListener('cometline:shortcut-action', handler);
+	},
 	notifyJob: (payload) => ipcRenderer.send('jobs:notify', payload)
 });

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -4733,8 +4733,15 @@ function defaultAppSettings() {
     iconVariant: "default",
     miniWindowSessionId: "",
     miniWindowLastActiveAt: 0,
-    miniWindowInactivityTimeoutMinutes: 30
+    miniWindowInactivityTimeoutMinutes: 30,
+    webPanelWidth: 0
   };
+}
+function normalizeWebPanelWidth(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return defaultAppSettings().webPanelWidth;
+  }
+  return Math.max(0, Math.floor(value));
 }
 function normalizeIconVariant(value) {
   return value === "man" ? "man" : "default";
@@ -4874,7 +4881,8 @@ function normalizeSettings(next, options = {}) {
       miniWindowLastActiveAt: normalizeMiniWindowLastActiveAt(next.app?.miniWindowLastActiveAt),
       miniWindowInactivityTimeoutMinutes: normalizeMiniWindowInactivityTimeoutMinutes(
         next.app?.miniWindowInactivityTimeoutMinutes
-      )
+      ),
+      webPanelWidth: normalizeWebPanelWidth(next.app?.webPanelWidth)
     },
     cometmind
   };
@@ -4951,7 +4959,8 @@ var providerSettingsSchema = external_exports.object({
     iconVariant: external_exports.enum(["default", "man"]),
     miniWindowSessionId: external_exports.string(),
     miniWindowLastActiveAt: external_exports.number().int().min(0),
-    miniWindowInactivityTimeoutMinutes: external_exports.number().int().min(1).max(24 * 60)
+    miniWindowInactivityTimeoutMinutes: external_exports.number().int().min(1).max(24 * 60),
+    webPanelWidth: external_exports.number().int().min(0)
   }),
   cometmind: external_exports.object({
     systemPromptPath: external_exports.string(),

--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -187,6 +187,18 @@ body {
 	box-shadow: var(--shadow-card);
 }
 
+/* While dragging the panel resizer, disable width/margin transitions so the
+   panel tracks the pointer directly, and prevent text selection. */
+body.panel-resizing {
+	cursor: col-resize;
+	user-select: none;
+}
+
+body.panel-resizing .main,
+body.panel-resizing .web-panel {
+	transition: none !important;
+}
+
 .content-panel-surface {
 	border: var(--content-panel-border-width) solid var(--border-soft);
 	border-radius: var(--radius-window);

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -70,6 +70,7 @@ declare global {
 		miniWindowSessionId: string;
 		miniWindowLastActiveAt: number;
 		miniWindowInactivityTimeoutMinutes: number;
+		webPanelWidth: number;
 	}
 
 	interface MiniWindowState {
@@ -301,6 +302,9 @@ declare global {
 			onToggleWebPanel?: (callback: () => void) => () => void;
 			onOpenWebPanel?: (callback: () => void) => () => void;
 			onNavigateSession?: (callback: (direction: 'prev' | 'next') => void) => () => void;
+			onShortcutAction?: (
+				callback: (action: import('$lib/keyboard-shortcuts').ShortcutAction) => void
+			) => () => void;
 			getMiniWindowState?: () => Promise<MiniWindowState>;
 			saveMiniWindowState?: (state: {
 				sessionId?: string;

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -13,7 +13,7 @@
 	import { startNewChat } from '$lib/actions/new-chat';
 	import { navigateAdjacentSession } from '$lib/actions/navigate-adjacent-session';
 	import { narrowViewportQuery, subscribeNarrowViewport } from '$lib/layout/narrow-viewport';
-	import { matchesShortcut } from '$lib/keyboard-shortcuts';
+	import { matchesShortcut, type ShortcutAction } from '$lib/keyboard-shortcuts';
 
 	const FALLBACK_SIDEBAR_DURATION = 240;
 
@@ -40,6 +40,41 @@
 			!event.shiftKey &&
 			event.key.toLowerCase() === 'w'
 		);
+	}
+
+	// Single source of truth for what each global shortcut does, so it behaves
+	// identically whether the key arrives via DOM keydown (renderer focused) or
+	// via IPC forwarded from the webview guest (web panel focused).
+	function runShortcutAction(action: ShortcutAction) {
+		switch (action) {
+			case 'toggleSidebar':
+				shellStore.toggleSidebar();
+				return;
+			case 'toggleWebPanel':
+				shellStore.toggleWebPanel();
+				return;
+			case 'openWebPanel':
+				shellStore.openWebPanelFromShortcut();
+				return;
+			case 'openSettings':
+				shellStore.openSettings();
+				return;
+			case 'newChat':
+				startNewChat();
+				return;
+			case 'focusSearch':
+				shellStore.openSidebar();
+				sidebarRef?.focusSearch();
+				return;
+			case 'previousSession':
+				if (shellStore.settingsOpen) return;
+				navigateAdjacentSession('prev');
+				return;
+			case 'nextSession':
+				if (shellStore.settingsOpen) return;
+				navigateAdjacentSession('next');
+				return;
+		}
 	}
 
 	onMount(() => {
@@ -75,44 +110,43 @@
 			}
 			if (matchesShortcut(event, shortcuts.toggleSidebar)) {
 				event.preventDefault();
-				shellStore.toggleSidebar();
+				runShortcutAction('toggleSidebar');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.toggleWebPanel)) {
 				event.preventDefault();
-				shellStore.toggleWebPanel();
+				runShortcutAction('toggleWebPanel');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.openWebPanel)) {
 				event.preventDefault();
-				shellStore.openWebPanelFromShortcut();
+				runShortcutAction('openWebPanel');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.openSettings)) {
 				event.preventDefault();
-				shellStore.openSettings();
+				runShortcutAction('openSettings');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.newChat)) {
 				event.preventDefault();
-				startNewChat();
+				runShortcutAction('newChat');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.focusSearch)) {
 				event.preventDefault();
-				shellStore.openSidebar();
-				sidebarRef?.focusSearch();
+				runShortcutAction('focusSearch');
 				return;
 			}
 			if (shellStore.settingsOpen) return;
 			if (matchesShortcut(event, shortcuts.previousSession)) {
 				event.preventDefault();
-				navigateAdjacentSession('prev');
+				runShortcutAction('previousSession');
 				return;
 			}
 			if (matchesShortcut(event, shortcuts.nextSession)) {
 				event.preventDefault();
-				navigateAdjacentSession('next');
+				runShortcutAction('nextSession');
 				return;
 			}
 		}
@@ -138,6 +172,12 @@
 			shellStore.openWebPanelFromShortcut();
 		});
 
+		// Shortcuts forwarded from the webview guest (web panel focused). Run the
+		// same effects as the DOM keydown dispatcher above.
+		const unsubscribeShortcutAction = window.electronAPI?.onShortcutAction?.((action) => {
+			runShortcutAction(action);
+		});
+
 		function updateFullScreen(isFullScreen: boolean) {
 			if (import.meta.env.DEV) {
 				console.log('[AppShell] fullscreen state:', isFullScreen);
@@ -152,6 +192,20 @@
 		}
 		document.addEventListener('fullscreenchange', onDomFullScreenChange);
 
+		// Keep a custom panel width within bounds when the window is resized so a
+		// previously-saved large width can't exceed the viewport.
+		function onWindowResize() {
+			const raw = document.documentElement.style.getPropertyValue('--web-panel-width').trim();
+			if (!raw.endsWith('px')) return;
+			const px = Number.parseFloat(raw);
+			if (!Number.isFinite(px)) return;
+			const clamped = clampPanelWidth(px);
+			if (clamped !== px) {
+				document.documentElement.style.setProperty('--web-panel-width', `${clamped}px`);
+			}
+		}
+		window.addEventListener('resize', onWindowResize);
+
 		return () => {
 			unsubscribeNarrowViewport();
 			window.removeEventListener('keydown', onKeydown, true);
@@ -159,8 +213,10 @@
 			unsubscribeCloseWebPanel?.();
 			unsubscribeToggleWebPanel?.();
 			unsubscribeOpenWebPanel?.();
+			unsubscribeShortcutAction?.();
 			unsubscribeFullScreen?.();
 			document.removeEventListener('fullscreenchange', onDomFullScreenChange);
+			window.removeEventListener('resize', onWindowResize);
 		};
 	});
 
@@ -190,6 +246,71 @@
 	function handleMainMouseDown() {
 		shellStore.setFocusedPane('chat');
 	}
+
+	// --- Web/file panel resize ---------------------------------------------
+	const PANEL_MIN_WIDTH = 320;
+	function panelMaxWidth() {
+		return Math.max(PANEL_MIN_WIDTH, Math.round(window.innerWidth * 0.75));
+	}
+	function currentPanelWidth() {
+		const raw = getComputedStyle(document.documentElement)
+			.getPropertyValue('--web-panel-width')
+			.trim();
+		const px = Number.parseFloat(raw);
+		if (raw.endsWith('px') && Number.isFinite(px)) return px;
+		// Fallback for vw/default: measure the rendered panel inner element.
+		const inner = document.querySelector<HTMLElement>('.web-panel-inner');
+		if (inner) return inner.getBoundingClientRect().width;
+		return Math.round(window.innerWidth * 0.5);
+	}
+
+	let resizing = $state(false);
+	let resizeStartX = 0;
+	let resizeStartWidth = 0;
+
+	function clampPanelWidth(width: number) {
+		return Math.min(Math.max(width, PANEL_MIN_WIDTH), panelMaxWidth());
+	}
+
+	function onResizePointerDown(event: PointerEvent) {
+		if (event.button !== 0) return;
+		event.preventDefault();
+		resizing = true;
+		resizeStartX = event.clientX;
+		resizeStartWidth = currentPanelWidth();
+		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+		document.body.classList.add('panel-resizing');
+	}
+
+	function onResizePointerMove(event: PointerEvent) {
+		if (!resizing) return;
+		// Panel is on the right: dragging left (negative delta) grows it.
+		const next = clampPanelWidth(resizeStartWidth - (event.clientX - resizeStartX));
+		document.documentElement.style.setProperty('--web-panel-width', `${next}px`);
+	}
+
+	function endResize(event: PointerEvent) {
+		if (!resizing) return;
+		resizing = false;
+		const target = event.currentTarget as HTMLElement;
+		if (target.hasPointerCapture(event.pointerId)) {
+			target.releasePointerCapture(event.pointerId);
+		}
+		document.body.classList.remove('panel-resizing');
+		void settingsStore.saveWebPanelWidth(currentPanelWidth());
+	}
+
+	function onResizeKeydown(event: KeyboardEvent) {
+		const step = event.shiftKey ? 64 : 16;
+		let next: number | null = null;
+		if (event.key === 'ArrowLeft') next = currentPanelWidth() + step;
+		else if (event.key === 'ArrowRight') next = currentPanelWidth() - step;
+		if (next === null) return;
+		event.preventDefault();
+		const clamped = clampPanelWidth(next);
+		document.documentElement.style.setProperty('--web-panel-width', `${clamped}px`);
+		void settingsStore.saveWebPanelWidth(clamped);
+	}
 </script>
 
 <div
@@ -208,6 +329,23 @@
 			{@render children()}
 			<RuntimeOverlay />
 		</main>
+		{#if shellStore.webPanelOpen}
+			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+			<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+			<div
+				class="panel-resizer"
+				class:resizing
+				role="separator"
+				aria-orientation="vertical"
+				aria-label="Resize web panel"
+				tabindex="0"
+				onpointerdown={onResizePointerDown}
+				onpointermove={onResizePointerMove}
+				onpointerup={endResize}
+				onpointercancel={endResize}
+				onkeydown={onResizeKeydown}
+			></div>
+		{/if}
 		<WebPanel />
 	</div>
 	<SettingsModal />
@@ -265,6 +403,41 @@
 		margin-left: var(--content-panel-inset);
 	}
 
+	.panel-resizer {
+		flex: 0 0 auto;
+		width: 8px;
+		margin: 0 -3px;
+		z-index: 2;
+		cursor: col-resize;
+		align-self: stretch;
+		background: transparent;
+		position: relative;
+	}
+
+	.panel-resizer::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 2px;
+		height: 36px;
+		border-radius: 999px;
+		background: var(--border-subtle, rgba(148, 163, 184, 0.4));
+		opacity: 0;
+		transition: opacity var(--duration-fast) var(--ease-smooth);
+	}
+
+	.panel-resizer:hover::before,
+	.panel-resizer:focus-visible::before,
+	.panel-resizer.resizing::before {
+		opacity: 1;
+	}
+
+	.panel-resizer:focus-visible {
+		outline: none;
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 		.main {
 			transition: none;
@@ -287,6 +460,10 @@
 			border-radius: 0;
 			background: transparent;
 			box-shadow: none;
+		}
+
+		.panel-resizer {
+			display: none;
 		}
 
 		.app-shell:not(.sidebar-collapsed) :global(.sidebar:not(.collapsed)) {

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -20,6 +20,7 @@
 	let { children }: { children: import('svelte').Snippet } = $props();
 
 	let sidebarRef = $state<{ focusSearch: () => void } | null>(null);
+	let contentRowRef = $state<HTMLDivElement | null>(null);
 
 	let activeSessionId = $derived(sessionStore.current?.id ?? null);
 
@@ -78,6 +79,8 @@
 	}
 
 	onMount(() => {
+		let resizeObserver: ResizeObserver | null = null;
+
 		if (narrowViewportQuery().matches) {
 			shellStore.closeSidebar();
 		}
@@ -194,17 +197,29 @@
 
 		// Keep a custom panel width within bounds when the window is resized so a
 		// previously-saved large width can't exceed the viewport.
-		function onWindowResize() {
+		function clampPanelWidthToLayout() {
+			if (!shellStore.webPanelOpen) return;
 			const raw = document.documentElement.style.getPropertyValue('--web-panel-width').trim();
-			if (!raw.endsWith('px')) return;
-			const px = Number.parseFloat(raw);
+			const current = raw.endsWith('px') ? Number.parseFloat(raw) : currentPanelWidth();
+			const px = Number.isFinite(current) ? current : currentPanelWidth();
 			if (!Number.isFinite(px)) return;
 			const clamped = clampPanelWidth(px);
 			if (clamped !== px) {
 				document.documentElement.style.setProperty('--web-panel-width', `${clamped}px`);
 			}
 		}
+
+		function onWindowResize() {
+			clampPanelWidthToLayout();
+		}
 		window.addEventListener('resize', onWindowResize);
+
+		if (contentRowRef) {
+			resizeObserver = new ResizeObserver(() => {
+				clampPanelWidthToLayout();
+			});
+			resizeObserver.observe(contentRowRef);
+		}
 
 		return () => {
 			unsubscribeNarrowViewport();
@@ -217,6 +232,7 @@
 			unsubscribeFullScreen?.();
 			document.removeEventListener('fullscreenchange', onDomFullScreenChange);
 			window.removeEventListener('resize', onWindowResize);
+			resizeObserver?.disconnect();
 		};
 	});
 
@@ -243,14 +259,34 @@
 		});
 	});
 
-	function handleMainMouseDown() {
+	function handleMainMouseDown(event: MouseEvent) {
 		shellStore.setFocusedPane('chat');
+		if (event.button !== 0) return;
+		const target = event.target;
+		if (!(target instanceof HTMLElement)) {
+			shellStore.requestComposerFocus();
+			return;
+		}
+		if (
+			target.closest(
+				'button, a, input, textarea, select, [role="button"], [contenteditable="true"]'
+			)
+		) {
+			return;
+		}
+		const selection = window.getSelection();
+		if (selection && !selection.isCollapsed) return;
+		shellStore.requestComposerFocus();
 	}
 
 	// --- Web/file panel resize ---------------------------------------------
 	const PANEL_MIN_WIDTH = 320;
+	// Keep the chat pane wide enough for avatar + bubble layout even when the
+	// sidebar and web panel are both visible.
+	const MAIN_PANEL_MIN_WIDTH = 720;
 	function panelMaxWidth() {
-		return Math.max(PANEL_MIN_WIDTH, Math.round(window.innerWidth * 0.75));
+		const rowWidth = contentRowRef?.clientWidth ?? window.innerWidth;
+		return Math.max(PANEL_MIN_WIDTH, rowWidth - MAIN_PANEL_MIN_WIDTH);
 	}
 	function currentPanelWidth() {
 		const raw = getComputedStyle(document.documentElement)
@@ -319,7 +355,7 @@
 	class:is-fullscreen={shellStore.fullscreen}
 >
 	<Sidebar bind:this={sidebarRef} collapsed={!shellStore.sidebarOpen} />
-	<div class="content-row">
+	<div class="content-row" bind:this={contentRowRef}>
 		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 		<main
 			class="main content-panel-surface max-[900px]:shadow-none"

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -145,6 +145,7 @@
 
 	let composerVariant = $derived(chatView.composerVariant);
 	let heroLayout = $derived(chatView.heroLayout);
+	let composerFocusRequestId = $derived(shellStore.composerFocusRequestId);
 
 	let heroFrameExiting = $state(false);
 
@@ -218,6 +219,11 @@
 			firstTurnActive,
 			awaitingFirstAssistant
 		});
+	});
+
+	$effect(() => {
+		if (!composerFocusRequestId || shellStore.focusedPane !== 'chat') return;
+		setTimeout(() => composerRef?.focus(), 0);
 	});
 
 	$effect(() => {

--- a/cometline/src/lib/components/WebPanel.svelte
+++ b/cometline/src/lib/components/WebPanel.svelte
@@ -280,6 +280,7 @@
 		const requestId = shellStore.addressBarFocusRequestId;
 		if (!requestId || !panelOpen) return;
 		queueMicrotask(() => {
+			shellStore.setFocusedPane('web');
 			addressInputEl?.focus();
 			addressInputEl?.select();
 		});

--- a/cometline/src/lib/components/WebPanel.svelte
+++ b/cometline/src/lib/components/WebPanel.svelte
@@ -119,8 +119,16 @@
 		}
 	}
 
-	function handlePanelMouseDown() {
+	function handlePanelMouseDown(event: MouseEvent) {
 		shellStore.setFocusedPane('web');
+		if (panelMode !== 'url' || event.button !== 0) return;
+		const target = event.target;
+		if (!(target instanceof HTMLElement)) {
+			shellStore.requestAddressBarFocus();
+			return;
+		}
+		if (target.closest('button, input, textarea, select, a, [role="button"]')) return;
+		shellStore.requestAddressBarFocus();
 	}
 
 	function submitAddress() {

--- a/cometline/src/lib/settings/schema.test.ts
+++ b/cometline/src/lib/settings/schema.test.ts
@@ -39,6 +39,27 @@ describe('settings schema', () => {
 		expect(settings.app.hasDismissedSetupWizard).toBe(true);
 	});
 
+	it('defaults webPanelWidth to 0 (use CSS default)', () => {
+		expect(defaultSettings().app.webPanelWidth).toBe(0);
+	});
+
+	it('normalizes webPanelWidth: floors, clamps negatives, falls back on invalid', () => {
+		const base = defaultSettings();
+		expect(
+			normalizeSettings({ ...base, app: { ...base.app, webPanelWidth: 642.9 } }).app
+				.webPanelWidth
+		).toBe(642);
+		expect(
+			normalizeSettings({ ...base, app: { ...base.app, webPanelWidth: -10 } }).app.webPanelWidth
+		).toBe(0);
+		expect(
+			normalizeSettings({
+				...base,
+				app: { ...base.app, webPanelWidth: 'oops' as unknown as number }
+			}).app.webPanelWidth
+		).toBe(0);
+	});
+
 	it('appends custom providers after built-ins', () => {
 		const settings = normalizeSettings({
 			...defaultSettings(),

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -683,8 +683,16 @@ function defaultAppSettings(): AppSettings {
 		iconVariant: 'default',
 		miniWindowSessionId: '',
 		miniWindowLastActiveAt: 0,
-		miniWindowInactivityTimeoutMinutes: 30
+		miniWindowInactivityTimeoutMinutes: 30,
+		webPanelWidth: 0
 	};
+}
+
+function normalizeWebPanelWidth(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return defaultAppSettings().webPanelWidth;
+	}
+	return Math.max(0, Math.floor(value));
 }
 
 function normalizeIconVariant(value: unknown): IconVariant {
@@ -887,7 +895,8 @@ export function normalizeSettings(
 			miniWindowLastActiveAt: normalizeMiniWindowLastActiveAt(next.app?.miniWindowLastActiveAt),
 			miniWindowInactivityTimeoutMinutes: normalizeMiniWindowInactivityTimeoutMinutes(
 				next.app?.miniWindowInactivityTimeoutMinutes
-			)
+			),
+			webPanelWidth: normalizeWebPanelWidth(next.app?.webPanelWidth)
 		},
 		cometmind
 	};
@@ -971,7 +980,8 @@ const providerSettingsSchema = z.object({
 		iconVariant: z.enum(['default', 'man']),
 		miniWindowSessionId: z.string(),
 		miniWindowLastActiveAt: z.number().int().min(0),
-		miniWindowInactivityTimeoutMinutes: z.number().int().min(1).max(24 * 60)
+		miniWindowInactivityTimeoutMinutes: z.number().int().min(1).max(24 * 60),
+		webPanelWidth: z.number().int().min(0)
 	}),
 	cometmind: z.object({
 		systemPromptPath: z.string(),

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -39,7 +39,8 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 			miniWindowSessionId: settings.app?.miniWindowSessionId ?? '',
 			miniWindowLastActiveAt: settings.app?.miniWindowLastActiveAt ?? 0,
 			miniWindowInactivityTimeoutMinutes:
-				settings.app?.miniWindowInactivityTimeoutMinutes ?? 30
+				settings.app?.miniWindowInactivityTimeoutMinutes ?? 30,
+			webPanelWidth: settings.app?.webPanelWidth ?? 0
 		},
 		cometmind: cloneCometMindSettings(normalizeCometMindSettings(settings.cometmind))
 	};

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -183,6 +183,31 @@ function createSettingsStore() {
 		await save(next, { restartCometMind: false });
 	}
 
+	async function saveWebPanelWidth(width: number) {
+		const next = Math.max(0, Math.floor(width));
+		if (settings.app.webPanelWidth === next) return;
+		error = '';
+		try {
+			const normalized = normalizeSettings({
+				...settings,
+				app: { ...settings.app, webPanelWidth: next }
+			});
+			if (window.electronAPI?.saveProviderSettings) {
+				apply(
+					await window.electronAPI.saveProviderSettings(normalized, {
+						restartCometMind: false
+					})
+				);
+				return;
+			}
+			writeLocalSettings(normalized);
+			apply(normalized);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save panel width';
+			throw err;
+		}
+	}
+
 	async function saveShortcuts(shortcuts: ProviderSettings['shortcuts']) {
 		error = '';
 		try {
@@ -289,6 +314,7 @@ function createSettingsStore() {
 		markSetupComplete,
 		markSetupDismissed,
 		saveShortcuts,
+		saveWebPanelWidth,
 		setActiveProvider,
 		updateProvider,
 		addProvider,

--- a/cometline/src/lib/stores/shell.svelte.ts
+++ b/cometline/src/lib/stores/shell.svelte.ts
@@ -230,6 +230,7 @@ function createShellStore() {
 			};
 			focusedPane = 'web';
 			syncWebPanelOpen(true);
+			addressBarFocusRequestId += 1;
 		},
 		openFilePreview(filePath: string, sessionId: string) {
 			webPanelsBySession = {
@@ -257,6 +258,7 @@ function createShellStore() {
 			};
 			focusedPane = 'web';
 			syncWebPanelOpen(true);
+			addressBarFocusRequestId += 1;
 		},
 		requestAddressBarFocus() {
 			const sessionId = panelSessionKey();
@@ -290,6 +292,9 @@ function createShellStore() {
 			};
 			focusedPane = visible ? 'web' : 'chat';
 			syncWebPanelOpen(visible);
+			if (visible && panel.mode === 'url') {
+				addressBarFocusRequestId += 1;
+			}
 		},
 		closeWebPanel() {
 			const sessionId = panelSessionKey();
@@ -297,7 +302,7 @@ function createShellStore() {
 			const next = { ...webPanelsBySession };
 			delete next[sessionId];
 			webPanelsBySession = next;
-			focusedPane = 'chat';
+			this.requestComposerFocus();
 			syncWebPanelOpen(false);
 		},
 		clearWebPanelForSession(sessionId: string) {
@@ -306,7 +311,7 @@ function createShellStore() {
 			delete next[sessionId];
 			webPanelsBySession = next;
 			if (activeSessionId() === sessionId) {
-				focusedPane = 'chat';
+				this.requestComposerFocus();
 				syncWebPanelOpen(false);
 			}
 		},

--- a/cometline/src/lib/stores/shell.svelte.ts
+++ b/cometline/src/lib/stores/shell.svelte.ts
@@ -40,6 +40,7 @@ function createShellStore() {
 	let webPanelsBySession = $state<Record<string, SessionWebPanel>>({});
 	let focusedPane = $state<FocusedPane>('chat');
 	let addressBarFocusRequestId = $state(0);
+	let composerFocusRequestId = $state(0);
 
 	function activeSessionId(): string | null {
 		return getActiveSessionId();
@@ -129,6 +130,9 @@ function createShellStore() {
 		get addressBarFocusRequestId() {
 			return addressBarFocusRequestId;
 		},
+		get composerFocusRequestId() {
+			return composerFocusRequestId;
+		},
 		/** Update persisted default; sync active when no session is open (home). */
 		setDefaultWorkspacePath(path: string) {
 			defaultWorkspacePath = path;
@@ -210,6 +214,10 @@ function createShellStore() {
 		},
 		setFocusedPane(pane: FocusedPane) {
 			focusedPane = pane;
+		},
+		requestComposerFocus() {
+			focusedPane = 'chat';
+			composerFocusRequestId += 1;
 		},
 		onActiveSessionChange() {
 			focusedPane = 'chat';

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -92,6 +92,8 @@ export interface AppSettings {
 	miniWindowSessionId: string;
 	miniWindowLastActiveAt: number;
 	miniWindowInactivityTimeoutMinutes: number;
+	/** Web/file panel width in px. 0 means use the default (50vw). */
+	webPanelWidth: number;
 }
 
 export interface ProviderSettings {

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -86,6 +86,19 @@
 		}
 	});
 
+	// Apply the persisted web/file panel width. 0 means "use the CSS default".
+	$effect(() => {
+		const width = settingsStore.settings.app.webPanelWidth;
+		const root = document.documentElement;
+		if (width > 0) {
+			const max = Math.round(window.innerWidth * 0.75);
+			const clamped = Math.min(Math.max(width, 320), Math.max(320, max));
+			root.style.setProperty('--web-panel-width', `${clamped}px`);
+		} else {
+			root.style.removeProperty('--web-panel-width');
+		}
+	});
+
 	$effect(() => {
 		if (connectionState.status !== 'ready') return;
 		if (shellStore.bootMessage) {

--- a/cometline/src/routes/+page.svelte
+++ b/cometline/src/routes/+page.svelte
@@ -15,7 +15,14 @@
 	import { renderUserText } from '$lib/markdown/render';
 
 	let bootMessage = $derived(shellStore.bootMessage);
+	let composerRef = $state<{ focus: () => void } | null>(null);
+	let composerFocusRequestId = $derived(shellStore.composerFocusRequestId);
 	let listJobsMessage = $state<string | null>(null);
+
+	$effect(() => {
+		if (!composerFocusRequestId || shellStore.focusedPane !== 'chat') return;
+		setTimeout(() => composerRef?.focus(), 0);
+	});
 
 	// Entering the home route is a one-shot reset: no reactive inputs, so this
 	// is a lifecycle action, not a reactive effect.
@@ -94,6 +101,7 @@
 		{/if}
 		<HeroComposerFrame>
 			<Composer
+				bind:this={composerRef}
 				{onSend}
 				onLocalUserMessage={showLocalUserMessage}
 				disabled={connectionState.status !== 'ready'}


### PR DESCRIPTION
## Background

The new draggable web panel needed a few follow-up fixes around focus handoff and layout constraints. This branch makes the chat pane and web panel behave more predictably when users resize panels, reopen the sidebar, switch focus between panes, and cut a release near the patch rollover boundary.

[affacc5](https://github.com/Cometline/cometline/commit/affacc5ab7f7a637e14f6900e45941afe7f2d565): Added the draggable divider for the web panel, persisted the panel width in settings, and forwarded global shortcuts from the webview guest back into the main renderer so app shortcuts keep working while the panel has focus.

[909930d](https://github.com/Cometline/cometline/commit/909930db2fe93c1f3195a8613a602026da1848e1): Tightened the desktop layout constraints so the sidebar, chat pane, and web panel can coexist without collapsing the main content, and added focus request plumbing so the composer and URL field can reclaim focus when pane state changes.

[8f436c1](https://github.com/Cometline/cometline/commit/8f436c1148996d5a6b4f58a35bc908fd044b62a0): Finished the web panel focus handoff so opening the panel activates the web-pane focus ring and URL input, while closing it returns focus to the composer automatically.

[d693550](https://github.com/Cometline/cometline/commit/d69355095d365b19dcf068430f13ff7c20bb482f): Fixed the release workflow version bump rule so `0.1.99` rolls to `0.2.0` instead of creating `0.1.100`.