### PR TITLE
fix(cometmind): mcp server refresh logic

### DIFF
--- a/cometmind/internal/mcp/oauth.go
+++ b/cometmind/internal/mcp/oauth.go
@@ -67,6 +67,14 @@ func LoadOAuthToken(serverID string) (*oauth2.Token, error) {
 
 // SaveOAuthToken writes an OAuth token for one MCP server (mode 0600).
 func SaveOAuthToken(serverID string, tok *oauth2.Token) error {
+	if err := saveOAuthToken(serverID, tok); err != nil {
+		return err
+	}
+	invalidateOAuthTokenSource(serverID)
+	return nil
+}
+
+func saveOAuthToken(serverID string, tok *oauth2.Token) error {
 	if tok == nil || strings.TrimSpace(tok.AccessToken) == "" {
 		return fmt.Errorf("empty oauth token")
 	}
@@ -79,6 +87,10 @@ func SaveOAuthToken(serverID string, tok *oauth2.Token) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func invalidateOAuthTokenSource(serverID string) {
+	oauthTokenSources.Delete(strings.TrimSpace(serverID))
 }
 
 // OAuthConnected reports whether a non-empty token file exists for the server.
@@ -96,14 +108,20 @@ type fileOAuthHandler struct {
 	serverID string
 }
 
-func (h fileOAuthHandler) TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	tok, err := LoadOAuthToken(h.serverID)
+var oauthTokenSources sync.Map // map[string]*persistingTokenSource
+
+func (h fileOAuthHandler) TokenSource(_ context.Context) (oauth2.TokenSource, error) {
+	serverID := strings.TrimSpace(h.serverID)
+	if cached, ok := oauthTokenSources.Load(serverID); ok {
+		return cached.(*persistingTokenSource), nil
+	}
+	tok, err := LoadOAuthToken(serverID)
 	if err != nil {
 		return nil, nil
 	}
 	// If we have persisted client info, build a refreshing source so expired
 	// access tokens are renewed via the stored refresh token + token endpoint.
-	if info, infoErr := loadOAuthClientInfo(h.serverID); infoErr == nil && info != nil {
+	if info, infoErr := loadOAuthClientInfo(serverID); infoErr == nil && info != nil {
 		cfg := &oauth2.Config{
 			ClientID:     info.ClientID,
 			ClientSecret: info.ClientSecret,
@@ -113,9 +131,9 @@ func (h fileOAuthHandler) TokenSource(ctx context.Context) (oauth2.TokenSource, 
 			},
 			Scopes: info.Scopes,
 		}
-		clientCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: 30 * time.Second})
-		base := cfg.TokenSource(clientCtx, tok)
-		return &persistingTokenSource{serverID: h.serverID, base: base, last: tok}, nil
+		source := newPersistingTokenSource(serverID, cfg, tok)
+		actual, _ := oauthTokenSources.LoadOrStore(serverID, source)
+		return actual.(*persistingTokenSource), nil
 	}
 	// No client info (e.g. token injected externally): serve it statically.
 	return oauth2.StaticTokenSource(tok), nil
@@ -128,7 +146,13 @@ func (h fileOAuthHandler) Authorize(ctx context.Context, _ *http.Request, resp *
 	// A 401 reached Authorize, meaning the bearer token was rejected. Attempt a
 	// silent refresh; only if that fails do we surface an actionable error.
 	if ts, err := h.TokenSource(ctx); err == nil && ts != nil {
-		if _, refreshErr := ts.Token(); refreshErr == nil {
+		if refresher, ok := ts.(*persistingTokenSource); ok {
+			if _, refreshErr := refresher.ForceRefresh(); refreshErr == nil {
+				// Refresh succeeded; returning nil triggers an immediate retry with
+				// the freshly persisted token.
+				return nil
+			}
+		} else if _, refreshErr := ts.Token(); refreshErr == nil {
 			// Refresh succeeded; returning nil triggers an immediate retry with
 			// the freshly persisted token.
 			return nil
@@ -141,24 +165,70 @@ func (h fileOAuthHandler) Authorize(ctx context.Context, _ *http.Request, resp *
 // tokens back to disk so subsequent runtime connects reuse the refreshed token.
 type persistingTokenSource struct {
 	serverID string
+	cfg      *oauth2.Config
 	base     oauth2.TokenSource
 	mu       sync.Mutex
 	last     *oauth2.Token
 }
 
+func newPersistingTokenSource(serverID string, cfg *oauth2.Config, tok *oauth2.Token) *persistingTokenSource {
+	return &persistingTokenSource{
+		serverID: serverID,
+		cfg:      cfg,
+		base:     cfg.TokenSource(oauthClientContext(), tok),
+		last:     tok,
+	}
+}
+
+func oauthClientContext() context.Context {
+	return context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Timeout: 30 * time.Second})
+}
+
 func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	tok, err := p.base.Token()
 	if err != nil {
 		return nil, err
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.last == nil || tok.AccessToken != p.last.AccessToken {
+	if p.last == nil || tokenChanged(tok, p.last) {
 		// Token rotated; persist it (best-effort, do not fail the request).
-		_ = SaveOAuthToken(p.serverID, tok)
+		_ = saveOAuthToken(p.serverID, tok)
 		p.last = tok
 	}
 	return tok, nil
+}
+
+func (p *persistingTokenSource) ForceRefresh() (*oauth2.Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	seed, err := LoadOAuthToken(p.serverID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(seed.RefreshToken) == "" {
+		return nil, fmt.Errorf("oauth token missing refresh_token")
+	}
+	expired := *seed
+	expired.Expiry = time.Now().Add(-time.Hour)
+	p.base = p.cfg.TokenSource(oauthClientContext(), &expired)
+	tok, err := p.base.Token()
+	if err != nil {
+		return nil, err
+	}
+	_ = saveOAuthToken(p.serverID, tok)
+	p.last = tok
+	return tok, nil
+}
+
+func tokenChanged(a, b *oauth2.Token) bool {
+	if a == nil || b == nil {
+		return a != b
+	}
+	return a.AccessToken != b.AccessToken ||
+		a.RefreshToken != b.RefreshToken ||
+		a.TokenType != b.TokenType ||
+		!a.Expiry.Equal(b.Expiry)
 }
 
 func oauthHandlerFor(serverID string, _ *OAuthConfig) auth.OAuthHandler {

--- a/cometmind/internal/mcp/oauth_test.go
+++ b/cometmind/internal/mcp/oauth_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,6 +122,144 @@ func TestPersistingTokenSourcePersistsRotatedToken(t *testing.T) {
 	if loaded.AccessToken != "new" {
 		t.Errorf("persisted AccessToken = %q, want new", loaded.AccessToken)
 	}
+}
+
+func TestFileOAuthHandlerConcurrentTokenSourceRefreshesOnce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var refreshes atomic.Int32
+	tokenEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("refresh_token"); got != "r1" {
+			http.Error(w, "unexpected refresh token", http.StatusBadRequest)
+			return
+		}
+		if refreshes.Add(1) > 1 {
+			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a2","refresh_token":"r2","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenEndpoint.Close()
+
+	const serverID = "rotating-concurrent"
+	if err := saveOAuthClientInfo(serverID, &oauthClientInfo{
+		TokenEndpoint: tokenEndpoint.URL,
+		ClientID:      "client",
+		AuthStyle:     oauth2.AuthStyleInParams,
+	}); err != nil {
+		t.Fatalf("saveOAuthClientInfo: %v", err)
+	}
+	if err := SaveOAuthToken(serverID, &oauth2.Token{
+		AccessToken:  "a1",
+		RefreshToken: "r1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveOAuthToken: %v", err)
+	}
+
+	handler := fileOAuthHandler{serverID: serverID}
+	const callers = 12
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ts, err := handler.TokenSource(context.Background())
+			if err != nil {
+				errs <- err
+				return
+			}
+			tok, err := ts.Token()
+			if err != nil {
+				errs <- err
+				return
+			}
+			if tok.AccessToken != "a2" || tok.RefreshToken != "r2" {
+				errs <- &unexpectedTokenError{access: tok.AccessToken, refresh: tok.RefreshToken}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refresh requests = %d, want 1", got)
+	}
+	loaded, err := LoadOAuthToken(serverID)
+	if err != nil {
+		t.Fatalf("LoadOAuthToken: %v", err)
+	}
+	if loaded.RefreshToken != "r2" {
+		t.Fatalf("persisted refresh token = %q, want r2", loaded.RefreshToken)
+	}
+}
+
+func TestFileOAuthHandlerAuthorizeForcesRefresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var refreshes atomic.Int32
+	tokenEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshes.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh","refresh_token":"r2","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenEndpoint.Close()
+
+	const serverID = "authorize-refresh"
+	if err := saveOAuthClientInfo(serverID, &oauthClientInfo{
+		TokenEndpoint: tokenEndpoint.URL,
+		ClientID:      "client",
+		AuthStyle:     oauth2.AuthStyleInParams,
+	}); err != nil {
+		t.Fatalf("saveOAuthClientInfo: %v", err)
+	}
+	if err := SaveOAuthToken(serverID, &oauth2.Token{
+		AccessToken:  "stale",
+		RefreshToken: "r1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveOAuthToken: %v", err)
+	}
+
+	handler := fileOAuthHandler{serverID: serverID}
+	resp := &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody}
+	if err := handler.Authorize(context.Background(), nil, resp); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refresh requests = %d, want 1", got)
+	}
+	loaded, err := LoadOAuthToken(serverID)
+	if err != nil {
+		t.Fatalf("LoadOAuthToken: %v", err)
+	}
+	if loaded.AccessToken != "fresh" || loaded.RefreshToken != "r2" {
+		t.Fatalf("persisted token = (%q, %q), want (fresh, r2)", loaded.AccessToken, loaded.RefreshToken)
+	}
+}
+
+type unexpectedTokenError struct {
+	access  string
+	refresh string
+}
+
+func (e *unexpectedTokenError) Error() string {
+	return "unexpected token: access=" + e.access + " refresh=" + e.refresh
 }
 
 func TestProtectedResourceMetadataCandidates(t *testing.T) {


### PR DESCRIPTION
## Background

This PR fixes the refresh token error in cometmind. 
releated issue: #35 

