### PR TITLE
[main] feat(cometline): pin follow-up user messages with turn min-height

### DIFF
--- a/cometline/docs/postmortem/README.md
+++ b/cometline/docs/postmortem/README.md
@@ -26,6 +26,7 @@ Short write-ups of non-obvious bugs in the Cometline UI layer (and cross-cutting
 | 2026-06-21 | Reload: reasoning-less tool/memory rows become loose, ungrouped pills                               | [reload-loose-tool-memory-pills-no-reasoning.md](./reload-loose-tool-memory-pills-no-reasoning.md)                 |
 | 2026-06-23 | Provider label casing inconsistency ("OpenAI Compatible" vs "OpenAI-compatible")                    | [provider-label-casing-inconsistency.md](./provider-label-casing-inconsistency.md)                                 |
 | 2026-06-29 | Settings "Save changes" stuck disabled after picking embedding model (state mutation in `$derived`) | [settings-save-disabled-state-mutation-in-derived.md](./settings-save-disabled-state-mutation-in-derived.md)       |
+| 2026-07-01 | Thread turn scroll pinning (user message upper-third, turn min-height, spacer removal)              | [thread-turn-scroll-pinning.md](./thread-turn-scroll-pinning.md)                                                   |
 
 ## When to add a postmortem
 

--- a/cometline/docs/postmortem/thread-turn-scroll-pinning.md
+++ b/cometline/docs/postmortem/thread-turn-scroll-pinning.md
@@ -1,0 +1,194 @@
+# Thread turn scroll pinning (user message positioning)
+
+**Date:** 2026-07-01  
+**Components:** `ChatThread.svelte`, `thread-scroll.ts`, `thread-scroll.svelte.ts`, `thread-turns.ts`, `first-turn-flight.ts`, `UserMessageRow.svelte`
+
+## Background and goals
+
+On follow-up turns (from the second user message onward), we wanted ChatGPT / Claude-style behavior:
+
+1. After the user sends a message, the bubble stays pinned near the **upper third** of the viewport.
+2. Enough space remains below so the start of the AI reply is visible **without scrolling down first**.
+3. **No layout shift** when streaming ends.
+4. “Jump to latest” and manual scrolling should not land in an **empty dead zone** with no content.
+
+## Why the existing implementation “did not work”
+
+The codebase already had `userMessageScrollTop()` and `createThreadScroll()`, but in practice pinning almost never behaved as intended. Several issues stacked on top of each other:
+
+### 1. User bubble flight fought the pin scroll
+
+On every follow-up message, `ChatView` runs `UserBubbleFlight` → `flyUserBubble()`, which calls `scrollThreadToBottom()` and scrolls the thread **to the bottom**.
+
+At the same time, `thread-scroll.svelte.ts` reacts to `lastUserId` changes and calls `scrollUserMessageToTop()` to **pin the user message upward**.
+
+Both schedule work via `tick().then(...)` — **whichever runs last wins**. In most cases, “scroll to bottom” overwrote the pin, so the message looked like it simply followed the previous assistant reply.
+
+**Fix (Phase 1):** Skip `scrollThreadToBottom()` when `origin === 'above-composer'` (follow-up turns).
+
+### 2. The bottom spacer almost never activated
+
+`ChatThread` used to append `<div class="thread-bottom-spacer">` when `last item === 'user'`.
+
+But `chatStore.send()` **immediately** pushes an empty assistant placeholder after the user item. By the time the DOM renders, the last item is already `assistant`, so spacer height was 0.
+
+Without extra scroll range, the pin target `scrollTop` often exceeded `scrollHeight - clientHeight`, the browser clamped it, and pinning **failed silently**.
+
+### 3. Pin offset was too small and inconsistent
+
+Follow-ups used 15% of viewport height; an older version used a fixed 128px. The first turn used 24px. In practice, messages still felt glued to the previous turn’s content.
+
+### 4. Spacer removal on stream end → layout shift
+
+We later kept the spacer through `sessionStreaming`, but when streaming stopped the spacer still disappeared. `scrollTop` stayed the same while content height shrank → **visible jump**.
+
+### 5. Spacer caused “Jump to latest” and manual scroll to enter a dead zone
+
+The spacer was real DOM height but not a message. Users could scroll into empty space; “Jump to latest” targeted `scrollHeight` and showed a blank area.
+
+We patched this with `maxContentScrollTop` + clamp, but that conflicted with the scroll range pinning needed — **band-aids on the wrong model**.
+
+## Final solution (Phase 2): Turn wrapper + min-height
+
+Aligned with common industry practice (most ChatGPT-style UIs): **no trailing spacer div** — use a **turn container** to own the empty space.
+
+### Architecture
+
+```
+thread-messages
+└── .thread-turn                    ← one turn per user message
+    ├── UserMessageRow
+    ├── FirstTurnAssistantSlot (first turn only)
+    └── assistant / tool / memory / …
+└── .thread-turn.thread-turn-active ← latest follow-up turn only
+    └── min-height: viewport - clearance
+```
+
+### Behavior
+
+| When | What happens |
+|------|----------------|
+| User sends follow-up (turn ≥ 2) | `activeTurnCanvas = true`; that turn gets `min-height` |
+| Pin positioning | `scrollIntoView({ block: 'start' })` + `.user-row { scroll-margin-top }` |
+| During / after AI stream | `min-height` persists until the **next user message** (not until `sessionStreaming` ends) |
+| Session switch / load history | `activeTurnCanvas = false`; old chats get no phantom blank area |
+| Jump to latest | Normal `scrollTo(scrollHeight)`; bottom is the natural end of turn content, not a dead zone |
+
+### New / main files
+
+| File | Role |
+|------|------|
+| [`thread-turns.ts`](../src/lib/conversation/thread-turns.ts) | `groupThreadItemsIntoTurns()`, `activeTurnMinHeight()` |
+| [`thread-turns.test.ts`](../src/lib/conversation/thread-turns.test.ts) | Turn grouping and min-height unit tests |
+| [`thread-scroll.ts`](../src/lib/conversation/thread-scroll.ts) | Slimmed down: near-bottom, scroll key, `followUpPinScrollMargin()` |
+| [`thread-scroll.svelte.ts`](../src/lib/conversation/thread-scroll.svelte.ts) | `scrollIntoView` pin, `activeTurnCanvas`, `activeTurnMinHeight` |
+| [`ChatThread.svelte`](../src/lib/components/chat/ChatThread.svelte) | `{#each threadTurns}`, `.thread-turn-active`, spacer removed |
+| [`first-turn-flight.ts`](../src/lib/first-turn-flight.ts) | Follow-up no longer calls `scrollThreadToBottom` |
+| [`app.css`](../src/app.css) | `--thread-user-pin-*`, `--thread-turn-bottom-clearance` tokens |
+
+### Removed concepts
+
+- `thread-bottom-spacer` DOM node
+- `reserveActiveTurnSpace` / `activeTurnBottomSpacerHeight`
+- `userMessageScrollTop` / `offsetTopRelativeTo` pin math
+- `maxContentScrollTop` / `clampScrollAboveBottomInset` (spacer inset only)
+
+## Design tokens (tunable)
+
+```css
+--thread-user-pin-offset-first: 24px;        /* first turn (flight-driven; pin rarely used) */
+--thread-user-pin-ratio-followup: 0.28;      /* follow-up upper third */
+--thread-turn-bottom-clearance: 96px;        /* min-height = viewport - clearance */
+```
+
+At runtime, `.thread` sets `--thread-user-pin-offset-followup` (px) for the active turn’s `scroll-margin-top`.
+
+## Takeaways
+
+### 1. Empty space should belong to the turn, not a ghost div at the list tail
+
+Most ChatGPT / Claude-style implementations reserve reply space with **`min-height` on the turn / last message**, not an unrelated spacer after `{#each}`.
+
+That means:
+
+- The semantic “bottom” of `scrollHeight` is still the end of the conversation structure
+- Jump to latest and near-bottom checks need no special cases
+- Users are less likely to scroll into a region with nothing on screen
+
+**Old model (trailing spacer):**
+
+```
+{#each items}  messages…  {/each}
+<div class="spacer" />   ← ghost: height without content
+```
+
+**New model (turn min-height):**
+
+```
+{#each turns}
+  <div class="thread-turn" style="min-height: …">
+    user + assistant rows
+    (empty area = min-height minus content — inside the turn)
+  </div>
+{/each}
+```
+
+### 2. Prefer platform-native pinning
+
+`scrollIntoView({ block: 'start' })` + `scroll-margin-top` is more stable than hand-computed `offsetTop` and custom `scrollTop`, and it conflicts less with layout changes (assistant placeholder, growing stream).
+
+### 3. Only one scroll owner per moment
+
+On follow-up, two systems competed:
+
+- flight’s `scrollThreadToBottom`
+- scroll controller’s pin
+
+Clarify **who scrolls when**. First turn: `FirstTurnFlight`. Follow-up pin: `createThreadScroll`; flight must not scroll to the bottom.
+
+### 4. State lifetime must match UX
+
+| State | Should last until |
+|-------|-------------------|
+| Active turn `min-height` | Next user message (not stream end) |
+| `activeTurnCanvas` | Same; cleared on session switch / hydration |
+| Pin scroll | Follow-up only (`userMessageCount > 1`), not initial transcript paint |
+
+### 5. Spacer on a flat list is a stepping stone, not the destination
+
+Phase 1 (spacer + inset + clamp) validated the requirement but kept causing:
+
+- layout shift (spacer appear / disappear)
+- jump / clamp / pin three-way conflicts
+- manual scroll into dead zones
+
+For a durable ChatGPT-level experience, **turn grouping** is effectively required.
+
+### 6. `ChatThread` stays a thin orchestrator; logic lives in pure modules
+
+Per [`FRONTEND_PATTERNS.md`](../FRONTEND_PATTERNS.md):
+
+- `thread-turns.ts` — testable turn grouping
+- `thread-scroll.svelte.ts` — scroll controller
+- `ChatThread.svelte` — thin `{#each}` + styles
+
+## Verification checklist
+
+1. **Turn 2+:** After send, user bubble near upper third; thinking / first tokens visible without scrolling down.
+2. **Stream end:** No jump; `min-height` remains until the next user message.
+3. **Jump to latest:** Shows the last AI content, not blank space.
+4. **Manual scroll:** Should not rest in a message-free dead zone (blank area is inside the turn, semantically “reply canvas”).
+5. **Session switch / open old chat:** No extra bottom gap; hydration still scrolls to bottom.
+6. **First turn:** Hero → dock flight unchanged.
+
+## Related docs
+
+- [`FRONTEND_PATTERNS.md`](../FRONTEND_PATTERNS.md) — Chat thread controller pattern
+- [`composer-phase-and-positioning.md`](./composer-phase-and-positioning.md) — First-turn composer / thread-shell positioning
+- [`streaming-avatar-disappears-spinner-jumps.md`](./streaming-avatar-disappears-spinner-jumps.md) — Assistant placeholder timing during stream
+
+## Future improvements
+
+- Unify turn 1 with turn `min-height` + pin; reduce reliance on `scrollThreadToBottom`.
+- Optional soft-follow during stream when user is near bottom (ChatGPT also only auto-scrolls when already pinned to bottom).
+- Tie `--thread-turn-bottom-clearance` to `--thread-dock-inset` responsively for mini / compact layouts.

--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -56,6 +56,11 @@
 	/* Clip thread at composer vertical center so scroll area extends further down. */
 	--thread-dock-inset: calc(var(--composer-dock-bottom) + 10rem);
 	--thread-padding-bottom: var(--thread-scroll-gap);
+	--thread-user-pin-offset-first: 24px;
+	--thread-user-pin-ratio-followup: 0.28;
+	--thread-turn-bottom-clearance: 96px;
+	/* Set on .thread at runtime from viewport height; used by active turn scroll-margin. */
+	--thread-user-pin-offset-followup: 0px;
 
 	/* Motion */
 	--ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);

