### PR TITLE
[main] feat: open settings in native window

### DIFF
--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -56,8 +56,10 @@ const MINI_WINDOW_MIN_WIDTH = 360;
 const MINI_WINDOW_MIN_HEIGHT = 440;
 const SETTINGS_WINDOW_WIDTH = 1040;
 const SETTINGS_WINDOW_HEIGHT = 760;
-const SETTINGS_WINDOW_MIN_WIDTH = 780;
-const SETTINGS_WINDOW_MIN_HEIGHT = 560;
+const SETTINGS_WINDOW_MIN_WIDTH = 900;
+const SETTINGS_WINDOW_MIN_HEIGHT = 640;
+const SETTINGS_WINDOW_MAX_WIDTH = 1280;
+const SETTINGS_WINDOW_MAX_HEIGHT = 920;
 const MINI_WINDOW_SCREEN_MARGIN = 18;
 const HEALTH_URL = `http://127.0.0.1:${COMETMIND_PORT}/api/v1/health`;
 const MAX_RETRIES = 50;
@@ -2183,6 +2185,8 @@ async function createSettingsWindow() {
 		height: SETTINGS_WINDOW_HEIGHT,
 		minWidth: SETTINGS_WINDOW_MIN_WIDTH,
 		minHeight: SETTINGS_WINDOW_MIN_HEIGHT,
+		maxWidth: SETTINGS_WINDOW_MAX_WIDTH,
+		maxHeight: SETTINGS_WINDOW_MAX_HEIGHT,
 		title: 'Settings',
 		titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
 		...(appIcon ? { icon: appIcon } : {}),

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -921,15 +921,24 @@ function handleDarwinCloseWindowShortcut(event, input, onCloseWindow) {
 	return true;
 }
 
-function attachWindowShortcuts(webContents, { onCloseWindow, includeSessionNavigation = false }) {
+function attachWindowShortcuts(
+	webContents,
+	{ onCloseWindow, includeSessionNavigation = false, includeSettingsShortcut = false }
+) {
 	webContents.on('before-input-event', (event, input) => {
 		if (handleDarwinCloseWindowShortcut(event, input, onCloseWindow)) {
 			return;
 		}
 
+		const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
+		if (includeSettingsShortcut && matchesInputShortcut(input, shortcuts.openSettings)) {
+			event.preventDefault();
+			void showSettingsWindow();
+			return;
+		}
+
 		if (!includeSessionNavigation) return;
 		if (shortcutCaptureActive || sessionNavigationSuspended) return;
-		const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
 		if (matchesInputShortcut(input, shortcuts.previousSession)) {
 			event.preventDefault();
 			webContents.send('cometline:navigate-session', 'prev');
@@ -951,7 +960,8 @@ function attachMainWindowShortcuts(webContents) {
 
 function attachMiniWindowShortcuts(webContents) {
 	attachWindowShortcuts(webContents, {
-		onCloseWindow: hideMiniWindow
+		onCloseWindow: hideMiniWindow,
+		includeSettingsShortcut: true
 	});
 }
 

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -54,6 +54,10 @@ const MINI_WINDOW_WIDTH = 460;
 const MINI_WINDOW_HEIGHT = 640;
 const MINI_WINDOW_MIN_WIDTH = 360;
 const MINI_WINDOW_MIN_HEIGHT = 440;
+const SETTINGS_WINDOW_WIDTH = 1040;
+const SETTINGS_WINDOW_HEIGHT = 760;
+const SETTINGS_WINDOW_MIN_WIDTH = 780;
+const SETTINGS_WINDOW_MIN_HEIGHT = 560;
 const MINI_WINDOW_SCREEN_MARGIN = 18;
 const HEALTH_URL = `http://127.0.0.1:${COMETMIND_PORT}/api/v1/health`;
 const MAX_RETRIES = 50;
@@ -141,6 +145,7 @@ protocol.registerSchemesAsPrivileged([
 
 let mainWindow = null;
 let miniWindow = null;
+let settingsWindow = null;
 let tray = null;
 let cometMindProcess = null;
 let cometMindGatewayProcess = null;
@@ -545,6 +550,14 @@ function sendShortcutAction(action) {
 	}
 }
 
+function broadcastProviderSettingsChanged(settings) {
+	for (const browserWindow of BrowserWindow.getAllWindows()) {
+		if (!browserWindow.isDestroyed()) {
+			browserWindow.webContents.send('cometline:provider-settings-changed', settings);
+		}
+	}
+}
+
 function loadAppRoute(window, route = '/') {
 	const cleanRoute = String(route || '/').startsWith('/') ? String(route || '/') : `/${route}`;
 	if (app.isPackaged) {
@@ -690,6 +703,10 @@ function ensureTray() {
 			label: 'Show Cometline',
 			click: () => showMainWindow()
 		},
+		{
+			label: 'Settings...',
+			click: () => void showSettingsWindow()
+		},
 		{ type: 'separator' },
 		{
 			label: 'Quit Cometline',
@@ -697,7 +714,7 @@ function ensureTray() {
 		}
 	]);
 	tray.setContextMenu(menu);
-	tray.on('click', () => showMainWindow());
+	tray.on('click', () => tray?.popUpContextMenu());
 
 	// macOS may hide new status items when the menu bar is crowded; re-assert once.
 	setTimeout(() => {
@@ -718,6 +735,73 @@ function destroyTray() {
 	if (!tray) return;
 	tray.destroy();
 	tray = null;
+}
+
+function configureApplicationMenu() {
+	const shortcuts = readProviderSettings().shortcuts ?? defaultSettings().shortcuts;
+	const settingsAccelerator = shortcutBindingToAccelerator(shortcuts.openSettings);
+	const settingsItem = {
+		label: 'Settings...',
+		...(settingsAccelerator ? { accelerator: settingsAccelerator } : {}),
+		click: () => void showSettingsWindow()
+	};
+	const template = [
+		...(process.platform === 'darwin'
+			? [
+					{
+						label: app.name,
+						submenu: [
+							settingsItem,
+							{ type: 'separator' },
+							{ role: 'services' },
+							{ type: 'separator' },
+							{ role: 'hide' },
+							{ role: 'hideOthers' },
+							{ role: 'unhide' },
+							{ type: 'separator' },
+							{ role: 'quit' }
+						]
+					}
+				]
+			: []),
+		{
+			label: 'File',
+			submenu: [
+				...(process.platform === 'darwin' ? [] : [settingsItem, { type: 'separator' }]),
+				{ role: 'close' }
+			]
+		},
+		{
+			label: 'Edit',
+			submenu: [
+				{ role: 'undo' },
+				{ role: 'redo' },
+				{ type: 'separator' },
+				{ role: 'cut' },
+				{ role: 'copy' },
+				{ role: 'paste' },
+				{ role: 'selectAll' }
+			]
+		},
+		{
+			label: 'View',
+			submenu: [
+				{ role: 'reload' },
+				{ role: 'toggleDevTools' },
+				{ type: 'separator' },
+				{ role: 'resetZoom' },
+				{ role: 'zoomIn' },
+				{ role: 'zoomOut' },
+				{ type: 'separator' },
+				{ role: 'togglefullscreen' }
+			]
+		},
+		{
+			label: 'Window',
+			submenu: [{ role: 'minimize' }, { role: 'zoom' }]
+		}
+	];
+	Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 function showMainWindow() {
@@ -779,10 +863,27 @@ async function showMiniWindow() {
 	miniWindow.focus();
 }
 
+async function showSettingsWindow() {
+	if (!windowCanShow(settingsWindow)) {
+		await createSettingsWindow();
+		return;
+	}
+	if (settingsWindow.isMinimized()) {
+		settingsWindow.restore();
+	}
+	settingsWindow.show();
+	settingsWindow.focus();
+}
+
 function hideMiniWindow() {
 	if (!windowCanShow(miniWindow)) return;
 	writeMiniWindowState({ lastActiveAt: Date.now() });
 	miniWindow.hide();
+}
+
+function hideSettingsWindow() {
+	if (!windowCanShow(settingsWindow)) return;
+	settingsWindow.hide();
 }
 
 async function toggleMiniWindow() {
@@ -851,6 +952,12 @@ function attachMainWindowShortcuts(webContents) {
 function attachMiniWindowShortcuts(webContents) {
 	attachWindowShortcuts(webContents, {
 		onCloseWindow: hideMiniWindow
+	});
+}
+
+function attachSettingsWindowShortcuts(webContents) {
+	attachWindowShortcuts(webContents, {
+		onCloseWindow: hideSettingsWindow
 	});
 }
 
@@ -2059,6 +2166,45 @@ async function createMiniWindow() {
 	return miniWindow;
 }
 
+async function createSettingsWindow() {
+	const appIcon = getAppIconImage(getPersonaId());
+	settingsWindow = new BrowserWindow({
+		width: SETTINGS_WINDOW_WIDTH,
+		height: SETTINGS_WINDOW_HEIGHT,
+		minWidth: SETTINGS_WINDOW_MIN_WIDTH,
+		minHeight: SETTINGS_WINDOW_MIN_HEIGHT,
+		title: 'Settings',
+		titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+		...(appIcon ? { icon: appIcon } : {}),
+		show: false,
+		backgroundColor: '#f5f7fb',
+		webPreferences: {
+			preload: path.join(__dirname, 'preload.cjs'),
+			contextIsolation: true,
+			nodeIntegration: false,
+			allowRunningInsecureContent: false,
+			webviewTag: false
+		}
+	});
+	attachExternalNavigationGuards(settingsWindow);
+	attachSettingsWindowShortcuts(settingsWindow.webContents);
+	await loadAppRoute(settingsWindow, '/settings');
+	settingsWindow.once('ready-to-show', () => {
+		settingsWindow?.show();
+		settingsWindow?.focus();
+	});
+	settingsWindow.on('close', (event) => {
+		if (!stoppingForQuit && !stoppedForQuit) {
+			event.preventDefault();
+			hideSettingsWindow();
+		}
+	});
+	settingsWindow.on('closed', () => {
+		settingsWindow = null;
+	});
+	return settingsWindow;
+}
+
 const FETCH_MODELS_TIMEOUT_MS = 30_000;
 
 function stripTrailingSlashes(url) {
@@ -2722,6 +2868,7 @@ app.whenReady().then(async () => {
 	installCometMindCliShim();
 	const startupSettings = readProviderSettings();
 	applyOpenAtLoginSetting(startupSettings.app?.openAtLogin);
+	configureApplicationMenu();
 	refreshGlobalShortcuts();
 	startCometMind();
 	// Create the window immediately and let the sidecar warm up in parallel.
@@ -2915,6 +3062,7 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 		runtimeAction = 'reload';
 	}
 	refreshGlobalShortcuts();
+	configureApplicationMenu();
 	if (runtimeAction === 'restart') {
 		await stopCometMind();
 		startCometMind();
@@ -2927,7 +3075,13 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 	if (personaIdChanged) {
 		applyPersona(saved.app?.personaId, saved);
 	}
+	broadcastProviderSettingsChanged(saved);
 	return saved;
+});
+
+ipcMain.handle('cometline:open-settings-window', async () => {
+	await showSettingsWindow();
+	return true;
 });
 
 ipcMain.handle('cometline:get-mini-window-state', () => readMiniWindowState());

--- a/cometline/electron/preload.cjs
+++ b/cometline/electron/preload.cjs
@@ -33,6 +33,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 	setOpenAtLogin: (enabled) => ipcRenderer.invoke('cometline:set-open-at-login', enabled),
 	openSessionInMainWindow: (sessionId) =>
 		ipcRenderer.invoke('cometline:open-session-in-main-window', sessionId),
+	openSettingsWindow: () => ipcRenderer.invoke('cometline:open-settings-window'),
 	getMiniWindowState: () => ipcRenderer.invoke('cometline:get-mini-window-state'),
 	saveMiniWindowState: (state) => ipcRenderer.invoke('cometline:save-mini-window-state', state),
 	fetchProviderModels: (config) => ipcRenderer.invoke('cometline:fetch-provider-models', config),
@@ -89,6 +90,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 		};
 		ipcRenderer.on('cometline:shortcut-action', handler);
 		return () => ipcRenderer.removeListener('cometline:shortcut-action', handler);
+	},
+	onProviderSettingsChanged: (callback) => {
+		const handler = (_event, settings) => callback(settings);
+		ipcRenderer.on('cometline:provider-settings-changed', handler);
+		return () => ipcRenderer.removeListener('cometline:provider-settings-changed', handler);
 	},
 	notifyJob: (payload) => ipcRenderer.send('jobs:notify', payload)
 });

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -337,6 +337,7 @@ declare global {
 			getOpenAtLogin?: () => Promise<OpenAtLoginState>;
 			setOpenAtLogin?: (enabled: boolean) => Promise<OpenAtLoginState>;
 			openSessionInMainWindow?: (sessionId: string) => Promise<boolean>;
+			openSettingsWindow?: () => Promise<boolean>;
 			fetchProviderModels?: (
 				config: ProviderConfig
 			) => Promise<FetchProviderModelsResult | string[]>;
@@ -378,6 +379,7 @@ declare global {
 			onShortcutAction?: (
 				callback: (action: import('$lib/keyboard-shortcuts').ShortcutAction) => void
 			) => () => void;
+			onProviderSettingsChanged?: (callback: (settings: ProviderSettings) => void) => () => void;
 			getMiniWindowState?: () => Promise<MiniWindowState>;
 			saveMiniWindowState?: (state: {
 				sessionId?: string;

--- a/cometline/src/lib/actions/open-settings.ts
+++ b/cometline/src/lib/actions/open-settings.ts
@@ -1,0 +1,13 @@
+import { shellStore } from '$lib/stores/shell.svelte';
+
+export function openSettings() {
+	const openWindow = window.electronAPI?.openSettingsWindow;
+	if (!openWindow) {
+		shellStore.openSettings();
+		return;
+	}
+
+	void openWindow().catch(() => {
+		shellStore.openSettings();
+	});
+}

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -11,6 +11,7 @@
 	import { sessionStore } from '$lib/stores/session.svelte';
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { startNewChat } from '$lib/actions/new-chat';
+	import { openSettings } from '$lib/actions/open-settings';
 	import { navigateAdjacentSession } from '$lib/actions/navigate-adjacent-session';
 	import { narrowViewportQuery, subscribeNarrowViewport } from '$lib/layout/narrow-viewport';
 	import { matchesShortcut, type ShortcutAction } from '$lib/keyboard-shortcuts';
@@ -58,7 +59,7 @@
 				shellStore.openWebPanelFromShortcut();
 				return;
 			case 'openSettings':
-				shellStore.openSettings();
+				openSettings();
 				return;
 			case 'newChat':
 				startNewChat();

--- a/cometline/src/lib/components/Sidebar.svelte
+++ b/cometline/src/lib/components/Sidebar.svelte
@@ -11,6 +11,7 @@
 	import { navigateToSession } from '$lib/actions/navigate-to-session';
 	import { chatStore } from '$lib/stores/chat.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
+	import { openSettings } from '$lib/actions/open-settings';
 	import { isNarrowViewport } from '$lib/layout/narrow-viewport';
 	import {
 		layoutSessionsForSidebar,
@@ -281,7 +282,7 @@
 		</div>
 
 		<div class="sidebar-footer p-2">
-			<button aria-label="Settings" title="Settings" onclick={shellStore.openSettings}>
+			<button aria-label="Settings" title="Settings" onclick={openSettings}>
 				<Settings size={16} stroke-width={1.8} />
 			</button>
 			<button

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -278,7 +278,7 @@
 			duration: mode === 'modal' ? 140 : 0
 		}}
 	>
-		<header>
+		<header class:window-header={mode === 'window'}>
 			<div class="title-mark"><Settings size={16} /></div>
 			<div>
 				<h2 id="settings-title">Settings</h2>
@@ -885,7 +885,7 @@
 	.settings-layer.window-mode {
 		position: relative;
 		min-height: 100vh;
-		padding: 46px 0 0;
+		padding: 0;
 		background: rgba(255, 255, 255, 0.96);
 	}
 
@@ -894,6 +894,7 @@
 		position: absolute;
 		inset: 0 0 auto;
 		height: 46px;
+		z-index: 3;
 		-webkit-app-region: drag;
 	}
 
@@ -922,19 +923,24 @@
 
 	.modal.window-mode {
 		width: 100%;
-		height: calc(100vh - 46px);
+		height: 100vh;
 		max-height: none;
 		background: rgba(255, 255, 255, 0.96);
 		border: none;
 		border-radius: 0;
 		box-shadow: none;
-		padding: 18px 28px 16px;
+		padding: 0 28px 16px;
 		-webkit-app-region: no-drag;
 	}
 
 	.modal.window-mode header {
-		min-height: 56px;
-		padding-bottom: 14px;
+		min-height: 46px;
+		padding: 7px 0 7px 84px;
+		-webkit-app-region: drag;
+	}
+
+	.modal.window-mode header > * {
+		-webkit-app-region: no-drag;
 	}
 
 	.modal.window-mode .title-mark {
@@ -942,19 +948,21 @@
 	}
 
 	.modal.window-mode header h2 {
-		font-size: 22px;
+		font-size: 14px;
 		font-weight: 700;
-		letter-spacing: -0.02em;
+		letter-spacing: -0.01em;
 	}
 
 	.modal.window-mode header p {
-		font-size: 13px;
+		min-height: 0;
+		font-size: 11px;
+		line-height: 1.25;
 	}
 
 	.modal.window-mode .settings-body {
 		grid-template-columns: 184px minmax(0, 1fr);
 		gap: 20px;
-		padding: 18px 0;
+		padding: 14px 0 18px;
 	}
 
 	.modal.window-mode .settings-nav {
@@ -1423,9 +1431,13 @@
 		}
 
 		.modal.window-mode {
-			height: calc(100vh - 46px);
+			height: 100vh;
 			max-height: none;
-			padding: 18px;
+			padding: 0 18px 18px;
+		}
+
+		.modal.window-mode header {
+			padding-left: 76px;
 		}
 
 		.modal.window-mode .settings-body {

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -934,8 +934,11 @@
 	}
 
 	.modal.window-mode header {
-		min-height: 46px;
-		padding: 7px 0 7px 84px;
+		min-height: 30px;
+		justify-content: center;
+		padding: 7px 0 0;
+		border-bottom: none;
+		text-align: center;
 		-webkit-app-region: drag;
 	}
 
@@ -948,46 +951,76 @@
 	}
 
 	.modal.window-mode header h2 {
-		font-size: 14px;
+		font-size: 13px;
 		font-weight: 700;
 		letter-spacing: -0.01em;
+		color: color-mix(in srgb, var(--text-main) 74%, transparent);
 	}
 
 	.modal.window-mode header p {
-		min-height: 0;
-		font-size: 11px;
-		line-height: 1.25;
+		display: none;
 	}
 
 	.modal.window-mode .settings-body {
-		grid-template-columns: 184px minmax(0, 1fr);
-		gap: 20px;
-		padding: 14px 0 18px;
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		padding: 6px 0 18px;
 	}
 
 	.modal.window-mode .settings-nav {
-		gap: 2px;
-		padding-right: 12px;
-		border-right: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+		display: flex;
+		justify-content: center;
+		gap: 28px;
+		padding: 0 72px 12px;
+		border-bottom: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
+		-webkit-app-region: drag;
 	}
 
 	.modal.window-mode .settings-nav-item {
+		position: relative;
+		display: grid;
+		place-items: center;
+		gap: 4px;
+		min-width: 82px;
 		border: none;
-		border-radius: 8px;
+		border-radius: 12px;
 		background: transparent;
-		padding: 7px 10px;
-		font-size: 13px;
-		font-weight: 600;
+		padding: 8px 10px 9px;
+		font-size: 12px;
+		font-weight: 700;
+		color: color-mix(in srgb, var(--text-main) 58%, transparent);
 		box-shadow: none;
+		-webkit-app-region: no-drag;
+	}
+
+	.modal.window-mode .settings-nav-item :global(svg) {
+		width: 24px;
+		height: 24px;
+		stroke-width: 1.9;
 	}
 
 	.modal.window-mode .settings-nav-item.selected {
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
+		background: color-mix(in srgb, var(--text-main) 7%, transparent);
+		color: var(--text-main);
 		box-shadow: none;
 	}
 
+	.modal.window-mode .settings-nav-item.has-pending::after {
+		content: '';
+		position: absolute;
+		top: 9px;
+		right: 12px;
+		width: 5px;
+		height: 5px;
+		border-radius: 999px;
+		background: var(--accent);
+	}
+
 	.modal.window-mode .settings-pane {
-		padding-right: 4px;
+		width: min(100%, 1160px);
+		margin: 0 auto;
+		padding: 18px 2px 0;
 	}
 
 	header,
@@ -1438,15 +1471,23 @@
 
 		.modal.window-mode header {
 			padding-left: 76px;
+			justify-content: flex-start;
+			text-align: left;
 		}
 
 		.modal.window-mode .settings-body {
-			grid-template-columns: 1fr;
+			display: flex;
 		}
 
 		.modal.window-mode .settings-nav {
-			border-right: none;
-			padding-right: 0;
+			justify-content: flex-start;
+			gap: 10px;
+			overflow-x: auto;
+			padding: 0 0 10px;
+		}
+
+		.modal.window-mode .settings-nav-item {
+			min-width: 76px;
 		}
 	}
 </style>

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -1004,6 +1004,7 @@
 		background: color-mix(in srgb, var(--text-main) 7%, transparent);
 		color: var(--text-main);
 		box-shadow: none;
+		border: 1px solid var(--border-soft);
 	}
 
 	.modal.window-mode .settings-nav-item.has-pending::after {
@@ -1113,7 +1114,7 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		width: 100%;
+		/* width: 70%; */
 		border: 1px solid var(--border-soft);
 		border-radius: 13px;
 		background: rgba(255, 255, 255, 0.72);

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -971,7 +971,7 @@
 	.modal.window-mode .settings-nav {
 		display: flex;
 		justify-content: center;
-		gap: 28px;
+		gap: 18px;
 		padding: 0 72px 12px;
 		border-bottom: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
 		-webkit-app-region: drag;
@@ -981,13 +981,13 @@
 		position: relative;
 		display: grid;
 		place-items: center;
-		gap: 4px;
-		min-width: 82px;
+		gap: 3px;
+		min-width: 72px;
 		border: none;
 		border-radius: 12px;
 		background: transparent;
-		padding: 8px 10px 9px;
-		font-size: 12px;
+		padding: 7px 8px 8px;
+		font-size: 11px;
 		font-weight: 700;
 		color: color-mix(in srgb, var(--text-main) 58%, transparent);
 		box-shadow: none;
@@ -995,8 +995,8 @@
 	}
 
 	.modal.window-mode .settings-nav-item :global(svg) {
-		width: 24px;
-		height: 24px;
+		width: 20px;
+		height: 20px;
 		stroke-width: 1.9;
 	}
 
@@ -1481,13 +1481,13 @@
 
 		.modal.window-mode .settings-nav {
 			justify-content: flex-start;
-			gap: 10px;
+			gap: 8px;
 			overflow-x: auto;
 			padding: 0 0 10px;
 		}
 
 		.modal.window-mode .settings-nav-item {
-			min-width: 76px;
+			min-width: 68px;
 		}
 	}
 </style>

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -12,7 +12,6 @@
 		Trash2,
 		Upload,
 		Workflow,
-		X,
 		Brain,
 		Sparkles
 	} from '@lucide/svelte';
@@ -39,6 +38,11 @@
 	import { createSettingsController } from './settings-controller.svelte';
 	import { createSettingsPanelController } from './settings-panel-controller.svelte';
 	import { cloneSettings } from '$lib/settings/settings-draft';
+
+	type SettingsPanelMode = 'modal' | 'window';
+
+	let { mode = 'modal', onClose }: { mode?: SettingsPanelMode; onClose?: () => void } =
+		$props();
 
 	let draft = $state<ProviderSettings>(cloneSettings(settingsStore.settings));
 	let selectedProviderId = $state<string>(settingsStore.settings.providers[0]?.id || '');
@@ -215,6 +219,11 @@
 		return selectedProvider.models.filter((model) => model.toLowerCase().includes(query));
 	});
 
+	function closeSettings() {
+		onClose?.();
+		if (!onClose) shellStore.closeSettings();
+	}
+
 	let enabledProviderCount = $derived(
 		draft.providers.filter((provider) => provider.enabled).length
 	);
@@ -250,14 +259,24 @@
 	onMount(() => panelController.initElectron());
 </script>
 
-<div class="settings-layer" transition:fade={{ duration: 120 }}>
-	<button class="scrim" aria-label="Close settings" onclick={shellStore.closeSettings}></button>
+<div
+	class="settings-layer"
+	class:window-mode={mode === 'window'}
+	transition:fade={{ duration: mode === 'modal' ? 120 : 0 }}
+>
+	{#if mode === 'modal'}
+		<button class="scrim" aria-label="Close settings" onclick={closeSettings}></button>
+	{/if}
 	<div
 		class="modal settings-ui"
-		role="dialog"
-		aria-modal="true"
+		class:window-mode={mode === 'window'}
+		role={mode === 'modal' ? 'dialog' : undefined}
+		aria-modal={mode === 'modal' ? 'true' : undefined}
 		aria-labelledby="settings-title"
-		transition:scale={{ start: 0.97, duration: 140 }}
+		transition:scale={{
+			start: mode === 'modal' ? 0.97 : 1,
+			duration: mode === 'modal' ? 140 : 0
+		}}
 	>
 		<header>
 			<div class="title-mark"><Settings size={16} /></div>
@@ -279,13 +298,15 @@
 					{/if}
 				</p>
 			</div>
-			<button
-				class="icon-button"
-				aria-label="Close settings"
-				onclick={shellStore.closeSettings}
-			>
-				<X size={16} />
-			</button>
+			{#if mode === 'modal'}
+				<button
+					class="icon-button"
+					aria-label="Close settings"
+					onclick={closeSettings}
+				>
+					Close
+				</button>
+			{/if}
 		</header>
 
 		<div class="settings-body">
@@ -861,6 +882,21 @@
 		padding: 30px;
 	}
 
+	.settings-layer.window-mode {
+		position: relative;
+		min-height: 100vh;
+		padding: 46px 0 0;
+		background: rgba(255, 255, 255, 0.96);
+	}
+
+	.settings-layer.window-mode::before {
+		content: '';
+		position: absolute;
+		inset: 0 0 auto;
+		height: 46px;
+		-webkit-app-region: drag;
+	}
+
 	.scrim {
 		position: absolute;
 		inset: 0;
@@ -882,6 +918,68 @@
 		border-radius: 22px;
 		box-shadow: 0 22px 70px rgba(15, 23, 42, 0.18);
 		padding: 18px;
+	}
+
+	.modal.window-mode {
+		width: 100%;
+		height: calc(100vh - 46px);
+		max-height: none;
+		background: rgba(255, 255, 255, 0.96);
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		padding: 18px 28px 16px;
+		-webkit-app-region: no-drag;
+	}
+
+	.modal.window-mode header {
+		min-height: 56px;
+		padding-bottom: 14px;
+	}
+
+	.modal.window-mode .title-mark {
+		display: none;
+	}
+
+	.modal.window-mode header h2 {
+		font-size: 22px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+	}
+
+	.modal.window-mode header p {
+		font-size: 13px;
+	}
+
+	.modal.window-mode .settings-body {
+		grid-template-columns: 184px minmax(0, 1fr);
+		gap: 20px;
+		padding: 18px 0;
+	}
+
+	.modal.window-mode .settings-nav {
+		gap: 2px;
+		padding-right: 12px;
+		border-right: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+	}
+
+	.modal.window-mode .settings-nav-item {
+		border: none;
+		border-radius: 8px;
+		background: transparent;
+		padding: 7px 10px;
+		font-size: 13px;
+		font-weight: 600;
+		box-shadow: none;
+	}
+
+	.modal.window-mode .settings-nav-item.selected {
+		background: color-mix(in srgb, var(--accent) 12%, transparent);
+		box-shadow: none;
+	}
+
+	.modal.window-mode .settings-pane {
+		padding-right: 4px;
 	}
 
 	header,
@@ -1322,6 +1420,21 @@
 		.modal {
 			height: calc(100vh - 40px);
 			max-height: calc(100vh - 40px);
+		}
+
+		.modal.window-mode {
+			height: calc(100vh - 46px);
+			max-height: none;
+			padding: 18px;
+		}
+
+		.modal.window-mode .settings-body {
+			grid-template-columns: 1fr;
+		}
+
+		.modal.window-mode .settings-nav {
+			border-right: none;
+			padding-right: 0;
 		}
 	}
 </style>

--- a/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
+++ b/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
@@ -572,7 +572,19 @@ export function createSettingsPanelController(deps: {
 	}
 
 	function discardSettings() {
-		shellStore.closeSettings();
+		const saved = cloneSettings(settingsStore.settings);
+		const selectedProviderId = deps.getSelectedProviderId();
+		deps.setDraft(saved);
+		deps.setSelectedProviderId(
+			saved.providers.some((provider) => provider.id === selectedProviderId)
+				? selectedProviderId
+				: (saved.providers[0]?.id ?? '')
+		);
+		deps.setModelSearch('');
+		cometmindPanelKey += 1;
+		memoryPanelKey += 1;
+		workspacePruneMessage = '';
+		deps.settingsController.status = 'Discarded unsaved changes.';
 	}
 
 	function selectSection(section: SettingsSection) {

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -18,6 +18,9 @@
 	let isMiniRoute = $derived(
 		page.url.pathname === '/mini' || page.url.pathname.startsWith('/mini/')
 	);
+	let isSettingsRoute = $derived(
+		page.url.pathname === '/settings' || page.url.pathname.startsWith('/settings/')
+	);
 	// Prevents the setup wizard from re-opening after the user skips it
 	// within the same session (in-memory guard). The durable guard is
 	// hasDismissedSetupWizard persisted in settings.
@@ -34,6 +37,9 @@
 			onNotify: (title, body) => {
 				window.electronAPI?.notifyJob?.({ title, body });
 			}
+		});
+		const unsubscribeSettingsChanged = window.electronAPI?.onProviderSettingsChanged?.((settings) => {
+			settingsStore.apply(settings);
 		});
 		void settingsStore.load().then(() => {
 			settingsLoaded = true;
@@ -58,6 +64,7 @@
 			connectionState.stopPolling();
 			stopJobNotifications();
 			stopStorageRetentionSync?.();
+			unsubscribeSettingsChanged?.();
 		};
 	});
 
@@ -159,7 +166,7 @@
 	}
 </script>
 
-{#if isMiniRoute}
+{#if isMiniRoute || isSettingsRoute}
 	{@render children()}
 {:else}
 	<AppShell>

--- a/cometline/src/routes/+page.svelte
+++ b/cometline/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 	import { modelStore } from '$lib/stores/model.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import { chatStore } from '$lib/stores/chat.svelte';
+	import { openSettings } from '$lib/actions/open-settings';
 	import { FolderOpen, X } from '@lucide/svelte';
 	import type { ChatTurnPayload } from '$lib/actions/start-chat';
 	import { renderUserText } from '$lib/markdown/render';
@@ -35,10 +36,6 @@
 		modelStore.selectDefault();
 		listJobsMessage = null;
 	});
-
-	function openSettings() {
-		shellStore.openSettings();
-	}
 
 	function showLocalUserMessage(text: string) {
 		listJobsMessage = text;

--- a/cometline/src/routes/settings/+page.svelte
+++ b/cometline/src/routes/settings/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import SettingsPanel from '$lib/components/settings/SettingsPanel.svelte';
+	import { settingsStore } from '$lib/stores/settings.svelte';
+
+	let ready = $state(false);
+	let loadError = $state('');
+
+	onMount(() => {
+		void settingsStore
+			.load()
+			.then(() => {
+				ready = true;
+			})
+			.catch((err) => {
+				loadError = err instanceof Error ? err.message : 'Failed to load settings';
+				ready = true;
+			});
+	});
+
+	function closeSettingsWindow() {
+		window.close();
+	}
+</script>
+
+<svelte:head>
+	<title>Settings - Cometline</title>
+</svelte:head>
+
+{#if ready}
+	{#if loadError}
+		<div class="settings-load-error" role="alert">
+			<h1>Settings</h1>
+			<p>{loadError}</p>
+		</div>
+	{:else}
+		<SettingsPanel mode="window" onClose={closeSettingsWindow} />
+	{/if}
+{:else}
+	<div class="settings-loading" role="status">Loading settings...</div>
+{/if}
+
+<style>
+	.settings-loading,
+	.settings-load-error {
+		display: grid;
+		place-content: center;
+		min-height: 100vh;
+		padding: 24px;
+		background: var(--app-bg);
+		color: var(--text-main);
+	}
+
+	.settings-load-error {
+		gap: 8px;
+		text-align: center;
+	}
+
+	.settings-load-error h1,
+	.settings-load-error p {
+		margin: 0;
+	}
+</style>

--- a/cometline/src/routes/settings/+page.ts
+++ b/cometline/src/routes/settings/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
## Background

Settings previously lived as an in-app modal, which made it compete with the chat shell and prevented it from behaving like a native desktop preferences window. This change moves settings into its own Electron window while preserving the existing settings shortcut and sidebar entry points.

[0cd53d3](https://github.com/Cometline/cometline/commit/0cd53d3890b6d43dc8505f42f340ad4c132ce6c7): Settings now open in a dedicated BrowserWindow with menu and tray entry points, cross-window settings refresh, and a client-only `/settings` route that waits for persisted settings before rendering. The settings UI has a window mode with macOS-safe titlebar spacing, native-style preferences chrome, no duplicate close icon, and a working discard action that resets unsaved draft state.