### PR TITLE
[main] fix: persona runtime updates and dock icon styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,7 +355,7 @@ Cometline can improve itself using the same agent runtime:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (12283 symbols, 29633 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (8719 symbols, 23018 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (12283 symbols, 29633 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (8719 symbols, 23018 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -15,7 +15,7 @@ const {
 } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
-const { spawn } = require('child_process');
+const { spawn, execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
@@ -338,6 +338,7 @@ const PERSONA_AVATAR_MAX_BYTES = 2 * 1024 * 1024;
 const PERSONA_APP_ICON_SIZE = 1024;
 const PERSONA_APP_ICON_RADIUS = 224;
 const PERSONA_APP_ICON_ARTWORK_SCALE = 0.8125;
+const PERSONA_ICON_SCRIPT = path.join(__dirname, '..', 'scripts', 'generate-project-icons.swift');
 
 function migratePersonaIdFromIconVariant(iconVariant) {
 	return iconVariant === 'man' ? 'souma' : 'minako';
@@ -1265,10 +1266,16 @@ function getPersonaId() {
 	return readSavedPersonaId(readProviderSettings());
 }
 
+function customPersonaAppIconPath(personaId) {
+	const dir = getPersonaDir(personaId);
+	return dir ? path.join(dir, 'app_icon.png') : '';
+}
+
 function resolveAppIconPaths(personaId = 'minako', settings = undefined) {
 	const customPersona = findCustomPersona(settings ?? readProviderSettings(), personaId);
-	if (customPersona?.avatarPath) {
-		return [path.resolve(expandHomePath(customPersona.avatarPath))];
+	if (customPersona) {
+		const appIconPath = customPersonaAppIconPath(customPersona.id);
+		return appIconPath ? [appIconPath] : [];
 	}
 	const variant = builtinPersonaToIconVariant(personaId);
 	if (variant === 'man') {
@@ -1283,7 +1290,11 @@ function resolveAppIconPaths(personaId = 'minako', settings = undefined) {
 	if (app.isPackaged) {
 		return [path.join(process.resourcesPath, 'icon.png')];
 	}
-	return [path.join(__dirname, '..', 'buildResources', 'icon.png')];
+	return [
+		path.join(app.getAppPath(), 'static', 'app_icon.png'),
+		path.join(__dirname, '..', 'static', 'app_icon.png'),
+		path.join(__dirname, '..', 'buildResources', 'icon.png')
+	];
 }
 
 function getAppIconPath(personaId = getPersonaId(), settings = undefined) {
@@ -1293,28 +1304,94 @@ function getAppIconPath(personaId = getPersonaId(), settings = undefined) {
 function createCustomPersonaAppIcon(customPersona) {
 	if (!customPersona?.avatarPath || !fs.existsSync(customPersona.avatarPath)) return null;
 	const ext = path.extname(customPersona.avatarPath).toLowerCase();
-	const mimeType = PERSONA_IMAGE_MIME_BY_EXT[ext];
-	if (!mimeType) return null;
-	let buffer;
-	try {
-		buffer = fs.readFileSync(customPersona.avatarPath);
-	} catch {
-		return null;
-	}
+	if (!PERSONA_IMAGE_MIME_BY_EXT[ext]) return null;
 	const artworkSize = PERSONA_APP_ICON_SIZE * PERSONA_APP_ICON_ARTWORK_SCALE;
 	const artworkInset = (PERSONA_APP_ICON_SIZE - artworkSize) / 2;
 	const artworkRadius = PERSONA_APP_ICON_RADIUS * PERSONA_APP_ICON_ARTWORK_SCALE;
-	const avatarDataUrl = `data:${mimeType};base64,${buffer.toString('base64')}`;
-	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${PERSONA_APP_ICON_SIZE}" height="${PERSONA_APP_ICON_SIZE}" viewBox="0 0 ${PERSONA_APP_ICON_SIZE} ${PERSONA_APP_ICON_SIZE}"><defs><clipPath id="persona-icon"><rect x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}" rx="${artworkRadius}" ry="${artworkRadius}"/></clipPath></defs><image href="${avatarDataUrl}" x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}" preserveAspectRatio="xMidYMid slice" clip-path="url(#persona-icon)"/></svg>`;
-	const image = nativeImage.createFromDataURL(`data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`);
+	const avatarHref = pathToFileURL(path.resolve(customPersona.avatarPath)).href;
+	const svg = [
+		`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"`,
+		`width="${PERSONA_APP_ICON_SIZE}" height="${PERSONA_APP_ICON_SIZE}"`,
+		`viewBox="0 0 ${PERSONA_APP_ICON_SIZE} ${PERSONA_APP_ICON_SIZE}">`,
+		`<defs><clipPath id="persona-icon">`,
+		`<rect x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}"`,
+		`rx="${artworkRadius}" ry="${artworkRadius}"/></clipPath></defs>`,
+		`<rect x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}"`,
+		`rx="${artworkRadius}" ry="${artworkRadius}" fill="#ffffff"/>`,
+		`<image href="${avatarHref}" xlink:href="${avatarHref}" x="${artworkInset}" y="${artworkInset}"`,
+		`width="${artworkSize}" height="${artworkSize}" preserveAspectRatio="xMidYMid slice"`,
+		`clip-path="url(#persona-icon)"/></svg>`
+	].join('');
+	const image = nativeImage.createFromDataURL(
+		`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+	);
 	return image.isEmpty() ? null : image;
+}
+
+function generatePersonaAppIconPng(avatarPath, outputPath) {
+	if (!avatarPath || !fs.existsSync(avatarPath) || !outputPath) return false;
+	try {
+		fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	} catch {
+		return false;
+	}
+	if (process.platform === 'darwin' && fs.existsSync(PERSONA_ICON_SCRIPT)) {
+		try {
+			execFileSync(
+				'swift',
+				[PERSONA_ICON_SCRIPT, 'persona', path.resolve(avatarPath), outputPath],
+				{ stdio: 'pipe', timeout: 30000 }
+			);
+			if (fs.existsSync(outputPath)) return true;
+		} catch (error) {
+			console.warn(
+				'[icon] Swift persona icon generation failed, falling back to SVG:',
+				error?.message ?? error
+			);
+		}
+	}
+	const fallback = createCustomPersonaAppIcon({ avatarPath, id: 'fallback' });
+	if (!fallback) return false;
+	try {
+		fs.writeFileSync(outputPath, fallback.toPNG());
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function ensureCustomPersonaAppIcon(customPersona) {
+	if (!customPersona?.avatarPath || !fs.existsSync(customPersona.avatarPath)) return null;
+	const iconPath = customPersonaAppIconPath(customPersona.id);
+	if (!iconPath) return createCustomPersonaAppIcon(customPersona);
+
+	let avatarMtime = 0;
+	let iconMtime = 0;
+	try {
+		avatarMtime = fs.statSync(customPersona.avatarPath).mtimeMs;
+		if (fs.existsSync(iconPath)) iconMtime = fs.statSync(iconPath).mtimeMs;
+	} catch {
+		return createCustomPersonaAppIcon(customPersona);
+	}
+
+	if (!fs.existsSync(iconPath) || iconMtime < avatarMtime) {
+		generatePersonaAppIconPng(customPersona.avatarPath, iconPath);
+	}
+
+	if (fs.existsSync(iconPath)) {
+		const cached = nativeImage.createFromPath(iconPath);
+		if (!cached.isEmpty()) return cached;
+	}
+	return createCustomPersonaAppIcon(customPersona);
 }
 
 function getAppIconImage(personaId = getPersonaId(), settings = undefined) {
 	const resolvedSettings = settings ?? readProviderSettings();
 	const customPersona = findCustomPersona(resolvedSettings, personaId);
-	const customIcon = createCustomPersonaAppIcon(customPersona);
-	if (customIcon) return customIcon;
+	if (customPersona) {
+		const customIcon = ensureCustomPersonaAppIcon(customPersona);
+		if (customIcon) return customIcon;
+	}
 	const iconPath = getAppIconPath(personaId, resolvedSettings);
 	if (!iconPath) return null;
 	const image = nativeImage.createFromPath(iconPath);
@@ -1324,8 +1401,10 @@ function getAppIconImage(personaId = getPersonaId(), settings = undefined) {
 function resolveTrayImageSource(personaId = getPersonaId(), settings = undefined) {
 	const customPersona = findCustomPersona(settings ?? readProviderSettings(), personaId);
 	if (customPersona?.avatarPath && fs.existsSync(customPersona.avatarPath)) {
-		const image = createCustomPersonaAppIcon(customPersona) ?? nativeImage.createFromPath(customPersona.avatarPath);
-		if (!image.isEmpty()) return image.resize({ width: 18, height: 18, quality: 'best' });
+		const image = ensureCustomPersonaAppIcon(customPersona);
+		if (image && !image.isEmpty()) {
+			return image.resize({ width: 18, height: 18, quality: 'best' });
+		}
 	}
 	const variant = builtinPersonaToIconVariant(personaId);
 	const trayIconPath = resolveTrayResourcePath(
@@ -1348,6 +1427,9 @@ function applyPersona(personaId = getPersonaId(), settings = undefined) {
 	}
 	if (mainWindow && !mainWindow.isDestroyed()) {
 		mainWindow.setIcon(image);
+	}
+	if (miniWindow && !miniWindow.isDestroyed()) {
+		miniWindow.setIcon(image);
 	}
 	if (!tray) return;
 	const trayImageSource = resolveTrayImageSource(personaId, settings);
@@ -3084,6 +3166,7 @@ async function saveCustomPersona(payload = {}) {
 		personas: { custom: nextCustomPersonas }
 	};
 	const saved = writeProviderSettings(settings);
+	generatePersonaAppIconPng(persona.avatarPath, customPersonaAppIconPath(persona.id));
 	await reloadCometMind();
 	applyPersona(saved.app?.personaId, saved);
 	return { ok: true, persona };

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -1098,8 +1098,11 @@ function providerEnv() {
 		COMETMIND_PROVIDER: active.id,
 		COMETMIND_MODEL: active.enabledModels[0] || active.selectedModel || active.models[0] || '',
 		COMETMIND_MAX_TOKENS: String(settings.cometmind?.maxTokens ?? 2048),
-		COMETMIND_LOG_LEVEL: settings.cometmind?.logLevel ?? 'error',
-		COMETMIND_SYSTEM_PROMPT_PATH: resolveSystemPromptPath(getPersonaId(), settings)
+		COMETMIND_LOG_LEVEL: settings.cometmind?.logLevel ?? 'error'
+		// Persona SOUL path lives in cometline-settings.json (cometmind.systemPromptPath).
+		// Do not inject COMETMIND_SYSTEM_PROMPT_PATH here — it is captured at process
+		// start and would override config.Load() on SIGHUP reload, so persona switches
+		// would not take effect until a full CometMind restart.
 	};
 	if (active.baseURL) env.COMETMIND_BASE_URL = active.baseURL;
 	if (active.apiKey) env.COMETMIND_API_KEY = active.apiKey;

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -2792,8 +2792,14 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	const previous = readProviderSettings();
 	const saved = writeProviderSettings(settings);
 	const personaIdChanged = (previous.app?.personaId ?? 'minako') !== (saved.app?.personaId ?? 'minako');
-	const runtimeAction =
+	let runtimeAction =
 		options.runtimeAction ?? (options.restartCometMind === false ? 'none' : 'restart');
+	if (
+		runtimeAction === 'none' &&
+		(previous.cometmind?.systemPromptPath ?? '') !== (saved.cometmind?.systemPromptPath ?? '')
+	) {
+		runtimeAction = 'reload';
+	}
 	refreshGlobalShortcuts();
 	if (runtimeAction === 'restart') {
 		await stopCometMind();

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -327,15 +327,123 @@ function pathWithCometMindCliBins(envPath = '') {
 	return [...new Set(entries)].join(delimiter);
 }
 
-function resolveSystemPromptPath(variant = 'default') {
-	if (process.env.COMETMIND_SYSTEM_PROMPT_PATH) {
-		return path.resolve(process.env.COMETMIND_SYSTEM_PROMPT_PATH);
+const BUILTIN_PERSONA_IDS = new Set(['minako', 'souma']);
+const PERSONA_IMAGE_MIME_BY_EXT = {
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.webp': 'image/webp'
+};
+const PERSONA_AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+
+function migratePersonaIdFromIconVariant(iconVariant) {
+	return iconVariant === 'man' ? 'souma' : 'minako';
+}
+
+function builtinPersonaToIconVariant(personaId) {
+	return personaId === 'souma' ? 'man' : 'default';
+}
+
+function isBuiltinPersonaId(personaId) {
+	return BUILTIN_PERSONA_IDS.has(String(personaId || ''));
+}
+
+function normalizePersonaSlug(value) {
+	return String(value || '')
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 48);
+}
+
+function expandHomePath(filePath) {
+	const clean = String(filePath || '').trim();
+	if (clean === '~') return os.homedir();
+	if (clean.startsWith(`~${path.sep}`) || clean.startsWith('~/')) {
+		return path.join(os.homedir(), clean.slice(2));
 	}
-	const filename = variant === 'man' ? 'SOUL_MAN.md' : 'SOUL.md';
+	return clean;
+}
+
+function getPersonasDir() {
+	const dir = path.join(os.homedir(), '.cometmind', 'personas');
+	if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function getPersonaDir(id) {
+	const slug = normalizePersonaSlug(id);
+	if (!slug) return '';
+	const root = getPersonasDir();
+	const dir = path.resolve(root, slug);
+	if (dir !== root && dir.startsWith(root + path.sep)) return dir;
+	return '';
+}
+
+function builtinSoulFilename(personaId) {
+	return personaId === 'souma' ? 'SOUL_MAN.md' : 'SOUL.md';
+}
+
+function resolveBuiltinSoulPath(personaId = 'minako') {
+	const filename = builtinSoulFilename(personaId);
 	if (app.isPackaged) {
 		return path.join(process.resourcesPath, filename);
 	}
 	return path.join(__dirname, '..', filename);
+}
+
+function normalizeCustomPersonaEntry(value) {
+	if (!value || typeof value !== 'object') return null;
+	const id = normalizePersonaSlug(value.id);
+	const name = String(value.name || '').trim();
+	const soulPath = path.resolve(expandHomePath(value.soulPath));
+	if (!id || !name || !soulPath) return null;
+	const avatarPath = String(value.avatarPath || '').trim()
+		? path.resolve(expandHomePath(value.avatarPath))
+		: '';
+	return {
+		id,
+		name,
+		avatarPath,
+		soulPath,
+		createdAt: Number.isFinite(value.createdAt) ? Number(value.createdAt) : Date.now()
+	};
+}
+
+function customPersonasFromSettings(settings) {
+	const custom = settings?.app?.personas?.custom;
+	if (!Array.isArray(custom)) return [];
+	return custom.map(normalizeCustomPersonaEntry).filter(Boolean);
+}
+
+function findCustomPersona(settings, personaId) {
+	const id = normalizePersonaSlug(personaId);
+	return customPersonasFromSettings(settings).find((persona) => persona.id === id) ?? null;
+}
+
+function readSavedPersonaId(saved) {
+	const requested = String(saved?.app?.personaId || '').trim();
+	if (isBuiltinPersonaId(requested) || findCustomPersona(saved, requested)) return requested;
+	return migratePersonaIdFromIconVariant(saved?.app?.iconVariant);
+}
+
+function resolveNextPersonaId(settings, current) {
+	const merged = { app: { ...(current.app ?? {}), ...(settings.app ?? {}) } };
+	const requested = String(settings.app?.personaId || '').trim();
+	if (isBuiltinPersonaId(requested) || findCustomPersona(merged, requested)) return requested;
+	return readSavedPersonaId(current);
+}
+
+function resolveSystemPromptPath(personaId = 'minako', settings = undefined) {
+	if (process.env.COMETMIND_SYSTEM_PROMPT_PATH) {
+		return path.resolve(process.env.COMETMIND_SYSTEM_PROMPT_PATH);
+	}
+	const customPersona = findCustomPersona(settings, personaId);
+	if (customPersona?.soulPath) {
+		return path.resolve(expandHomePath(customPersona.soulPath));
+	}
+	return resolveBuiltinSoulPath(personaId);
 }
 
 function getLogPath() {
@@ -350,22 +458,11 @@ function getSettingsPath() {
 	return path.join(dir, 'cometline-settings.json');
 }
 
-function settingsNormalizeOptions(iconVariant = 'default') {
+function settingsNormalizeOptions(personaId = 'minako', settings = undefined) {
 	return {
 		fallbackWorkspacePath: readStoredWorkspacePath() || getDefaultWorkspacePath(),
-		systemPromptPath: resolveSystemPromptPath(iconVariant)
+		systemPromptPath: resolveSystemPromptPath(personaId, settings)
 	};
-}
-
-function readSavedIconVariant(saved) {
-	return saved?.app?.iconVariant === 'man' ? 'man' : 'default';
-}
-
-function resolveNextIconVariant(settings, current) {
-	if (settings.app?.iconVariant === 'man' || settings.app?.iconVariant === 'default') {
-		return settings.app.iconVariant;
-	}
-	return current.app?.iconVariant === 'man' ? 'man' : 'default';
 }
 
 function shortcutKeyMatches(a, b) {
@@ -564,7 +661,8 @@ function ensureTray() {
 	if (process.platform !== 'darwin') return false;
 	if (tray) return true;
 
-	const variant = getIconVariant();
+	const personaId = getPersonaId();
+	const variant = builtinPersonaToIconVariant(personaId);
 	const trayIconPath = resolveTrayResourcePath(
 		variant === 'man' ? 'trayIcon_man.png' : 'trayIcon.png'
 	);
@@ -839,8 +937,8 @@ function readSavedProviderSettings() {
 		}
 	}
 
-	const iconVariant = readSavedIconVariant(saved);
-	return parseAndNormalizeSettings(saved, settingsNormalizeOptions(iconVariant));
+	const personaId = readSavedPersonaId(saved);
+	return parseAndNormalizeSettings(saved, settingsNormalizeOptions(personaId, saved));
 }
 
 function writeProviderSettings(settings) {
@@ -855,10 +953,12 @@ function writeProviderSettings(settings) {
 			: (nextProviders.find((p) => p.enabled && p.enabledModels.length > 0)?.id ??
 				nextProviders[0]?.id ??
 				'');
-	const iconVariant = resolveNextIconVariant(settings, current);
+	const appSettings = { ...(current.app ?? {}), ...(settings.app ?? {}) };
+	const personaId = resolveNextPersonaId(settings, current);
+	appSettings.personaId = personaId;
 	const nextCometMind = {
 		...(settings.cometmind ?? current.cometmind),
-		systemPromptPath: resolveSystemPromptPath(iconVariant)
+		systemPromptPath: resolveSystemPromptPath(personaId, { app: appSettings })
 	};
 	const next = validateSettings(
 		normalizeSettings(
@@ -870,9 +970,9 @@ function writeProviderSettings(settings) {
 				appearance: settings.appearance ?? current.appearance,
 				shortcuts: settings.shortcuts ?? current.shortcuts,
 				cometmind: nextCometMind,
-				app: { ...(current.app ?? {}), ...(settings.app ?? {}), iconVariant }
+				app: appSettings
 			},
-			settingsNormalizeOptions(iconVariant)
+			settingsNormalizeOptions(personaId, { app: appSettings })
 		)
 	);
 	const settingsPath = getSettingsPath();
@@ -966,9 +1066,9 @@ async function importProviderSettings() {
 	const filePath = result.filePaths[0];
 	const raw = fs.readFileSync(filePath, 'utf8');
 	const parsed = JSON.parse(raw);
-	const iconVariant = readSavedIconVariant(parsed);
+	const personaId = readSavedPersonaId(parsed);
 	const imported = validateSettings(
-		parseAndNormalizeSettings(parsed, settingsNormalizeOptions(iconVariant))
+		parseAndNormalizeSettings(parsed, settingsNormalizeOptions(personaId, parsed))
 	);
 	const saved = writeProviderSettings(imported);
 	await stopCometMind();
@@ -976,7 +1076,7 @@ async function importProviderSettings() {
 	await waitForHealth();
 	await syncDiscordGatewayFromSettings(saved);
 	applyOpenAtLoginSetting(saved.app?.openAtLogin);
-	applyIconVariant(saved.app?.iconVariant);
+	applyPersona(saved.app?.personaId);
 	return { canceled: false, path: filePath, settings: saved };
 }
 
@@ -996,7 +1096,7 @@ function providerEnv() {
 		COMETMIND_MODEL: active.enabledModels[0] || active.selectedModel || active.models[0] || '',
 		COMETMIND_MAX_TOKENS: String(settings.cometmind?.maxTokens ?? 2048),
 		COMETMIND_LOG_LEVEL: settings.cometmind?.logLevel ?? 'error',
-		COMETMIND_SYSTEM_PROMPT_PATH: resolveSystemPromptPath(getIconVariant())
+		COMETMIND_SYSTEM_PROMPT_PATH: resolveSystemPromptPath(getPersonaId(), settings)
 	};
 	if (active.baseURL) env.COMETMIND_BASE_URL = active.baseURL;
 	if (active.apiKey) env.COMETMIND_API_KEY = active.apiKey;
@@ -1155,12 +1255,16 @@ async function selectWorkspacePath() {
 	return writeStoredWorkspacePath(result.filePaths[0]);
 }
 
-function getIconVariant() {
-	const variant = readProviderSettings().app?.iconVariant;
-	return variant === 'man' ? 'man' : 'default';
+function getPersonaId() {
+	return readSavedPersonaId(readProviderSettings());
 }
 
-function resolveAppIconPaths(variant = 'default') {
+function resolveAppIconPaths(personaId = 'minako', settings = undefined) {
+	const customPersona = findCustomPersona(settings ?? readProviderSettings(), personaId);
+	if (customPersona?.avatarPath) {
+		return [path.resolve(expandHomePath(customPersona.avatarPath))];
+	}
+	const variant = builtinPersonaToIconVariant(personaId);
 	if (variant === 'man') {
 		if (app.isPackaged) {
 			return [path.join(process.resourcesPath, 'app_icon_man.png')];
@@ -1176,11 +1280,18 @@ function resolveAppIconPaths(variant = 'default') {
 	return [path.join(__dirname, '..', 'buildResources', 'icon.png')];
 }
 
-function getAppIconPath(variant = getIconVariant()) {
-	return resolveAppIconPaths(variant).find((candidate) => fs.existsSync(candidate));
+function getAppIconPath(personaId = getPersonaId(), settings = undefined) {
+	return resolveAppIconPaths(personaId, settings).find((candidate) => fs.existsSync(candidate));
 }
 
-function resolveTrayImageSource(variant = getIconVariant()) {
+
+function resolveTrayImageSource(personaId = getPersonaId(), settings = undefined) {
+	const customPersona = findCustomPersona(settings ?? readProviderSettings(), personaId);
+	if (customPersona?.avatarPath && fs.existsSync(customPersona.avatarPath)) {
+		const image = nativeImage.createFromPath(customPersona.avatarPath);
+		if (!image.isEmpty()) return image.resize({ width: 18, height: 18, quality: 'best' });
+	}
+	const variant = builtinPersonaToIconVariant(personaId);
 	const trayIconPath = resolveTrayResourcePath(
 		variant === 'man' ? 'trayIcon_man.png' : 'trayIcon.png'
 	);
@@ -1190,15 +1301,15 @@ function resolveTrayImageSource(variant = getIconVariant()) {
 	return resolveTrayIcon(variant);
 }
 
-function applyIconVariant(variant = getIconVariant()) {
-	const iconPath = getAppIconPath(variant);
+function applyPersona(personaId = getPersonaId(), settings = undefined) {
+	const iconPath = getAppIconPath(personaId, settings);
 	if (!iconPath) {
-		console.warn('[icon] No app icon found for variant', variant);
+		console.warn('[icon] No app icon found for persona', personaId);
 		return;
 	}
 	const image = nativeImage.createFromPath(iconPath);
 	if (image.isEmpty()) {
-		console.warn('[icon] Failed to load app icon for variant', variant, iconPath);
+		console.warn('[icon] Failed to load app icon for persona', personaId, iconPath);
 		return;
 	}
 	if (process.platform === 'darwin') {
@@ -1208,7 +1319,7 @@ function applyIconVariant(variant = getIconVariant()) {
 		mainWindow.setIcon(image);
 	}
 	if (!tray) return;
-	const trayImageSource = resolveTrayImageSource(variant);
+	const trayImageSource = resolveTrayImageSource(personaId, settings);
 	if (typeof trayImageSource === 'string') {
 		tray.setImage(trayImageSource);
 		return;
@@ -1707,7 +1818,7 @@ function registerAppProtocol() {
 }
 
 async function createWindow() {
-	const iconPath = getAppIconPath(getIconVariant());
+	const iconPath = getAppIconPath(getPersonaId());
 	mainWindow = new BrowserWindow({
 		width: 1200,
 		height: 800,
@@ -1786,7 +1897,7 @@ async function createWindow() {
 }
 
 async function createMiniWindow() {
-	const iconPath = getAppIconPath(getIconVariant());
+	const iconPath = getAppIconPath(getPersonaId());
 	miniWindow = new BrowserWindow({
 		width: MINI_WINDOW_WIDTH,
 		height: MINI_WINDOW_HEIGHT,
@@ -2513,7 +2624,7 @@ app.whenReady().then(async () => {
 		}
 	});
 	await windowReady;
-	applyIconVariant(startupSettings.app?.iconVariant);
+	applyPersona(startupSettings.app?.personaId, startupSettings);
 	configureAutoUpdater();
 
 	app.on('second-instance', () => {
@@ -2651,6 +2762,16 @@ ipcMain.handle('cometline:read-workspace-file', (_event, workspacePath, relative
 	readWorkspaceFileForPreview(workspacePath, relativePath)
 );
 
+ipcMain.handle('cometline:list-custom-personas', () => customPersonasFromSettings(readProviderSettings()));
+
+ipcMain.handle('cometline:read-persona-avatar', (_event, id) => readPersonaAvatar(id));
+
+ipcMain.handle('cometline:read-builtin-soul', (_event, personaId) => readPersonaSoul(personaId));
+
+ipcMain.handle('cometline:save-custom-persona', (_event, payload) => saveCustomPersona(payload));
+
+ipcMain.handle('cometline:delete-custom-persona', (_event, id) => deleteCustomPersona(id));
+
 ipcMain.handle('cometline:get-provider-settings', () => readProviderSettings());
 
 ipcMain.handle('cometline:get-codex-auth-status', () => getCodexAuthStatus());
@@ -2670,8 +2791,7 @@ ipcMain.handle('cometline:fetch-provider-models', async (_event, config) => {
 ipcMain.handle('cometline:save-provider-settings', async (_event, settings, options = {}) => {
 	const previous = readProviderSettings();
 	const saved = writeProviderSettings(settings);
-	const iconVariantChanged =
-		(previous.app?.iconVariant ?? 'default') !== (saved.app?.iconVariant ?? 'default');
+	const personaIdChanged = (previous.app?.personaId ?? 'minako') !== (saved.app?.personaId ?? 'minako');
 	const runtimeAction =
 		options.runtimeAction ?? (options.restartCometMind === false ? 'none' : 'restart');
 	refreshGlobalShortcuts();
@@ -2684,8 +2804,8 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	}
 	await syncDiscordGatewayFromSettings(saved);
 	applyOpenAtLoginSetting(saved.app?.openAtLogin);
-	if (iconVariantChanged) {
-		applyIconVariant(saved.app?.iconVariant);
+	if (personaIdChanged) {
+		applyPersona(saved.app?.personaId, saved);
 	}
 	return saved;
 });
@@ -2824,6 +2944,135 @@ async function readWorkspaceFileForPreview(workspacePath, relativePath) {
 	}
 
 	return { ok: true, kind: 'text', content, extension: ext };
+}
+
+async function readPersonaSoul(personaId) {
+	const settings = readProviderSettings();
+	const customPersona = findCustomPersona(settings, personaId);
+	const soulPath = customPersona?.soulPath ?? resolveBuiltinSoulPath(personaId);
+	try {
+		const stat = await fs.promises.stat(soulPath);
+		if (!stat.isFile()) return { ok: false, error: 'SOUL file is not a file' };
+		const content = await fs.promises.readFile(soulPath, 'utf8');
+		return { ok: true, content };
+	} catch {
+		return { ok: false, error: 'SOUL file not found' };
+	}
+}
+
+async function readPersonaAvatar(id) {
+	const settings = readProviderSettings();
+	const customPersona = findCustomPersona(settings, id);
+	if (!customPersona?.avatarPath) return { ok: false, error: 'Avatar image not found' };
+	const avatarPath = path.resolve(expandHomePath(customPersona.avatarPath));
+	let stat;
+	try {
+		stat = await fs.promises.stat(avatarPath);
+	} catch {
+		return { ok: false, error: 'Avatar image not found' };
+	}
+	if (!stat.isFile()) return { ok: false, error: 'Avatar image is not a file' };
+	if (stat.size > PERSONA_AVATAR_MAX_BYTES) {
+		return { ok: false, error: 'Avatar image exceeds 2 MB limit' };
+	}
+	const ext = path.extname(avatarPath).toLowerCase();
+	const mimeType = PERSONA_IMAGE_MIME_BY_EXT[ext];
+	if (!mimeType) return { ok: false, error: 'Unsupported avatar image type' };
+	const buffer = await fs.promises.readFile(avatarPath);
+	return { ok: true, dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}` };
+}
+
+function decodePersonaAvatarDataUrl(dataUrl) {
+	const match = String(dataUrl || '').match(/^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/=]+)$/);
+	if (!match) return null;
+	const ext = match[1] === 'image/jpeg' ? '.jpg' : match[1] === 'image/webp' ? '.webp' : '.png';
+	const buffer = Buffer.from(match[2], 'base64');
+	if (buffer.length > PERSONA_AVATAR_MAX_BYTES) {
+		throw new Error('Avatar image exceeds 2 MB limit');
+	}
+	return { ext, buffer };
+}
+
+function nextCustomPersonaId(requestedId, name, existingPersonas) {
+	const existing = new Set(existingPersonas.map((persona) => persona.id));
+	const base = normalizePersonaSlug(requestedId) || normalizePersonaSlug(name) || 'persona';
+	if (requestedId || !existing.has(base)) return base;
+	for (let i = 2; i < 1000; i += 1) {
+		const candidate = `${base}-${i}`;
+		if (!existing.has(candidate)) return candidate;
+	}
+	return `${base}-${Date.now()}`;
+}
+
+async function saveCustomPersona(payload = {}) {
+	const name = String(payload.name || '').trim();
+	const soulMarkdown = String(payload.soulMarkdown || '').trim();
+	if (!name) return { ok: false, error: 'Persona name is required.' };
+	if (!soulMarkdown) return { ok: false, error: 'SOUL.md content is required.' };
+
+	const settings = readProviderSettings();
+	const customPersonas = customPersonasFromSettings(settings);
+	const id = nextCustomPersonaId(payload.id, name, customPersonas);
+	const personaDir = getPersonaDir(id);
+	if (!personaDir) return { ok: false, error: 'Invalid persona id.' };
+	await fs.promises.mkdir(personaDir, { recursive: true });
+
+	const existing = customPersonas.find((persona) => persona.id === id);
+	const soulPath = path.join(personaDir, 'SOUL.md');
+	await fs.promises.writeFile(soulPath, `${soulMarkdown}\n`, { mode: 0o600 });
+
+	let avatarPath = existing?.avatarPath ?? '';
+	if (payload.avatarDataUrl) {
+		let decoded;
+		try {
+			decoded = decodePersonaAvatarDataUrl(payload.avatarDataUrl);
+		} catch (err) {
+			return { ok: false, error: err?.message ?? 'Invalid avatar image.' };
+		}
+		if (!decoded) return { ok: false, error: 'Avatar image must be PNG, JPEG, or WebP.' };
+		avatarPath = path.join(personaDir, `avatar${decoded.ext}`);
+		await fs.promises.writeFile(avatarPath, decoded.buffer, { mode: 0o600 });
+	}
+
+	const persona = {
+		id,
+		name,
+		avatarPath,
+		soulPath,
+		createdAt: existing?.createdAt ?? Date.now()
+	};
+	const nextCustomPersonas = [...customPersonas.filter((item) => item.id !== id), persona];
+	settings.app = {
+		...settings.app,
+		personaId: id,
+		personas: { custom: nextCustomPersonas }
+	};
+	const saved = writeProviderSettings(settings);
+	await reloadCometMind();
+	applyPersona(saved.app?.personaId, saved);
+	return { ok: true, persona };
+}
+
+async function deleteCustomPersona(id) {
+	const cleanId = normalizePersonaSlug(id);
+	if (!cleanId) return { ok: false, error: 'Invalid persona id.' };
+	const settings = readProviderSettings();
+	const customPersonas = customPersonasFromSettings(settings);
+	const existing = customPersonas.find((persona) => persona.id === cleanId);
+	if (!existing) return { ok: false, error: 'Persona not found.' };
+	settings.app = {
+		...settings.app,
+		personaId: settings.app?.personaId === cleanId ? 'minako' : settings.app?.personaId,
+		personas: { custom: customPersonas.filter((persona) => persona.id !== cleanId) }
+	};
+	const saved = writeProviderSettings(settings);
+	const personaDir = getPersonaDir(cleanId);
+	if (personaDir) {
+		await fs.promises.rm(personaDir, { recursive: true, force: true });
+	}
+	await reloadCometMind();
+	applyPersona(saved.app?.personaId, saved);
+	return { ok: true };
 }
 
 ipcMain.handle('cometline:open-external', async (_event, rawUrl) => {

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -335,6 +335,9 @@ const PERSONA_IMAGE_MIME_BY_EXT = {
 	'.webp': 'image/webp'
 };
 const PERSONA_AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+const PERSONA_APP_ICON_SIZE = 1024;
+const PERSONA_APP_ICON_RADIUS = 224;
+const PERSONA_APP_ICON_ARTWORK_SCALE = 0.8125;
 
 function migratePersonaIdFromIconVariant(iconVariant) {
 	return iconVariant === 'man' ? 'souma' : 'minako';
@@ -1284,11 +1287,41 @@ function getAppIconPath(personaId = getPersonaId(), settings = undefined) {
 	return resolveAppIconPaths(personaId, settings).find((candidate) => fs.existsSync(candidate));
 }
 
+function createCustomPersonaAppIcon(customPersona) {
+	if (!customPersona?.avatarPath || !fs.existsSync(customPersona.avatarPath)) return null;
+	const ext = path.extname(customPersona.avatarPath).toLowerCase();
+	const mimeType = PERSONA_IMAGE_MIME_BY_EXT[ext];
+	if (!mimeType) return null;
+	let buffer;
+	try {
+		buffer = fs.readFileSync(customPersona.avatarPath);
+	} catch {
+		return null;
+	}
+	const artworkSize = PERSONA_APP_ICON_SIZE * PERSONA_APP_ICON_ARTWORK_SCALE;
+	const artworkInset = (PERSONA_APP_ICON_SIZE - artworkSize) / 2;
+	const artworkRadius = PERSONA_APP_ICON_RADIUS * PERSONA_APP_ICON_ARTWORK_SCALE;
+	const avatarDataUrl = `data:${mimeType};base64,${buffer.toString('base64')}`;
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${PERSONA_APP_ICON_SIZE}" height="${PERSONA_APP_ICON_SIZE}" viewBox="0 0 ${PERSONA_APP_ICON_SIZE} ${PERSONA_APP_ICON_SIZE}"><defs><clipPath id="persona-icon"><rect x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}" rx="${artworkRadius}" ry="${artworkRadius}"/></clipPath></defs><image href="${avatarDataUrl}" x="${artworkInset}" y="${artworkInset}" width="${artworkSize}" height="${artworkSize}" preserveAspectRatio="xMidYMid slice" clip-path="url(#persona-icon)"/></svg>`;
+	const image = nativeImage.createFromDataURL(`data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`);
+	return image.isEmpty() ? null : image;
+}
+
+function getAppIconImage(personaId = getPersonaId(), settings = undefined) {
+	const resolvedSettings = settings ?? readProviderSettings();
+	const customPersona = findCustomPersona(resolvedSettings, personaId);
+	const customIcon = createCustomPersonaAppIcon(customPersona);
+	if (customIcon) return customIcon;
+	const iconPath = getAppIconPath(personaId, resolvedSettings);
+	if (!iconPath) return null;
+	const image = nativeImage.createFromPath(iconPath);
+	return image.isEmpty() ? null : image;
+}
 
 function resolveTrayImageSource(personaId = getPersonaId(), settings = undefined) {
 	const customPersona = findCustomPersona(settings ?? readProviderSettings(), personaId);
 	if (customPersona?.avatarPath && fs.existsSync(customPersona.avatarPath)) {
-		const image = nativeImage.createFromPath(customPersona.avatarPath);
+		const image = createCustomPersonaAppIcon(customPersona) ?? nativeImage.createFromPath(customPersona.avatarPath);
 		if (!image.isEmpty()) return image.resize({ width: 18, height: 18, quality: 'best' });
 	}
 	const variant = builtinPersonaToIconVariant(personaId);
@@ -1302,14 +1335,9 @@ function resolveTrayImageSource(personaId = getPersonaId(), settings = undefined
 }
 
 function applyPersona(personaId = getPersonaId(), settings = undefined) {
-	const iconPath = getAppIconPath(personaId, settings);
-	if (!iconPath) {
+	const image = getAppIconImage(personaId, settings);
+	if (!image) {
 		console.warn('[icon] No app icon found for persona', personaId);
-		return;
-	}
-	const image = nativeImage.createFromPath(iconPath);
-	if (image.isEmpty()) {
-		console.warn('[icon] Failed to load app icon for persona', personaId, iconPath);
 		return;
 	}
 	if (process.platform === 'darwin') {
@@ -1818,7 +1846,7 @@ function registerAppProtocol() {
 }
 
 async function createWindow() {
-	const iconPath = getAppIconPath(getPersonaId());
+	const appIcon = getAppIconImage(getPersonaId());
 	mainWindow = new BrowserWindow({
 		width: 1200,
 		height: 800,
@@ -1837,7 +1865,7 @@ async function createWindow() {
 					visualEffectState: 'active'
 				}
 			: {}),
-		...(iconPath ? { icon: iconPath } : {}),
+		...(appIcon ? { icon: appIcon } : {}),
 		show: false,
 		webPreferences: {
 			preload: path.join(__dirname, 'preload.cjs'),
@@ -1848,9 +1876,8 @@ async function createWindow() {
 		}
 	});
 	setWindowButtonPosition(WINDOW_BUTTON_OPEN_POSITION);
-	if (process.platform === 'darwin' && iconPath) {
-		const dockIcon = nativeImage.createFromPath(iconPath);
-		if (!dockIcon.isEmpty()) app.dock?.setIcon(dockIcon);
+	if (process.platform === 'darwin' && appIcon) {
+		app.dock?.setIcon(appIcon);
 	}
 
 	attachExternalNavigationGuards(mainWindow);
@@ -1897,7 +1924,7 @@ async function createWindow() {
 }
 
 async function createMiniWindow() {
-	const iconPath = getAppIconPath(getPersonaId());
+	const appIcon = getAppIconImage(getPersonaId());
 	miniWindow = new BrowserWindow({
 		width: MINI_WINDOW_WIDTH,
 		height: MINI_WINDOW_HEIGHT,
@@ -1911,7 +1938,7 @@ async function createMiniWindow() {
 					trafficLightPosition: { x: 14, y: 14 }
 				}
 			: {}),
-		...(iconPath ? { icon: iconPath } : {}),
+		...(appIcon ? { icon: appIcon } : {}),
 		show: false,
 		webPreferences: {
 			preload: path.join(__dirname, 'preload.cjs'),

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -15,6 +15,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 	pruneWorkspaceStore: () => ipcRenderer.invoke('cometline:prune-workspace-store'),
 	readWorkspaceFile: (workspacePath, relativePath) =>
 		ipcRenderer.invoke('cometline:read-workspace-file', workspacePath, relativePath),
+	listCustomPersonas: () => ipcRenderer.invoke('cometline:list-custom-personas'),
+	saveCustomPersona: (payload) => ipcRenderer.invoke('cometline:save-custom-persona', payload),
+	deleteCustomPersona: (id) => ipcRenderer.invoke('cometline:delete-custom-persona', id),
+	readPersonaAvatar: (id) => ipcRenderer.invoke('cometline:read-persona-avatar', id),
+	readBuiltinSoul: (personaId) => ipcRenderer.invoke('cometline:read-builtin-soul', personaId),
 	getProviderSettings: () => ipcRenderer.invoke('cometline:get-provider-settings'),
 	getCodexAuthStatus: () => ipcRenderer.invoke('cometline:get-codex-auth-status'),
 	startCodexLogin: () => ipcRenderer.invoke('cometline:start-codex-login'),

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -4085,10 +4085,20 @@ var coerce = {
 var NEVER = INVALID;
 
 // src/lib/hero-composer-appearance.ts
+var HERO_COMPOSER_PRESET_ROSE = {
+  presetId: "rose",
+  glowColor: "#f43f5e",
+  ringColor: "#fb7185"
+};
 var HERO_COMPOSER_PRESET_BLUE = {
+  presetId: "blue",
   glowColor: "#72c0ff",
   ringColor: "#4a9de8"
 };
+var HERO_COMPOSER_PRESETS = [
+  { id: "blue", label: "Blue", appearance: HERO_COMPOSER_PRESET_BLUE },
+  { id: "rose", label: "Rose", appearance: HERO_COMPOSER_PRESET_ROSE }
+];
 var DEFAULT_HERO_COMPOSER_APPEARANCE = {
   ...HERO_COMPOSER_PRESET_BLUE
 };
@@ -4103,8 +4113,27 @@ function normalizeHexColor(value, fallback) {
   }
   return trimmed.toLowerCase();
 }
-function normalizeHeroComposerAppearance(appearance) {
+function presetAppearanceFor(id) {
+  return id === "rose" ? HERO_COMPOSER_PRESET_ROSE : HERO_COMPOSER_PRESET_BLUE;
+}
+function presetIdFromValue(value) {
+  return value === "rose" || value === "custom" ? value : value === "blue" ? "blue" : void 0;
+}
+function normalizeCustomPreset(appearance) {
+  if (!appearance?.customPreset) return void 0;
   return {
+    glowColor: normalizeHexColor(
+      appearance.customPreset.glowColor,
+      DEFAULT_HERO_COMPOSER_APPEARANCE.glowColor
+    ),
+    ringColor: normalizeHexColor(
+      appearance.customPreset.ringColor,
+      DEFAULT_HERO_COMPOSER_APPEARANCE.ringColor
+    )
+  };
+}
+function normalizeHeroComposerAppearance(appearance) {
+  const legacyColors = {
     glowColor: normalizeHexColor(
       appearance?.glowColor,
       DEFAULT_HERO_COMPOSER_APPEARANCE.glowColor
@@ -4114,6 +4143,17 @@ function normalizeHeroComposerAppearance(appearance) {
       DEFAULT_HERO_COMPOSER_APPEARANCE.ringColor
     )
   };
+  const matchedPreset = HERO_COMPOSER_PRESETS.find(
+    (preset2) => legacyColors.glowColor === preset2.appearance.glowColor && legacyColors.ringColor === preset2.appearance.ringColor
+  )?.id;
+  const customPreset = normalizeCustomPreset(appearance) ?? (matchedPreset ? void 0 : legacyColors);
+  const presetId = presetIdFromValue(appearance?.presetId) ?? matchedPreset ?? "blue";
+  if (presetId === "custom") {
+    const custom2 = customPreset ?? legacyColors;
+    return { presetId: "custom", ...custom2, customPreset: custom2 };
+  }
+  const preset = presetAppearanceFor(presetId);
+  return { ...preset, customPreset };
 }
 
 // src/lib/keyboard-shortcuts.ts
@@ -4997,8 +5037,13 @@ var providerSettingsSchema = external_exports.object({
   defaultProviderId: external_exports.string(),
   appearance: external_exports.object({
     heroComposer: external_exports.object({
+      presetId: external_exports.enum(["blue", "rose", "custom"]),
       glowColor: external_exports.string(),
-      ringColor: external_exports.string()
+      ringColor: external_exports.string(),
+      customPreset: external_exports.object({
+        glowColor: external_exports.string(),
+        ringColor: external_exports.string()
+      }).optional()
     }),
     caretTrail: external_exports.object({
       enabled: external_exports.boolean(),

--- a/cometline/scripts/generate-project-icons.swift
+++ b/cometline/scripts/generate-project-icons.swift
@@ -200,7 +200,35 @@ let variants: [Variant] = [
 	)
 ]
 
-let requestedVariant = CommandLine.arguments.dropFirst().first
+let cliArgs = Array(CommandLine.arguments.dropFirst())
+if cliArgs.first == "persona" {
+	guard cliArgs.count >= 3 else {
+		fail("usage: generate-project-icons.swift persona <source-image> <output-app-icon.png>")
+	}
+	let sourcePath = cliArgs[1]
+	let outputPath = cliArgs[2]
+	guard FileManager.default.fileExists(atPath: sourcePath) else {
+		fail("source image not found: \(sourcePath)")
+	}
+	guard let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: sourcePath) as CFURL, nil),
+		let sourceImage = CGImageSourceCreateImageAtIndex(source, 0, nil),
+		let cropped = centerCroppedSquare(from: sourceImage)
+	else {
+		fail("could not read or crop \(sourcePath)")
+	}
+	let personaDockOutput = Output(
+		path: outputPath,
+		size: 1024,
+		radius: 224,
+		artworkScale: 0.8125,
+		clipToRoundedRect: true
+	)
+	renderOutput(personaDockOutput, from: cropped)
+	print("Generated persona app icon at \(outputPath).")
+	exit(0)
+}
+
+let requestedVariant = cliArgs.first
 let selectedVariants = variants.filter { variant in
 	guard let requestedVariant else { return true }
 	return variant.label == requestedVariant

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -18,8 +18,13 @@ declare global {
 	}
 
 	interface HeroComposerAppearance {
+		presetId: 'blue' | 'rose' | 'custom';
 		glowColor: string;
 		ringColor: string;
+		customPreset?: {
+			glowColor: string;
+			ringColor: string;
+		};
 	}
 
 	interface CaretTrailSettings {

--- a/cometline/src/lib/components/IntroAnimation.svelte
+++ b/cometline/src/lib/components/IntroAnimation.svelte
@@ -6,6 +6,7 @@
 	import { resolvePersona, personaAvatarSrcset as builtinAvatarSrcset } from '$lib/personas';
 	import { personaAvatarCache } from '$lib/personas/avatar-cache.svelte';
 	import { rectStyle } from '$lib/first-turn-flight';
+	import { normalizeHeroComposerAppearance } from '$lib/hero-composer-appearance';
 
 	// ──────────────────────────────────────────────────────────────────────────
 	// Cometline first-run intro.
@@ -52,7 +53,9 @@
 		resolvedPersona.kind === 'builtin' ? builtinAvatarSrcset(resolvedPersona) : undefined
 	);
 
-	const GLOW = () => settingsStore.settings.appearance.heroComposer.glowColor || '#72c0ff';
+	let heroGlowColor = $derived(
+		normalizeHeroComposerAppearance(settingsStore.settings.appearance.heroComposer).glowColor
+	);
 
 	function readCssVar(name: string, fallback: string): string {
 		if (typeof window === 'undefined') return fallback;
@@ -70,6 +73,17 @@
 		ctx.fillRect(0, 0, 1, 1);
 		const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
 		return { r, g, b };
+	}
+
+	function darkenRgb(
+		{ r, g, b }: { r: number; g: number; b: number },
+		factor: number
+	): { r: number; g: number; b: number } {
+		return {
+			r: Math.round(r * factor),
+			g: Math.round(g * factor),
+			b: Math.round(b * factor)
+		};
 	}
 
 	// easeOutCubic for cinematic deceleration.
@@ -154,10 +168,11 @@
 		resize();
 		window.addEventListener('resize', resize);
 
-		// Palette: hero glow blue + tomlord.io ink, on warm paper.
-		const glow = toRgb(GLOW()); // hero glow blue (#72c0ff)
-		const ink = toRgb(readCssVar('--intro-blue', '#4078f2')); // tomlord accent
-		const inkDeep = toRgb(readCssVar('--intro-blue-deep', '#0184bc'));
+		// Palette: user's hero-glow preset on warm paper.
+		const glowHex = readCssVar('--hero-composer-glow-color', heroGlowColor);
+		const glow = toRgb(glowHex);
+		const ink = glow;
+		const inkDeep = darkenRgb(glow, 0.58);
 		const bg = readCssVar('--intro-bg', '#fafafa');
 		const bgDeep = readCssVar('--intro-bg-deep', '#eef1f6');
 
@@ -424,11 +439,11 @@
 		display: block;
 	}
 
-	/* Vintage double-rule border in blue ink, inset from the edges. */
+	/* Vintage double-rule border in hero-glow ink, inset from the edges. */
 	.frame {
 		position: absolute;
 		inset: 26px;
-		border: 1px solid color-mix(in srgb, var(--intro-blue, #4078f2) 38%, transparent);
+		border: 1px solid color-mix(in srgb, var(--hero-composer-glow-color, #72c0ff) 38%, transparent);
 		border-radius: 4px;
 		pointer-events: none;
 		opacity: 0;
@@ -439,7 +454,7 @@
 		content: '';
 		position: absolute;
 		inset: 5px;
-		border: 1px solid color-mix(in srgb, var(--intro-blue, #4078f2) 18%, transparent);
+		border: 1px solid color-mix(in srgb, var(--hero-composer-glow-color, #72c0ff) 18%, transparent);
 		border-radius: 2px;
 	}
 
@@ -516,7 +531,7 @@
 	}
 
 	.wordmark .trail {
-		color: var(--intro-ink, #383a42);
+		color: var(--hero-composer-glow-color, #72c0ff);
 	}
 
 	.tagline {
@@ -525,7 +540,7 @@
 		font-style: italic;
 		font-size: clamp(13px, 1.7vw, 17px);
 		letter-spacing: 0.04em;
-		color: var(--intro-ink-soft, rgba(56, 58, 66, 0.55));
+		color: color-mix(in srgb, var(--hero-composer-glow-color, #72c0ff) 42%, var(--intro-ink, #383a42));
 		opacity: 0;
 		transform: translateY(8px);
 		transition:
@@ -546,7 +561,7 @@
 		z-index: 3;
 		border: 0;
 		background: transparent;
-		color: var(--intro-ink-soft, rgba(56, 58, 66, 0.55));
+		color: color-mix(in srgb, var(--hero-composer-glow-color, #72c0ff) 35%, var(--intro-ink, #383a42));
 		font-size: 11px;
 		letter-spacing: 0.16em;
 		text-transform: uppercase;
@@ -560,7 +575,7 @@
 
 	.skip:hover {
 		opacity: 1;
-		color: var(--intro-blue, #4078f2);
+		color: var(--hero-composer-glow-color, #72c0ff);
 	}
 
 	.is-exit .card {

--- a/cometline/src/lib/components/RichComposerInput.svelte
+++ b/cometline/src/lib/components/RichComposerInput.svelte
@@ -95,9 +95,20 @@
 		resetCustomCaret(editor);
 	}
 
+	let queuedCaretState: CustomCaretState | null = null;
+	let caretStateUpdateQueued = false;
+
 	function onCaretStateChange(state: CustomCaretState) {
-		focused = state.focused;
-		caretReady = state.ready;
+		queuedCaretState = state;
+		if (caretStateUpdateQueued) return;
+		caretStateUpdateQueued = true;
+		queueMicrotask(() => {
+			caretStateUpdateQueued = false;
+			if (!queuedCaretState) return;
+			focused = queuedCaretState.focused;
+			caretReady = queuedCaretState.ready;
+			queuedCaretState = null;
+		});
 	}
 
 	/** Build a non-editable inline chip element for a URL. */

--- a/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
@@ -105,10 +105,11 @@
 									class:empty={!hasCustomPreset}
 									style={hasCustomPreset
 										? `background: linear-gradient(135deg, ${appearance.customPreset?.glowColor} 0%, ${appearance.customPreset?.ringColor} 100%)`
-										: undefined}
+										: "background: linear-gradient(135deg, #23232a 0%, #454553 100%)"}
+					
 									aria-hidden="true"
 								></span>
-								{hasCustomPreset ? 'Custom' : 'Create custom'}
+								Custom
 							</button>
 						</div>
 					</div>

--- a/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
@@ -4,7 +4,8 @@
 		DEFAULT_HERO_COMPOSER_APPEARANCE,
 		HERO_COMPOSER_PRESETS,
 		heroComposerCssVarStyle,
-		matchHeroComposerPreset
+		matchHeroComposerPreset,
+		normalizeHeroComposerAppearance
 	} from '$lib/hero-composer-appearance';
 
 	let {
@@ -14,9 +15,40 @@
 
 	let previewStyle = $derived(heroComposerCssVarStyle(appearance));
 	let activePreset = $derived(matchHeroComposerPreset(appearance));
+	let hasCustomPreset = $derived(Boolean(appearance.customPreset));
+	let customControlsDisabled = $derived(activePreset !== 'custom');
 
 	function applyPreset(preset: (typeof HERO_COMPOSER_PRESETS)[number]) {
-		appearance = { ...preset.appearance };
+		appearance = {
+			...preset.appearance,
+			customPreset: appearance.customPreset ? { ...appearance.customPreset } : undefined
+		};
+	}
+
+	function createOrSelectCustomPreset() {
+		const normalized = normalizeHeroComposerAppearance(appearance);
+		const customPreset = normalized.customPreset ?? {
+			glowColor: normalized.glowColor,
+			ringColor: normalized.ringColor
+		};
+		appearance = {
+			presetId: 'custom',
+			...customPreset,
+			customPreset: { ...customPreset }
+		};
+	}
+
+	function updateCustomColor(key: 'glowColor' | 'ringColor', value: string) {
+		const base = appearance.customPreset ?? {
+			glowColor: appearance.glowColor,
+			ringColor: appearance.ringColor
+		};
+		const customPreset = { ...base, [key]: value };
+		appearance = {
+			presetId: 'custom',
+			...customPreset,
+			customPreset
+		};
 	}
 
 	function resetDefaults() {
@@ -61,9 +93,23 @@
 									{preset.label}
 								</button>
 							{/each}
-							{#if activePreset === 'custom'}
-								<span class="preset-custom">Custom</span>
-							{/if}
+							<button
+								type="button"
+								class="preset-chip custom-preset-chip"
+								class:selected={activePreset === 'custom'}
+								aria-pressed={activePreset === 'custom'}
+								onclick={createOrSelectCustomPreset}
+							>
+								<span
+									class="preset-swatch"
+									class:empty={!hasCustomPreset}
+									style={hasCustomPreset
+										? `background: linear-gradient(135deg, ${appearance.customPreset?.glowColor} 0%, ${appearance.customPreset?.ringColor} 100%)`
+										: undefined}
+									aria-hidden="true"
+								></span>
+								{hasCustomPreset ? 'Custom' : 'Create custom'}
+							</button>
 						</div>
 					</div>
 
@@ -72,14 +118,18 @@
 						<div class="color-field">
 							<input
 								type="color"
-								bind:value={appearance.glowColor}
+								value={appearance.glowColor}
+								disabled={customControlsDisabled}
 								aria-label="Glow color"
+								oninput={(e) => updateCustomColor('glowColor', e.currentTarget.value)}
 							/>
 							<input
 								type="text"
-								bind:value={appearance.glowColor}
+								value={appearance.glowColor}
+								disabled={customControlsDisabled}
 								spellcheck="false"
 								pattern="^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+								oninput={(e) => updateCustomColor('glowColor', e.currentTarget.value)}
 							/>
 						</div>
 					</label>
@@ -89,14 +139,18 @@
 						<div class="color-field">
 							<input
 								type="color"
-								bind:value={appearance.ringColor}
+								value={appearance.ringColor}
+								disabled={customControlsDisabled}
 								aria-label="Border color"
+								oninput={(e) => updateCustomColor('ringColor', e.currentTarget.value)}
 							/>
 							<input
 								type="text"
-								bind:value={appearance.ringColor}
+								value={appearance.ringColor}
+								disabled={customControlsDisabled}
 								spellcheck="false"
 								pattern="^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+								oninput={(e) => updateCustomColor('ringColor', e.currentTarget.value)}
 							/>
 						</div>
 					</label>
@@ -226,6 +280,10 @@
 		background: rgba(15, 23, 42, 0.08);
 	}
 
+	.custom-preset-chip {
+		padding-right: 12px;
+	}
+
 	.preset-swatch {
 		width: 22px;
 		height: 22px;
@@ -235,11 +293,11 @@
 		flex-shrink: 0;
 	}
 
-	.preset-custom {
-		font-size: 11px;
-		font-weight: 600;
-		color: var(--text-soft);
-		padding: 0 4px;
+	.preset-swatch.empty {
+		background:
+			linear-gradient(90deg, transparent 9px, rgba(15, 23, 42, 0.16) 9px 11px, transparent 11px),
+			linear-gradient(0deg, transparent 9px, rgba(15, 23, 42, 0.16) 9px 11px, transparent 11px),
+			rgba(15, 23, 42, 0.04);
 	}
 
 	label {
@@ -284,6 +342,11 @@
 	input[type='color']:focus {
 		border-color: rgba(0, 102, 204, 0.35);
 		box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.1);
+	}
+
+	input:disabled {
+		cursor: not-allowed;
+		opacity: 0.56;
 	}
 
 	.appearance-preview {

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -62,7 +62,7 @@
 	let personaEditorAvatarDataUrl = $state<string | undefined>(undefined);
 	let personaEditorError = $state('');
 	let personaEditorBusy = $state(false);
-let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
+	let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 
 	interface CustomPersonaLike {
 		id: string;
@@ -444,7 +444,10 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 										</button>
 									{/each}
 									{#each customPersonas as persona (persona.id)}
-										<div class="icon-variant-chip custom-persona-chip">
+										<div
+											class="icon-variant-chip custom-persona-chip"
+											class:selected={draft.app.personaId === persona.id}
+										>
 											<button
 												type="button"
 												class="custom-persona-select"
@@ -524,7 +527,7 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 											class="secondary"
 											onclick={() => (soulPreviewOpen = false)}>Close</button
 										>
-									</div>
+										</div>
 								</div>
 								<pre class="soul-preview-body">{soulPreviewText}</pre>
 							</div>
@@ -1085,8 +1088,8 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 	}
 
 	.icon-variant-chip.selected {
-		border-color: rgba(0, 102, 204, 0.4);
-		box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.08);
+		border-color: var(--pane-focus-border);
+		box-shadow: 0 0 0 3px var(--pane-focus-glow);
 	}
 
 	.icon-variant-chip:hover {
@@ -1115,6 +1118,11 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 		border-radius: 10px;
 	}
 
+	.custom-persona-select:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 3px var(--pane-focus-glow);
+	}
+
 	.custom-persona-select img {
 		width: 40px;
 		height: 40px;
@@ -1124,7 +1132,12 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 	}
 
 	.custom-persona-select.selected {
-		color: var(--accent);
+		color: var(--hero-composer-glow-color);
+	}
+
+	.custom-persona-chip.selected {
+		border-color: var(--pane-focus-border);
+		box-shadow: 0 0 0 3px var(--pane-focus-glow);
 	}
 
 	.custom-persona-actions {
@@ -1202,6 +1215,7 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 		position: relative;
 		z-index: 1;
 		display: grid;
+		grid-template-rows: auto minmax(0, 1fr);
 		gap: 12px;
 		width: min(560px, 100%);
 		max-height: min(640px, calc(100vh - 60px));
@@ -1215,6 +1229,7 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 
 	.persona-editor-panel {
 		background: rgba(255, 255, 255, 0.98);
+		grid-template-rows: auto auto minmax(0, auto) auto;
 		overflow-y: auto;
 	}
 
@@ -1239,6 +1254,8 @@ let personaAvatarFileInput = $state<HTMLInputElement | undefined>(undefined);
 
 	.soul-preview-body {
 		margin: 0;
+		min-height: 0;
+		max-height: min(520px, calc(100vh - 180px));
 		overflow: auto;
 		white-space: pre-wrap;
 		word-break: break-word;

--- a/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
+++ b/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
@@ -364,7 +364,9 @@ export function createSettingsPanelController(deps: {
 		const payload: ProviderSettings = providerPayloadFromDraft(draft);
 		payload.activeProviderId = activeProvider?.id ?? '';
 		const personaIdChanged = settingsStore.settings.app.personaId !== draft.app.personaId;
-		const runtimeAction = runtimeActionForSettingsSave(settingsStore.settings, payload);
+		const runtimeAction = personaIdChanged
+			? 'reload'
+			: runtimeActionForSettingsSave(settingsStore.settings, payload);
 		const { settings: saved } = await settingsStore.save(payload, { runtimeAction });
 		deps.setDraft(cloneSettings(saved));
 		cometmindPanelKey += 1;
@@ -550,6 +552,7 @@ export function createSettingsPanelController(deps: {
 				settingsStore.apply(settings);
 				deps.setDraft(cloneSettings(settings));
 			}
+			setTimeout(replayIntro, 600);
 		}
 		return result;
 	}
@@ -565,6 +568,7 @@ export function createSettingsPanelController(deps: {
 				settingsStore.apply(settings);
 				deps.setDraft(cloneSettings(settings));
 			}
+			setTimeout(replayIntro, 600);
 		}
 		return result;
 	}

--- a/cometline/src/lib/hero-composer-appearance.ts
+++ b/cometline/src/lib/hero-composer-appearance.ts
@@ -1,18 +1,23 @@
 import type { HeroComposerAppearance } from '$lib/types';
 
 export interface HeroComposerPreset {
-	id: 'blue' | 'rose';
+	id: HeroComposerPresetId;
 	label: string;
 	appearance: HeroComposerAppearance;
 }
 
+export type HeroComposerPresetId = 'blue' | 'rose';
+export type HeroComposerPresetSelection = HeroComposerPresetId | 'custom';
+
 export const HERO_COMPOSER_PRESET_ROSE: HeroComposerAppearance = {
+	presetId: 'rose',
 	glowColor: '#f43f5e',
 	ringColor: '#fb7185'
 };
 
 /** Soft Arc-style blue — default hero glow. */
 export const HERO_COMPOSER_PRESET_BLUE: HeroComposerAppearance = {
+	presetId: 'blue',
 	glowColor: '#72c0ff',
 	ringColor: '#4a9de8'
 };
@@ -39,10 +44,34 @@ export function normalizeHexColor(value: string | undefined, fallback: string): 
 	return trimmed.toLowerCase();
 }
 
+function presetAppearanceFor(id: HeroComposerPresetId): HeroComposerAppearance {
+	return id === 'rose' ? HERO_COMPOSER_PRESET_ROSE : HERO_COMPOSER_PRESET_BLUE;
+}
+
+function presetIdFromValue(value: unknown): HeroComposerPresetSelection | undefined {
+	return value === 'rose' || value === 'custom' ? value : value === 'blue' ? 'blue' : undefined;
+}
+
+function normalizeCustomPreset(
+	appearance: Partial<HeroComposerAppearance> | undefined
+): HeroComposerAppearance['customPreset'] | undefined {
+	if (!appearance?.customPreset) return undefined;
+	return {
+		glowColor: normalizeHexColor(
+			appearance.customPreset.glowColor,
+			DEFAULT_HERO_COMPOSER_APPEARANCE.glowColor
+		),
+		ringColor: normalizeHexColor(
+			appearance.customPreset.ringColor,
+			DEFAULT_HERO_COMPOSER_APPEARANCE.ringColor
+		)
+	};
+}
+
 export function normalizeHeroComposerAppearance(
 	appearance: Partial<HeroComposerAppearance> | undefined
 ): HeroComposerAppearance {
-	return {
+	const legacyColors = {
 		glowColor: normalizeHexColor(
 			appearance?.glowColor,
 			DEFAULT_HERO_COMPOSER_APPEARANCE.glowColor
@@ -52,6 +81,19 @@ export function normalizeHeroComposerAppearance(
 			DEFAULT_HERO_COMPOSER_APPEARANCE.ringColor
 		)
 	};
+	const matchedPreset = HERO_COMPOSER_PRESETS.find(
+		(preset) =>
+			legacyColors.glowColor === preset.appearance.glowColor &&
+			legacyColors.ringColor === preset.appearance.ringColor
+	)?.id;
+	const customPreset = normalizeCustomPreset(appearance) ?? (matchedPreset ? undefined : legacyColors);
+	const presetId = presetIdFromValue(appearance?.presetId) ?? matchedPreset ?? 'blue';
+	if (presetId === 'custom') {
+		const custom = customPreset ?? legacyColors;
+		return { presetId: 'custom', ...custom, customPreset: custom };
+	}
+	const preset = presetAppearanceFor(presetId);
+	return { ...preset, customPreset };
 }
 
 export function heroComposerAppearanceEquals(
@@ -65,12 +107,9 @@ export function heroComposerAppearanceEquals(
 
 export function matchHeroComposerPreset(
 	appearance: HeroComposerAppearance
-): HeroComposerPreset['id'] | 'custom' {
+): HeroComposerPresetSelection {
 	const normalized = normalizeHeroComposerAppearance(appearance);
-	for (const preset of HERO_COMPOSER_PRESETS) {
-		if (heroComposerAppearanceEquals(normalized, preset.appearance)) return preset.id;
-	}
-	return 'custom';
+	return normalized.presetId;
 }
 
 export function hexToRgba(hex: string, alpha: number): string {

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -984,8 +984,15 @@ const providerSettingsSchema = z.object({
 	defaultProviderId: z.string(),
 	appearance: z.object({
 		heroComposer: z.object({
+			presetId: z.enum(['blue', 'rose', 'custom']),
 			glowColor: z.string(),
-			ringColor: z.string()
+			ringColor: z.string(),
+			customPreset: z
+				.object({
+					glowColor: z.string(),
+					ringColor: z.string()
+				})
+				.optional()
 		}),
 		caretTrail: z.object({
 			enabled: z.boolean(),

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -26,7 +26,12 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 		defaultModelId: settings.defaultModelId ?? '',
 		defaultProviderId: settings.defaultProviderId ?? '',
 		appearance: {
-			heroComposer: { ...settings.appearance.heroComposer },
+			heroComposer: {
+				...settings.appearance.heroComposer,
+				customPreset: settings.appearance.heroComposer.customPreset
+					? { ...settings.appearance.heroComposer.customPreset }
+					: undefined
+			},
 			caretTrail: { ...settings.appearance.caretTrail }
 		},
 		shortcuts: cloneShortcuts(settings),
@@ -58,7 +63,12 @@ export function providerPayloadFromDraft(draft: ProviderSettings): ProviderSetti
 		defaultModelId: draft.defaultModelId ?? '',
 		defaultProviderId: draft.defaultProviderId ?? '',
 		appearance: {
-			heroComposer: { ...draft.appearance.heroComposer },
+			heroComposer: {
+				...draft.appearance.heroComposer,
+				customPreset: draft.appearance.heroComposer.customPreset
+					? { ...draft.appearance.heroComposer.customPreset }
+					: undefined
+			},
 			caretTrail: { ...draft.appearance.caretTrail }
 		},
 		shortcuts: cloneShortcuts(draft),

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -38,8 +38,13 @@ export interface FetchProviderModelsResult {
 }
 
 export interface HeroComposerAppearance {
+	presetId: 'blue' | 'rose' | 'custom';
 	glowColor: string;
 	ringColor: string;
+	customPreset?: {
+		glowColor: string;
+		ringColor: string;
+	};
 }
 
 export interface CaretTrailSettings {

--- a/cometmind/internal/runtime/runtime_test.go
+++ b/cometmind/internal/runtime/runtime_test.go
@@ -71,6 +71,68 @@ func TestRuntimeNewDoesNotRequireAPIKey(t *testing.T) {
 	}
 }
 
+func TestRuntimeReloadUpdatesSystemPromptFromSettings(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	soulA := filepath.Join(home, "SOUL_A.md")
+	soulB := filepath.Join(home, "SOUL_B.md")
+	if err := os.WriteFile(soulA, []byte("persona A soul\n"), 0o600); err != nil {
+		t.Fatalf("write soul A: %v", err)
+	}
+	if err := os.WriteFile(soulB, []byte("persona B soul\n"), 0o600); err != nil {
+		t.Fatalf("write soul B: %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".cometmind", "cometline-settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	writeSettings := func(promptPath string) {
+		t.Helper()
+		body := []byte(`{"providers":[{"id":"anthropic","name":"Anthropic","method":"anthropic","enabled":true,"apiKey":"test-key","selectedModel":"claude-sonnet-4-5","models":["claude-sonnet-4-5"],"enabledModels":["claude-sonnet-4-5"]}],"activeProviderId":"anthropic","cometmind":{"systemPromptPath":"` + promptPath + `"}}`)
+		if err := os.WriteFile(settingsPath, body, 0o600); err != nil {
+			t.Fatalf("write settings: %v", err)
+		}
+	}
+	writeSettings(soulA)
+
+	rt, err := New(ctx)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer rt.Close()
+	if rt.SystemPrompt != "persona A soul" {
+		t.Fatalf("SystemPrompt = %q, want persona A soul", rt.SystemPrompt)
+	}
+
+	writeSettings(soulB)
+	if err := rt.Reload(ctx); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	if rt.SystemPrompt != "persona B soul" {
+		t.Fatalf("after Reload SystemPrompt = %q, want persona B soul", rt.SystemPrompt)
+	}
+
+	ws, err := rt.WorkspaceForCommand(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("WorkspaceForCommand() error = %v", err)
+	}
+	sess, err := rt.Sessions.NewSession(ctx, ws.ID, rt.Config.Model, rt.Config.Provider)
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	runner, err := rt.RunnerFor(sess, ws.Path)
+	if err != nil {
+		t.Fatalf("RunnerFor() error = %v", err)
+	}
+	if runner.SystemPrompt != "persona B soul" {
+		t.Fatalf("runner.SystemPrompt = %q, want persona B soul", runner.SystemPrompt)
+	}
+}
+
 func TestRuntimeLoadsSystemPromptFromConfiguredPath(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()


### PR DESCRIPTION
## Background

PR #29 and the follow-up IPC wiring on `main` made persona selection work in the renderer, but several desktop behaviors still lagged behind. Switching persona updated avatars while CometMind kept the old SOUL until restart, custom persona Dock icons rendered as raw square uploads, and several appearance surfaces still used hardcoded blue tokens instead of the active hero glow preset.

[52fa330](https://github.com/Cometline/cometline/commit/52fa3305e1b76b0287812e807196474924c7ef0cf6): Persona saves now force a CometMind reload when the resolved system prompt path changes, replay the intro after custom persona edits, and polish the persona picker plus SOUL preview to use hero glow tokens. The custom caret action also defers state writes so Svelte does not mutate rune state during derived evaluation.

[96e1cfb](https://github.com/Cometline/cometline/commit/96e1cfb546f2f5d9d3e5f85edd4ed74b27435259): Settings gains a locked custom hero glow preset alongside the Blue and Rose defaults. Custom persona Dock and window icons start using rounded composited artwork instead of the raw uploaded avatar file.

[58f29b1](https://github.com/Cometline/cometline/commit/58f29b13eba56b87a79745e5e7fa988d2c376e2b): The first-run intro animation now reads `--hero-composer-glow-color` so its canvas accents and title card follow the active appearance preset.

[5be46ed](https://github.com/Cometline/cometline/commit/5be46ed3be44c48d55fec56e6f5b7e6f54872556): Electron stops injecting `COMETMIND_SYSTEM_PROMPT_PATH` into the sidecar environment at process start. That stale env value was overriding `cometline-settings.json` on SIGHUP reload, which is why persona switches did not change agent behavior until a full app restart. A CometMind runtime test covers reload picking up a new SOUL path from settings.

[3576bbc](https://github.com/Cometline/cometline/commit/3576bbc9b517dd9d98616fe0366769e1accb48d1): Custom persona icons are generated through the existing Swift icon pipeline into `~/.cometmind/personas/{id}/app_icon.png`, cached when the avatar changes, and applied to the Dock, tray, main window, and mini window on persona switch.

### Reference

[Issue #24](https://github.com/Cometline/cometline/issues/24)
[PR #29](https://github.com/Cometline/cometline/pull/29)