--- a/cometline/src/lib/components/chat/ChatThread.svelte
+++ b/cometline/src/lib/components/chat/ChatThread.svelte
@@ -32,6 +32,7 @@
 	import { createFoldController } from '$lib/conversation/thread-fold.svelte';
 	import { createThreadScroll } from '$lib/conversation/thread-scroll.svelte';
 	import { createThreadClocks } from '$lib/conversation/thread-clocks.svelte';
+	import { groupThreadItemsIntoTurns } from '$lib/conversation/thread-turns';
 	import { hasReasoning } from '$lib/conversation/reasoning';
 	import type { ChatTurnPayload } from '$lib/actions/start-chat';
 	import type { JobResource } from '$lib/client/cometmind';
@@ -76,6 +77,7 @@
 
 	let scrollerEl = $state<HTMLDivElement | undefined>(undefined);
 	let threadItems = $derived(isSessionSynced ? chatStore.items : snapshotItems);
+	let threadTurns = $derived(groupThreadItemsIntoTurns(threadItems));
 	let embeddedPinnedJobIds = $derived(pinnedJobProposalToolIds(threadItems));
 	let firstAssistantItem = $derived(
 		threadItems.find(
@@ -194,11 +196,6 @@
 		onStartJob
 	});
 
-	let bottomSpacerHeight = $derived(
-		userMessageCount > 1 && scroll.viewportHeight > 0 && threadItems.at(-1)?.type === 'user'
-			? Math.max(0, scroll.viewportHeight - 240)
-			: 0
-	);
 	let showMessages = $derived(
 		threadItems.length > 0 || (isSessionSynced && awaitingFirstAssistant && !firstUserId)
 	);
@@ -241,6 +238,7 @@
 		class="thread scrollbar-none"
 		bind:this={scrollerEl}
 		onscroll={scroll.onScroll}
+		style:--thread-user-pin-offset-followup="{scroll.userPinScrollMargin}px"
 		role="log"
 		aria-label="Conversation"
 		aria-live="polite"
@@ -267,17 +265,29 @@
 						/>
 					{/if}
 
-					{#each threadItems as item, index (item.id)}
-						{#if item.type === 'user'}
+					{#each threadTurns as turn (turn.id)}
+						{@const isActiveTurn =
+							scroll.activeTurnMinHeight > 0 && turn.id === lastUserId}
+						<div
+							class="thread-turn"
+							class:thread-turn-active={isActiveTurn}
+							style:min-height={isActiveTurn
+								? `${scroll.activeTurnMinHeight}px`
+								: undefined}
+						>
 							<UserMessageRow
-								{item}
+								item={turn.user}
 								{avatarSrc}
 								{avatarSrcset}
-								continuationRow={!startsSpeakerRun(threadItems, index, 'user')}
+								continuationRow={!startsSpeakerRun(
+									threadItems,
+									turn.userIndex,
+									'user'
+								)}
 								copiedId={clocks.copiedId}
 								onCopyMessage={clocks.copyMessage}
 							/>
-							{#if showFirstTurnAvatarSlot(visibilityContext) && item.id === firstUserId}
+							{#if showFirstTurnAvatarSlot(visibilityContext) && turn.user.id === firstUserId}
 								<FirstTurnAssistantSlot
 									{avatarSrc}
 									{avatarSrcset}
@@ -291,58 +301,54 @@
 									ariaHidden={!firstAssistantId}
 								/>
 							{/if}
-						{:else if item.type === 'assistant' && showAssistantRow(item) && shouldShowAssistantInNormalList(item, visibilityContext)}
-							<AssistantMessageRow
-								{item}
-								{threadItems}
-								{index}
-								{avatarSrc}
-								{avatarSrcset}
-								{stackContext}
-								{showActivitySpinner}
-								hideAvatarForFirstTurn={hideAssistantAvatarForFirstTurn(
-									item,
-									firstTurnHandoffPending,
-									firstAssistantRowId
-								)}
-							/>
-						{:else if item.type === 'tool' && !isToolInBuffer(item) && !embeddedPinnedJobIds.has(item.id)}
-							<ToolMessageRow
-								{item}
-								{threadItems}
-								{index}
-								{avatarSrc}
-								{avatarSrcset}
-								{sessionId}
-								toolFoldLabel={stackContext.toolFoldLabel}
-								{fold}
-								{onNotifyAgent}
-								{onStartJob}
-							/>
-						{:else if item.type === 'subagent' && !isSubagentInBuffer(item)}
-							<SubagentMessageRow
-							{item}
-							{threadItems}
-							{index}
-							{avatarSrc}
-							{avatarSrcset}
-							{fold}
-						/>
-						{:else if item.type === 'memory' && !isMemoryInBuffer(item)}
-							<MemoryEventRow {item} memoryCycleTick={clocks.memoryCycleTick} />
-						{:else if item.type === 'status'}
-							<div class="status">{usageText(item)}</div>
-						{:else if item.type === 'error'}
-							<ErrorEventRow {item} />
-						{/if}
+							{#each turn.items as { item, index } (item.id)}
+								{#if item.type === 'assistant' && showAssistantRow(item) && shouldShowAssistantInNormalList(item, visibilityContext)}
+									<AssistantMessageRow
+										{item}
+										{threadItems}
+										{index}
+										{avatarSrc}
+										{avatarSrcset}
+										{stackContext}
+										{showActivitySpinner}
+										hideAvatarForFirstTurn={hideAssistantAvatarForFirstTurn(
+											item,
+											firstTurnHandoffPending,
+											firstAssistantRowId
+										)}
+									/>
+								{:else if item.type === 'tool' && !isToolInBuffer(item) && !embeddedPinnedJobIds.has(item.id)}
+									<ToolMessageRow
+										{item}
+										{threadItems}
+										{index}
+										{avatarSrc}
+										{avatarSrcset}
+										{sessionId}
+										toolFoldLabel={stackContext.toolFoldLabel}
+										{fold}
+										{onNotifyAgent}
+										{onStartJob}
+									/>
+								{:else if item.type === 'subagent' && !isSubagentInBuffer(item)}
+									<SubagentMessageRow
+										{item}
+										{threadItems}
+										{index}
+										{avatarSrc}
+										{avatarSrcset}
+										{fold}
+									/>
+								{:else if item.type === 'memory' && !isMemoryInBuffer(item)}
+									<MemoryEventRow {item} memoryCycleTick={clocks.memoryCycleTick} />
+								{:else if item.type === 'status'}
+									<div class="status">{usageText(item)}</div>
+								{:else if item.type === 'error'}
+									<ErrorEventRow {item} />
+								{/if}
+							{/each}
+						</div>
 					{/each}
-					{#if bottomSpacerHeight > 0}
-						<div
-							class="thread-bottom-spacer"
-							style:height="{bottomSpacerHeight}px"
-							aria-hidden="true"
-						></div>
-					{/if}
 				</div>
 			{/if}
 		</div>
@@ -391,9 +397,14 @@
 		pointer-events: none;
 	}
 
-	.thread-bottom-spacer {
-		flex: 0 0 auto;
-		pointer-events: none;
+	.thread-turn {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+	}
+
+	.thread-turn-active :global(.user-row) {
+		scroll-margin-top: var(--thread-user-pin-offset-followup);
 	}
 
 	@media (min-width: 768px) {

--- a/cometline/src/lib/conversation/thread-scroll.svelte.ts
+++ b/cometline/src/lib/conversation/thread-scroll.svelte.ts
@@ -1,10 +1,10 @@
 import { tick, untrack } from 'svelte';
 import type { ChatItem } from '$lib/stores/chat.svelte';
+import { activeTurnMinHeight } from './thread-turns';
 import {
 	buildScrollKey,
-	offsetTopRelativeTo,
-	shouldShowJumpToBottom,
-	userMessageScrollTop
+	followUpPinScrollMargin,
+	shouldShowJumpToBottom
 } from './thread-scroll';
 
 export interface ThreadScrollDeps {
@@ -25,8 +25,14 @@ export function createThreadScroll(deps: ThreadScrollDeps) {
 	let viewportHeight = $state(0);
 	let scrollFrame = 0;
 	let isInitialTranscriptPaint = $state(true);
+	/** Keeps min-height on the latest turn from send until the next user message. */
+	let activeTurnCanvas = $state(false);
 
 	const scrollKey = $derived(buildScrollKey(deps.getThreadItems(), deps.getSessionStreaming()));
+	const turnMinHeight = $derived.by(() =>
+		activeTurnCanvas ? activeTurnMinHeight(viewportHeight) : 0
+	);
+	const userPinScrollMargin = $derived(followUpPinScrollMargin(viewportHeight));
 
 	function setScroller(element: HTMLDivElement | undefined) {
 		scroller = element;
@@ -50,14 +56,21 @@ export function createThreadScroll(deps: ThreadScrollDeps) {
 		showJumpToBottom = false;
 	}
 
-	function scrollUserMessageToTop(userId: string) {
+	function scrollUserMessageIntoView(userId: string) {
 		if (!scroller) return;
 		const target = scroller.querySelector<HTMLElement>(`[data-user-item-id="${userId}"]`);
-		if (!target) return;
-		const absoluteTop = offsetTopRelativeTo(target, scroller);
-		const top = userMessageScrollTop(absoluteTop, deps.getUserMessageCount(), viewportHeight);
-		scroller.scrollTo({ top, behavior: 'smooth' });
+		target?.scrollIntoView({ block: 'start', behavior: 'auto' });
 		updateJumpToBottom();
+	}
+
+	function pinUserMessageAfterLayout(userId: string) {
+		let frame = 0;
+		const settle = () => {
+			scrollUserMessageIntoView(userId);
+			frame += 1;
+			if (frame < 3) requestAnimationFrame(settle);
+		};
+		requestAnimationFrame(settle);
 	}
 
 	$effect(() => {
@@ -65,6 +78,7 @@ export function createThreadScroll(deps: ThreadScrollDeps) {
 		untrack(() => {
 			lastScrolledUserId = deps.getLastUserId();
 			isInitialTranscriptPaint = !deps.sessionHasCachedTranscript(deps.getSessionId());
+			activeTurnCanvas = false;
 		});
 	});
 
@@ -168,19 +182,23 @@ export function createThreadScroll(deps: ThreadScrollDeps) {
 			return;
 		}
 		if (userId === lastScrolledUserId) return;
-		if (isInitialTranscriptPaint) {
-			lastScrolledUserId = userId;
-			return;
-		}
 		lastScrolledUserId = userId;
+		if (isInitialTranscriptPaint || deps.getUserMessageCount() <= 1) return;
+		activeTurnCanvas = true;
 		void tick().then(() => {
-			requestAnimationFrame(() => scrollUserMessageToTop(userId));
+			pinUserMessageAfterLayout(userId);
 		});
 	});
 
 	return {
 		get showJumpToBottom() {
 			return showJumpToBottom;
+		},
+		get activeTurnMinHeight() {
+			return turnMinHeight;
+		},
+		get userPinScrollMargin() {
+			return userPinScrollMargin;
 		},
 		get viewportHeight() {
 			return viewportHeight;

--- a/cometline/src/lib/conversation/thread-scroll.test.ts
+++ b/cometline/src/lib/conversation/thread-scroll.test.ts
@@ -2,9 +2,9 @@
 import { describe, expect, it } from 'vitest';
 import {
 	buildScrollKey,
+	followUpPinScrollMargin,
 	isNearBottom,
-	offsetTopRelativeTo,
-	userMessageScrollTop
+	shouldShowJumpToBottom
 } from './thread-scroll';
 import type { ChatItem } from '$lib/stores/chat.svelte';
 
@@ -37,27 +37,32 @@ describe('isNearBottom', () => {
 	});
 });
 
-describe('userMessageScrollTop', () => {
-	it('uses first-turn offset for the first user message', () => {
-		expect(userMessageScrollTop(200, 1, 800)).toBe(176);
+describe('shouldShowJumpToBottom', () => {
+	it('returns false when already near the bottom', () => {
+		const el = {
+			scrollHeight: 1000,
+			scrollTop: 904,
+			clientHeight: 96
+		} as HTMLElement;
+		expect(shouldShowJumpToBottom(el, 96)).toBe(false);
 	});
 
-	it('uses follow-up offset for later user messages', () => {
-		expect(userMessageScrollTop(400, 2, 800)).toBe(280);
+	it('returns true when content overflows and the viewport is far from bottom', () => {
+		const el = {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 96
+		} as HTMLElement;
+		expect(shouldShowJumpToBottom(el, 96)).toBe(true);
 	});
 });
 
-describe('offsetTopRelativeTo', () => {
-	it('sums offsetTop along the offsetParent chain', () => {
-		const ancestor = document.createElement('div');
-		const parent = document.createElement('div');
-		const child = document.createElement('div');
-		ancestor.appendChild(parent);
-		parent.appendChild(child);
-		Object.defineProperty(parent, 'offsetParent', { value: ancestor });
-		Object.defineProperty(child, 'offsetParent', { value: parent });
-		Object.defineProperty(parent, 'offsetTop', { value: 40 });
-		Object.defineProperty(child, 'offsetTop', { value: 12 });
-		expect(offsetTopRelativeTo(child, ancestor)).toBe(52);
+describe('followUpPinScrollMargin', () => {
+	it('uses the upper-third ratio when viewport height is known', () => {
+		expect(followUpPinScrollMargin(800)).toBe(224);
+	});
+
+	it('falls back when viewport height is zero', () => {
+		expect(followUpPinScrollMargin(0)).toBe(100);
 	});
 });

--- a/cometline/src/lib/conversation/thread-scroll.ts
+++ b/cometline/src/lib/conversation/thread-scroll.ts
@@ -3,6 +3,10 @@ import { anyReasoningPending, reasoningTextLength } from './reasoning';
 
 export const SCROLL_PIN_THRESHOLD = 96;
 export const USER_SEND_TOP_OFFSET = 24;
+/** Upper-third pin for follow-up turns (turn 2+), applied via scroll-margin-top. */
+export const USER_PIN_RATIO_FOLLOWUP = 0.28;
+export const USER_PIN_OFFSET_FALLBACK = 100;
+export const TURN_BOTTOM_CLEARANCE = 96;
 
 export function isNearBottom(element: HTMLElement, threshold = SCROLL_PIN_THRESHOLD) {
 	return element.scrollHeight - element.scrollTop - element.clientHeight <= threshold;
@@ -11,17 +15,6 @@ export function isNearBottom(element: HTMLElement, threshold = SCROLL_PIN_THRESH
 export function shouldShowJumpToBottom(element: HTMLElement, threshold = SCROLL_PIN_THRESHOLD) {
 	const overflowing = element.scrollHeight - element.clientHeight > threshold;
 	return overflowing && !isNearBottom(element, threshold);
-}
-
-/** Walk the offsetParent chain to get an element's top offset relative to an ancestor. */
-export function offsetTopRelativeTo(el: HTMLElement, ancestor: HTMLElement): number {
-	let top = 0;
-	let cur: HTMLElement | null = el;
-	while (cur && cur !== ancestor) {
-		top += cur.offsetTop;
-		cur = cur.offsetParent as HTMLElement | null;
-	}
-	return top;
 }
 
 export function buildScrollKey(items: readonly ChatItem[], sessionStreaming: boolean) {
@@ -41,15 +34,12 @@ export function buildScrollKey(items: readonly ChatItem[], sessionStreaming: boo
 	return `stream:empty:${items.length}`;
 }
 
-export function userMessageScrollTop(
-	absoluteTop: number,
-	userMessageCount: number,
-	viewportHeight: number,
-	firstTurnOffset = USER_SEND_TOP_OFFSET
-) {
-	if (userMessageCount > 1) {
-		const followupOffset = viewportHeight > 0 ? Math.round(viewportHeight * 0.15) : 80;
-		return Math.max(0, absoluteTop - followupOffset);
-	}
-	return Math.max(0, absoluteTop - firstTurnOffset);
+export function followUpPinScrollMargin(viewportHeight: number) {
+	return viewportHeight > 0
+		? Math.round(viewportHeight * USER_PIN_RATIO_FOLLOWUP)
+		: USER_PIN_OFFSET_FALLBACK;
+}
+
+export function countUserMessages(items: readonly ChatItem[]) {
+	return items.reduce((count, item) => (item.type === 'user' ? count + 1 : count), 0);
 }

--- a/cometline/src/lib/conversation/thread-turns.test.ts
+++ b/cometline/src/lib/conversation/thread-turns.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { activeTurnMinHeight, groupThreadItemsIntoTurns } from './thread-turns';
+import type { ChatItem } from '$lib/stores/chat.svelte';
+
+describe('groupThreadItemsIntoTurns', () => {
+	it('groups follow-up items under the preceding user message', () => {
+		const items: ChatItem[] = [
+			{ id: 'u1', type: 'user', text: 'first' },
+			{ id: 'a1', type: 'assistant', text: 'reply' },
+			{ id: 't1', type: 'tool', toolName: 'read', input: {}, output: 'ok' },
+			{ id: 'u2', type: 'user', text: 'second' },
+			{ id: 'a2', type: 'assistant', text: 'again' }
+		];
+
+		const turns = groupThreadItemsIntoTurns(items);
+
+		expect(turns).toHaveLength(2);
+		expect(turns[0].id).toBe('u1');
+		expect(turns[0].items.map((entry) => entry.item.id)).toEqual(['a1', 't1']);
+		expect(turns[1].id).toBe('u2');
+		expect(turns[1].items.map((entry) => entry.item.id)).toEqual(['a2']);
+	});
+
+	it('returns an empty list for an empty transcript', () => {
+		expect(groupThreadItemsIntoTurns([])).toEqual([]);
+	});
+});
+
+describe('activeTurnMinHeight', () => {
+	it('subtracts clearance from the viewport height', () => {
+		expect(activeTurnMinHeight(600)).toBe(504);
+	});
+
+	it('returns zero when the viewport is unknown', () => {
+		expect(activeTurnMinHeight(0)).toBe(0);
+	});
+});

--- a/cometline/src/lib/conversation/thread-turns.ts
+++ b/cometline/src/lib/conversation/thread-turns.ts
@@ -1,0 +1,38 @@
+import type { ChatItem } from '$lib/stores/chat.svelte';
+import { TURN_BOTTOM_CLEARANCE } from './thread-scroll';
+
+export interface ThreadTurnItem {
+	item: ChatItem;
+	index: number;
+}
+
+export interface ThreadTurn {
+	id: string;
+	user: Extract<ChatItem, { type: 'user' }>;
+	userIndex: number;
+	items: ThreadTurnItem[];
+}
+
+/** Group a flat transcript into user-anchored turns. */
+export function groupThreadItemsIntoTurns(items: readonly ChatItem[]): ThreadTurn[] {
+	const turns: ThreadTurn[] = [];
+	let current: ThreadTurn | null = null;
+
+	for (let index = 0; index < items.length; index++) {
+		const item = items[index];
+		if (item.type === 'user') {
+			current = { id: item.id, user: item, userIndex: index, items: [] };
+			turns.push(current);
+			continue;
+		}
+		current?.items.push({ item, index });
+	}
+
+	return turns;
+}
+
+/** Min-height for the active turn canvas (follow-up turns only). */
+export function activeTurnMinHeight(viewportHeight: number, clearance = TURN_BOTTOM_CLEARANCE) {
+	if (viewportHeight <= 0) return 0;
+	return Math.max(0, viewportHeight - clearance);
+}

--- a/cometline/src/lib/first-turn-flight.ts
+++ b/cometline/src/lib/first-turn-flight.ts
@@ -205,12 +205,13 @@ export async function flyUserBubble(params: FlyUserBubbleParams): Promise<boolea
 		if (skipReveal || deferReveal) return;
 		revealStagedUser();
 	};
+	const isFollowUpTurn = origin === 'above-composer';
 
 	if (prefersReducedMotion()) {
 		if (!skipOnPrepare) onPrepare?.();
 		if (!skipStage) stageUser(text, images);
 		await tick();
-		scrollThreadToBottom(root);
+		if (!isFollowUpTurn) scrollThreadToBottom(root);
 		reveal();
 		return true;
 	}
@@ -218,7 +219,7 @@ export async function flyUserBubble(params: FlyUserBubbleParams): Promise<boolea
 	if (!skipOnPrepare) onPrepare?.();
 	if (!skipStage) stageUser(text, images);
 	await tick();
-	scrollThreadToBottom(root);
+	if (!isFollowUpTurn) scrollThreadToBottom(root);
 	await afterPaint();
 
 	const userTarget = await waitForSelector(root, '[data-flight-target="user"]');


### PR DESCRIPTION
## Background

Follow-up messages in the chat thread did not stay at a fixed viewport position. The old trailing spacer and manual scrollTop math fought the user bubble flight animation, collapsed when streaming ended, and let Jump to latest scroll into empty space. This change groups the transcript into turns, pins follow-up user bubbles with scrollIntoView, and reserves reply space with min-height on the active turn instead of a ghost spacer div.

[e19375a](https://github.com/Cometline/cometline/commit/e19375a73c03e0621da7ef8fdc492b9c1657f4fe): Adds turn grouping in `thread-turns.ts`, refactors `ChatThread.svelte` to render `{#each threadTurns}` with `.thread-turn-active` min-height, replaces spacer and offset math with `scrollIntoView` plus `scroll-margin-top`, skips `scrollThreadToBottom` on follow-up flight, and documents the investigation and takeaways in a postmortem.

### Reference

[Thread turn scroll pinning postmortem](https://github.com/Cometline/cometline/blob/fix/message-position/cometline/docs/postmortem/thread-turn-scroll-pinning.md)