### PR TITLE
[main] feat: enhance MCP stability with heartbeat and auto-reconnect mechanism

### DIFF
--- a/cometmind/internal/mcp/client.go
+++ b/cometmind/internal/mcp/client.go
@@ -14,6 +14,18 @@ import (
 
 const defaultConnectTimeout = 10 * time.Second
 
+// defaultKeepAlive enables the go-sdk's built-in ping/keepalive loop
+// (mcp.ClientOptions.KeepAlive) for every MCP session, regardless of
+// transport (stdio, HTTP, or SSE). Without this, a silently-dead connection
+// (network drop, idle load-balancer reap, subprocess exit) is never detected
+// proactively — the SDK only surfaces the failure reactively, the next time a
+// tool call happens to be attempted. With KeepAlive set, the SDK pings the
+// peer on this interval and, if a ping fails, closes the session itself
+// (see go-sdk mcp/shared.go startKeepalive), which Manager's monitorConnection
+// observes via ClientSession.Wait() to correct the cached status and drive a
+// bounded automatic reconnect.
+const defaultKeepAlive = 30 * time.Second
+
 var clientImpl = &mcp.Implementation{Name: "cometmind", Version: "0.1.0"}
 
 // DiscoveredTool is one MCP tool exposed to CometMind.
@@ -44,6 +56,7 @@ func connectServer(ctx context.Context, cfg ServerConfig) (*connectedServer, err
 
 	client := mcp.NewClient(clientImpl, &mcp.ClientOptions{
 		Capabilities: &mcp.ClientCapabilities{},
+		KeepAlive:    defaultKeepAlive,
 	})
 	session, err := client.Connect(connectCtx, transport, nil)
 	if err != nil {

--- a/cometmind/internal/mcp/manager.go
+++ b/cometmind/internal/mcp/manager.go
@@ -74,6 +74,15 @@ type managedServer struct {
 	conn      *connectedServer
 	status    ServerStatus
 	lastError string
+	// generation identifies the current connection "episode" for this
+	// server. It is bumped by connectOne every time it (re)connects — success
+	// or failure — and by Close for every entry it tears down. A
+	// monitorConnection/autoReconnect goroutine captures the generation at
+	// the moment its connection was installed; before acting on a wake-up it
+	// re-checks the entry's current generation against that captured value,
+	// so a stale goroutine racing a newer connect/reconnect/reload for the
+	// same server safely no-ops instead of clobbering fresher state.
+	generation uint64
 }
 
 // NewManager builds a manager from settings without connecting.
@@ -138,13 +147,23 @@ func (m *Manager) connectOne(ctx context.Context, serverID string) error {
 		_ = entry.conn.session.Close()
 		entry.conn = nil
 	}
+	// Bump generation before the (slow, unlocked) connectServer call so that
+	// any monitorConnection goroutine watching a session we just closed above
+	// sees a generation mismatch when its Wait() unblocks, and treats the
+	// closure as an intentional supersession rather than an unexpected death.
+	entry.generation++
+	gen := entry.generation
 	m.mu.Unlock()
 
 	conn, err := connectServer(ctx, cfg)
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	entry, ok = m.servers[serverID]
-	if !ok {
+	if !ok || entry.generation != gen {
+		// The server was removed, or a newer connect/reconnect/reload already
+		// superseded this attempt while connectServer was in flight — discard
+		// this (now-stale) result instead of clobbering fresher state.
+		m.mu.Unlock()
 		if conn != nil && conn.session != nil {
 			_ = conn.session.Close()
 		}
@@ -154,12 +173,88 @@ func (m *Manager) connectOne(ctx context.Context, serverID string) error {
 		entry.conn = nil
 		entry.status = StatusError
 		entry.lastError = err.Error()
+		m.mu.Unlock()
 		return err
 	}
 	entry.conn = conn
 	entry.status = StatusConnected
 	entry.lastError = ""
+	m.mu.Unlock()
+
+	go m.monitorConnection(serverID, gen, conn)
 	return nil
+}
+
+// mcpAutoReconnectBackoff defines the bounded automatic-reconnect policy
+// applied when monitorConnection observes a live session die unexpectedly.
+// After these attempts are exhausted, the server is left in StatusError with
+// lastError set — matching manual recovery via the existing
+// reconnection-runs API / Settings UI reconnect button, rather than retrying
+// silently forever.
+var mcpAutoReconnectBackoff = []time.Duration{2 * time.Second, 8 * time.Second, 30 * time.Second}
+
+// monitorConnection watches one connected session for the underlying
+// transport dying — a failed keepalive ping (see defaultKeepAlive in
+// client.go), a stdio subprocess exiting, or any other transport-level
+// error — and reacts by correcting the cached status (which would otherwise
+// stay StatusConnected forever) and driving a bounded automatic reconnect.
+//
+// gen is the generation captured at the moment this conn was installed. If,
+// by the time session.Wait() returns, the entry's live generation no longer
+// matches gen, some other connect/reconnect/reload/close already superseded
+// this connection intentionally, and this goroutine is a no-op.
+func (m *Manager) monitorConnection(serverID string, gen uint64, conn *connectedServer) {
+	waitErr := conn.session.Wait()
+
+	m.mu.Lock()
+	entry, ok := m.servers[serverID]
+	if !ok || entry.generation != gen {
+		m.mu.Unlock()
+		return
+	}
+	entry.conn = nil
+	entry.status = StatusError
+	if waitErr != nil {
+		entry.lastError = waitErr.Error()
+	} else {
+		entry.lastError = "MCP session closed unexpectedly"
+	}
+	m.mu.Unlock()
+
+	logging.L().Error("mcp.session_closed", "server", serverID, "error", waitErr)
+	m.autoReconnect(serverID)
+}
+
+// autoReconnect retries connectOne a bounded number of times with backoff
+// after monitorConnection detects an unexpected session death. It bails out
+// early if the server was disabled, the manager started reloading, or
+// something else (a manual Reconnect racing this loop) already restored the
+// connection — connectOne itself remains the single source of truth for
+// generation-safe connect races, so this loop only needs to decide whether
+// it's still worth attempting another connect.
+func (m *Manager) autoReconnect(serverID string) {
+	for attempt, delay := range mcpAutoReconnectBackoff {
+		time.Sleep(delay)
+
+		m.mu.RLock()
+		entry, ok := m.servers[serverID]
+		reloading := m.reloading
+		alreadyConnected := ok && entry.status == StatusConnected
+		enabled := ok && m.cfg.Enabled && entry.cfg.Enabled
+		m.mu.RUnlock()
+		if !ok || reloading || !enabled || alreadyConnected {
+			return
+		}
+
+		connectCtx, cancel := context.WithTimeout(context.Background(), defaultConnectTimeout)
+		err := m.connectOne(connectCtx, serverID)
+		cancel()
+		if err == nil {
+			logging.L().Info("mcp.auto_reconnect_succeeded", "server", serverID, "attempt", attempt+1)
+			return
+		}
+		logging.L().Warn("mcp.auto_reconnect_failed", "server", serverID, "attempt", attempt+1, "error", err)
+	}
 }
 
 // Close disconnects all MCP sessions.
@@ -167,6 +262,13 @@ func (m *Manager) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, entry := range m.servers {
+		// Bump generation first so any monitorConnection goroutine watching
+		// this session sees a mismatch when session.Close() below unblocks
+		// its Wait() call, and treats this as an intentional shutdown rather
+		// than an unexpected death — otherwise it would overwrite
+		// StatusDisconnected with StatusError and kick off a pointless
+		// autoReconnect loop against a manager that is shutting down.
+		entry.generation++
 		if entry.conn != nil && entry.conn.session != nil {
 			_ = entry.conn.session.Close()
 			entry.conn = nil

--- a/cometmind/internal/mcp/manager_reconnect_test.go
+++ b/cometmind/internal/mcp/manager_reconnect_test.go
@@ -1,0 +1,364 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// withFastBackoff overrides the package-level auto-reconnect backoff policy
+// for the duration of a test, so tests exercising autoReconnect don't have to
+// wait out the real 2s/8s/30s schedule.
+func withFastBackoff(t *testing.T, delays []time.Duration) {
+	t.Helper()
+	original := mcpAutoReconnectBackoff
+	mcpAutoReconnectBackoff = delays
+	t.Cleanup(func() { mcpAutoReconnectBackoff = original })
+}
+
+// newInMemoryConnectedServer wires up a client session against an in-process
+// MCP server over an in-memory transport pair, mirroring the pattern used by
+// TestManagerInMemoryToolCall. It returns the connected client-side server
+// plus a func to close/kill the server side (simulating a transport death).
+func newInMemoryConnectedServer(t *testing.T, cfg ServerConfig) (*connectedServer, func()) {
+	t.Helper()
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "v0.0.1"}, nil)
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	conn, err := connectServerWithTransport(ctx, cfg, t2)
+	if err != nil {
+		_ = serverSession.Close()
+		t.Fatalf("connectServerWithTransport: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.session.Close() })
+	return conn, func() { _ = serverSession.Close() }
+}
+
+// TestMonitorConnectionDetectsSessionDeathAndSetsError verifies that when the
+// underlying transport dies (session.Wait() returns), monitorConnection
+// corrects the cached status from Connected to Error and records a
+// last-error message, instead of leaving the stale "connected" status in
+// place forever.
+func TestMonitorConnectionDetectsSessionDeathAndSetsError(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond})
+
+	cfg := ServerConfig{ID: "demo", Name: "Demo", Enabled: false, Transport: TransportStdio}
+	conn, kill := newInMemoryConnectedServer(t, cfg)
+
+	mgr := NewManager(Config{Enabled: true})
+	mgr.mu.Lock()
+	mgr.servers["demo"] = &managedServer{cfg: cfg, status: StatusConnected, generation: 1}
+	mgr.mu.Unlock()
+
+	kill() // server-side close unblocks conn.session.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.monitorConnection("demo", 1, conn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorConnection did not return in time")
+	}
+
+	mgr.mu.RLock()
+	entry := mgr.servers["demo"]
+	status, lastError := entry.status, entry.lastError
+	mgr.mu.RUnlock()
+
+	if status != StatusError {
+		t.Fatalf("status = %q, want %q", status, StatusError)
+	}
+	if lastError == "" {
+		t.Fatal("lastError = \"\", want a non-empty message describing the session closure")
+	}
+}
+
+// TestMonitorConnectionStaleGenerationIsNoop verifies that a monitorConnection
+// goroutine watching a superseded connection (generation bumped by a newer
+// connect/reconnect/reload/close) does not clobber the entry's current state
+// when its Wait() call eventually unblocks.
+func TestMonitorConnectionStaleGenerationIsNoop(t *testing.T) {
+	cfg := ServerConfig{ID: "demo", Name: "Demo", Enabled: true, Transport: TransportStdio}
+	conn, kill := newInMemoryConnectedServer(t, cfg)
+
+	mgr := NewManager(Config{Enabled: true})
+	mgr.mu.Lock()
+	mgr.servers["demo"] = &managedServer{cfg: cfg, status: StatusConnected, generation: 5}
+	mgr.mu.Unlock()
+
+	kill()
+
+	done := make(chan struct{})
+	go func() {
+		// gen=3 is stale relative to the entry's live generation (5).
+		mgr.monitorConnection("demo", 3, conn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorConnection did not return in time")
+	}
+
+	mgr.mu.RLock()
+	status := mgr.servers["demo"].status
+	mgr.mu.RUnlock()
+
+	if status != StatusConnected {
+		t.Fatalf("status = %q, want %q (stale-generation monitor should be a no-op)", status, StatusConnected)
+	}
+}
+
+// TestMonitorConnectionUnknownServerIsNoop verifies that if the server entry
+// has been removed entirely (e.g. Reload rebuilt the servers map) by the time
+// Wait() unblocks, monitorConnection returns without panicking.
+func TestMonitorConnectionUnknownServerIsNoop(t *testing.T) {
+	cfg := ServerConfig{ID: "demo", Name: "Demo", Enabled: true, Transport: TransportStdio}
+	conn, kill := newInMemoryConnectedServer(t, cfg)
+
+	mgr := NewManager(Config{Enabled: true})
+	// Intentionally do not register "demo" in mgr.servers.
+
+	kill()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.monitorConnection("demo", 1, conn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorConnection did not return in time")
+	}
+}
+
+// TestAutoReconnectBailsWhenAlreadyConnected verifies autoReconnect exits on
+// its first backoff tick without attempting a connect when some other path
+// (a manual Reconnect racing this loop) already restored the connection.
+func TestAutoReconnectBailsWhenAlreadyConnected(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond, time.Hour})
+
+	mgr := NewManager(Config{
+		Enabled: true,
+		Servers: []ServerConfig{{ID: "a", Name: "A", Enabled: true, Transport: TransportStdio, Command: "false"}},
+	})
+	mgr.mu.Lock()
+	mgr.servers["a"] = &managedServer{cfg: mgr.cfg.Servers[0], status: StatusConnected}
+	mgr.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.autoReconnect("a")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("autoReconnect did not bail promptly when already connected")
+	}
+
+	mgr.mu.RLock()
+	status := mgr.servers["a"].status
+	mgr.mu.RUnlock()
+	if status != StatusConnected {
+		t.Fatalf("status = %q, want %q (should be untouched)", status, StatusConnected)
+	}
+}
+
+// TestAutoReconnectBailsWhenDisabled verifies autoReconnect stops retrying
+// once the server (or MCP globally) has been disabled, rather than
+// hammering a connect attempt against a server the user turned off.
+func TestAutoReconnectBailsWhenDisabled(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond, time.Hour})
+
+	mgr := NewManager(Config{
+		Enabled: true,
+		Servers: []ServerConfig{{ID: "a", Name: "A", Enabled: false, Transport: TransportStdio, Command: "false"}},
+	})
+	mgr.mu.Lock()
+	mgr.servers["a"] = &managedServer{cfg: mgr.cfg.Servers[0], status: StatusError, lastError: "prior failure"}
+	mgr.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.autoReconnect("a")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("autoReconnect did not bail promptly when disabled")
+	}
+
+	mgr.mu.RLock()
+	entry := mgr.servers["a"]
+	status, lastError := entry.status, entry.lastError
+	mgr.mu.RUnlock()
+	if status != StatusError {
+		t.Fatalf("status = %q, want %q (untouched)", status, StatusError)
+	}
+	if lastError != "prior failure" {
+		t.Fatalf("lastError = %q, want unchanged %q (no connect attempt should have run)", lastError, "prior failure")
+	}
+}
+
+// TestAutoReconnectBailsWhileReloading verifies autoReconnect defers to an
+// in-flight Reload rather than racing Start()'s from-scratch rebuild of the
+// servers map.
+func TestAutoReconnectBailsWhileReloading(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond, time.Hour})
+
+	mgr := NewManager(Config{
+		Enabled: true,
+		Servers: []ServerConfig{{ID: "a", Name: "A", Enabled: true, Transport: TransportStdio, Command: "false"}},
+	})
+	mgr.mu.Lock()
+	mgr.servers["a"] = &managedServer{cfg: mgr.cfg.Servers[0], status: StatusError, lastError: "prior failure"}
+	mgr.reloading = true
+	mgr.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.autoReconnect("a")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("autoReconnect did not bail promptly while reloading")
+	}
+
+	mgr.mu.RLock()
+	lastError := mgr.servers["a"].lastError
+	mgr.mu.RUnlock()
+	if lastError != "prior failure" {
+		t.Fatalf("lastError = %q, want unchanged %q (no connect attempt should have run)", lastError, "prior failure")
+	}
+}
+
+// TestAutoReconnectBailsWhenServerRemoved verifies autoReconnect stops if the
+// server entry has been removed entirely (e.g. deleted from settings).
+func TestAutoReconnectBailsWhenServerRemoved(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond, time.Hour})
+
+	mgr := NewManager(Config{Enabled: true})
+
+	done := make(chan struct{})
+	go func() {
+		mgr.autoReconnect("missing")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("autoReconnect did not bail promptly for a removed server")
+	}
+}
+
+// TestAutoReconnectRetriesUntilExhausted verifies autoReconnect attempts a
+// connect on every backoff tick (via connectOne) and, once the schedule is
+// exhausted against a server that keeps failing, leaves the server in
+// StatusError with a fresh lastError from the final attempt rather than
+// retrying forever.
+func TestAutoReconnectRetriesUntilExhausted(t *testing.T) {
+	withFastBackoff(t, []time.Duration{time.Millisecond, time.Millisecond})
+
+	mgr := NewManager(Config{
+		Enabled: true,
+		Servers: []ServerConfig{{ID: "a", Name: "A", Enabled: true, Transport: TransportStdio, Command: "false"}},
+	})
+	mgr.mu.Lock()
+	mgr.servers["a"] = &managedServer{cfg: mgr.cfg.Servers[0], status: StatusError, lastError: "prior failure"}
+	mgr.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.autoReconnect("a")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("autoReconnect did not finish its bounded retry schedule")
+	}
+
+	mgr.mu.RLock()
+	entry := mgr.servers["a"]
+	status, lastError, gen := entry.status, entry.lastError, entry.generation
+	mgr.mu.RUnlock()
+	if status != StatusError {
+		t.Fatalf("status = %q, want %q", status, StatusError)
+	}
+	if lastError == "prior failure" || lastError == "" {
+		t.Fatalf("lastError = %q, want it replaced by a fresh connect failure message", lastError)
+	}
+	if gen == 0 {
+		t.Fatal("generation was never bumped; connectOne does not appear to have run")
+	}
+}
+
+// TestConnectOneDiscardsResultWhenSuperseded verifies the race-safety
+// invariant documented on connectOne: if a newer connect/reconnect/reload
+// bumps the entry's generation while an in-flight connectServer call is
+// still unlocked, the original (now-stale) connectOne discards its result
+// instead of clobbering the fresher state installed by the winner.
+func TestConnectOneDiscardsResultWhenSuperseded(t *testing.T) {
+	cfg := ServerConfig{
+		ID: "a", Name: "A", Enabled: true, Transport: TransportStdio,
+		Command: "sh", Args: []string{"-c", "sleep 0.3; exit 1"},
+	}
+	mgr := NewManager(Config{Enabled: true, Servers: []ServerConfig{cfg}})
+	mgr.mu.Lock()
+	mgr.servers["a"] = &managedServer{cfg: cfg, status: StatusDisconnected}
+	mgr.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.connectOne(context.Background(), "a")
+	}()
+
+	// Give the goroutine time to capture its generation and enter the
+	// unlocked connectServer call before we simulate a superseding
+	// connect/reconnect having already installed fresher state.
+	time.Sleep(50 * time.Millisecond)
+
+	mgr.mu.Lock()
+	mgr.servers["a"].generation++
+	mgr.servers["a"].status = StatusConnected
+	mgr.servers["a"].lastError = ""
+	mgr.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("connectOne did not return in time")
+	}
+
+	mgr.mu.RLock()
+	status, lastError := mgr.servers["a"].status, mgr.servers["a"].lastError
+	mgr.mu.RUnlock()
+	if status != StatusConnected {
+		t.Fatalf("status = %q, want %q (stale connectOne must not overwrite fresher state)", status, StatusConnected)
+	}
+	if lastError != "" {
+		t.Fatalf("lastError = %q, want empty (stale connectOne must not overwrite fresher state)", lastError)
+	}
+}

--- a/cometmind/internal/tools/mcp_manage.go
+++ b/cometmind/internal/tools/mcp_manage.go
@@ -1,0 +1,98 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mcppkg "github.com/cometline/cometmind/internal/mcp"
+)
+
+// listMCPServersTool lets the agent inspect MCP server connection status
+// directly (e.g. "is Jira connected?") instead of relying on the user to
+// check Settings or a human operator to hit the management API by hand.
+type listMCPServersTool struct {
+	mgr *mcppkg.Manager
+}
+
+func (listMCPServersTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "list_mcp_servers",
+		Description: "List configured MCP servers and their live connection status (connected, error, disconnected, disabled, reloading), tool count, and last error if any. Use this to check whether an MCP server (e.g. Jira, Confluence, Atlassian) is currently reachable before or after reconnecting it.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
+func (t listMCPServersTool) Execute(ctx context.Context, _ json.RawMessage) (Result, error) {
+	if t.mgr == nil {
+		return Result{OK: false, Output: "MCP is not configured"}, nil
+	}
+	servers := t.mgr.ListServers()
+	if len(servers) == 0 {
+		return Result{OK: true, Output: "No MCP servers configured."}, nil
+	}
+	var b strings.Builder
+	for _, s := range servers {
+		fmt.Fprintf(&b, "- %s (%s) [%s transport] status=%s tools=%d",
+			s.Name, s.ID, s.Transport, s.Status, s.ToolCount)
+		if s.LastError != "" {
+			fmt.Fprintf(&b, " last_error=%q", s.LastError)
+		}
+		b.WriteString("\n")
+	}
+	return Result{OK: true, Output: strings.TrimSpace(b.String())}, nil
+}
+
+// reconnectMCPServerTool lets the agent force a disconnect+reconnect of a
+// single MCP server on request (e.g. "reconnect Jira for me"), instead of
+// requiring the user or an operator to call the management API by hand.
+type reconnectMCPServerTool struct {
+	mgr *mcppkg.Manager
+}
+
+func (reconnectMCPServerTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "reconnect_mcp_server",
+		Description: "Force a disconnect and fresh reconnect of one configured MCP server by its server ID (see list_mcp_servers for IDs). Use this when a server's status is error/disconnected, or when the user asks to reconnect an MCP server (e.g. Jira, Confluence).",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"server_id":{"type":"string","description":"The MCP server ID to reconnect, as returned by list_mcp_servers"}
+			},
+			"required":["server_id"]
+		}`),
+	}
+}
+
+func (t reconnectMCPServerTool) Execute(ctx context.Context, input json.RawMessage) (Result, error) {
+	if t.mgr == nil {
+		return Result{OK: false, Output: "MCP is not configured"}, nil
+	}
+	var in struct {
+		ServerID string `json:"server_id"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return Result{OK: false, Output: "invalid tool input: " + err.Error()}, nil
+	}
+	serverID := strings.TrimSpace(in.ServerID)
+	if serverID == "" {
+		return Result{OK: false, Output: "server_id is required"}, nil
+	}
+	if err := t.mgr.Reconnect(ctx, serverID); err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	for _, s := range t.mgr.ListServers() {
+		if s.ID == serverID {
+			if s.Status == mcppkg.StatusConnected {
+				return Result{OK: true, Output: fmt.Sprintf("Reconnected %s (%s): status=%s tools=%d", s.Name, s.ID, s.Status, s.ToolCount)}, nil
+			}
+			out := fmt.Sprintf("Reconnect attempted for %s (%s): status=%s", s.Name, s.ID, s.Status)
+			if s.LastError != "" {
+				out += fmt.Sprintf(" last_error=%q", s.LastError)
+			}
+			return Result{OK: false, Output: out}, nil
+		}
+	}
+	return Result{OK: false, Output: fmt.Sprintf("unknown server: %s", serverID)}, nil
+}

--- a/cometmind/internal/tools/mcp_manage_test.go
+++ b/cometmind/internal/tools/mcp_manage_test.go
@@ -1,0 +1,254 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcppkg "github.com/cometline/cometmind/internal/mcp"
+)
+
+// TestListMCPServersToolNilManager verifies the tool degrades gracefully
+// when MCP isn't configured at all, instead of panicking on a nil manager.
+func TestListMCPServersToolNilManager(t *testing.T) {
+	tool := listMCPServersTool{}
+	res, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK {
+		t.Fatal("Execute() OK = true, want false (nil manager)")
+	}
+	if res.Output != "MCP is not configured" {
+		t.Fatalf("Execute() output = %q, want %q", res.Output, "MCP is not configured")
+	}
+}
+
+// TestListMCPServersToolNoServers verifies the "no servers configured"
+// message when MCP is enabled but nothing has been added.
+func TestListMCPServersToolNoServers(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{Enabled: true})
+	mgr.Start(context.Background())
+
+	tool := listMCPServersTool{mgr: mgr}
+	res, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("Execute() OK = false, want true")
+	}
+	if res.Output != "No MCP servers configured." {
+		t.Fatalf("Execute() output = %q, want %q", res.Output, "No MCP servers configured.")
+	}
+}
+
+// TestListMCPServersToolFormatsStatusAndError verifies the tool lists every
+// configured server with its transport, status, tool count, and — when
+// present — its last error, so the agent can answer "is Jira connected?"
+// without needing to hit the management API itself.
+func TestListMCPServersToolFormatsStatusAndError(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{
+		Enabled: true,
+		Servers: []mcppkg.ServerConfig{
+			{ID: "broken", Name: "Broken", Enabled: true, Transport: mcppkg.TransportStdio, Command: "false"},
+		},
+	})
+	mgr.Start(context.Background())
+
+	tool := listMCPServersTool{mgr: mgr}
+	res, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("Execute() OK = false, want true")
+	}
+	for _, want := range []string{"Broken", "broken", "stdio transport", "status=error", "tools=0", "last_error="} {
+		if !strings.Contains(res.Output, want) {
+			t.Errorf("Execute() output = %q, missing %q", res.Output, want)
+		}
+	}
+}
+
+// TestListMCPServersToolSpec verifies the exposed tool schema stays stable
+// (name and an empty-object parameter shape, since this tool takes no input).
+func TestListMCPServersToolSpec(t *testing.T) {
+	spec := listMCPServersTool{}.Spec()
+	if spec.Name != "list_mcp_servers" {
+		t.Fatalf("Spec().Name = %q, want %q", spec.Name, "list_mcp_servers")
+	}
+	if spec.Description == "" {
+		t.Fatal("Spec().Description is empty")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(spec.Parameters, &schema); err != nil {
+		t.Fatalf("Spec().Parameters is not valid JSON: %v", err)
+	}
+}
+
+// TestReconnectMCPServerToolNilManager verifies the reconnect tool also
+// degrades gracefully with no manager configured.
+func TestReconnectMCPServerToolNilManager(t *testing.T) {
+	tool := reconnectMCPServerTool{}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"server_id":"anything"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK {
+		t.Fatal("Execute() OK = true, want false (nil manager)")
+	}
+	if res.Output != "MCP is not configured" {
+		t.Fatalf("Execute() output = %q, want %q", res.Output, "MCP is not configured")
+	}
+}
+
+// TestReconnectMCPServerToolMissingServerID verifies the tool validates its
+// required input instead of forwarding an empty ID to the manager.
+func TestReconnectMCPServerToolMissingServerID(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{Enabled: true})
+	mgr.Start(context.Background())
+
+	tool := reconnectMCPServerTool{mgr: mgr}
+	for _, input := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"server_id":"   "}`),
+	} {
+		res, err := tool.Execute(context.Background(), input)
+		if err != nil {
+			t.Fatalf("Execute(%s) error = %v", input, err)
+		}
+		if res.OK {
+			t.Fatalf("Execute(%s) OK = true, want false", input)
+		}
+		if res.Output != "server_id is required" {
+			t.Fatalf("Execute(%s) output = %q, want %q", input, res.Output, "server_id is required")
+		}
+	}
+}
+
+// TestReconnectMCPServerToolInvalidJSON verifies malformed input surfaces as
+// a soft tool failure (OK=false) rather than an error/panic.
+func TestReconnectMCPServerToolInvalidJSON(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{Enabled: true})
+	mgr.Start(context.Background())
+
+	tool := reconnectMCPServerTool{mgr: mgr}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`not json`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK {
+		t.Fatal("Execute() OK = true, want false for invalid JSON input")
+	}
+	if !strings.Contains(res.Output, "invalid tool input") {
+		t.Fatalf("Execute() output = %q, want it to mention invalid input", res.Output)
+	}
+}
+
+// TestReconnectMCPServerToolUnknownServer verifies reconnecting an ID that
+// was never configured reports a clear "unknown server" failure rather than
+// a generic error, so the agent (or user) knows to re-check list_mcp_servers.
+func TestReconnectMCPServerToolUnknownServer(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{Enabled: true})
+	mgr.Start(context.Background())
+
+	tool := reconnectMCPServerTool{mgr: mgr}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"server_id":"ghost"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK {
+		t.Fatal("Execute() OK = true, want false for an unknown server")
+	}
+	if !strings.Contains(res.Output, "unknown server: ghost") {
+		t.Fatalf("Execute() output = %q, want it to mention unknown server", res.Output)
+	}
+}
+
+// TestReconnectMCPServerToolFailedReconnect verifies a reconnect attempt
+// against a server that fails to connect reports OK=false with the
+// underlying connect error surfaced as the output, so the agent can relay
+// the concrete failure reason to the user.
+func TestReconnectMCPServerToolFailedReconnect(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{
+		Enabled: true,
+		Servers: []mcppkg.ServerConfig{
+			{ID: "broken", Name: "Broken", Enabled: true, Transport: mcppkg.TransportStdio, Command: "false"},
+		},
+	})
+	mgr.Start(context.Background())
+
+	tool := reconnectMCPServerTool{mgr: mgr}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"server_id":"broken"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK {
+		t.Fatal("Execute() OK = true, want false (command always fails)")
+	}
+	if res.Output == "" {
+		t.Fatal("Execute() output is empty, want the underlying connect error")
+	}
+
+	// The server's cached status should also reflect the failure, so a
+	// follow-up list_mcp_servers call is consistent with this result.
+	for _, s := range mgr.ListServers() {
+		if s.ID == "broken" && s.Status != mcppkg.StatusError {
+			t.Errorf("server status = %q, want %q", s.Status, mcppkg.StatusError)
+		}
+	}
+}
+
+// TestReconnectMCPServerToolSpec verifies the exposed schema requires
+// server_id, since Execute depends on it being present.
+func TestReconnectMCPServerToolSpec(t *testing.T) {
+	spec := reconnectMCPServerTool{}.Spec()
+	if spec.Name != "reconnect_mcp_server" {
+		t.Fatalf("Spec().Name = %q, want %q", spec.Name, "reconnect_mcp_server")
+	}
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(spec.Parameters, &schema); err != nil {
+		t.Fatalf("Spec().Parameters is not valid JSON: %v", err)
+	}
+	found := false
+	for _, r := range schema.Required {
+		if r == "server_id" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Spec().Parameters required = %v, want it to include %q", schema.Required, "server_id")
+	}
+}
+
+// TestRegistryIncludesMCPManageToolsWhenMCPConfigured verifies NewRegistry
+// wires list_mcp_servers and reconnect_mcp_server whenever an MCP manager is
+// supplied via RegistryOptions.
+func TestRegistryIncludesMCPManageToolsWhenMCPConfigured(t *testing.T) {
+	mgr := mcppkg.NewManager(mcppkg.Config{Enabled: true})
+	mgr.Start(context.Background())
+
+	r := NewRegistry(t.TempDir(), RegistryOptions{MCP: mgr})
+	for _, name := range []string{"list_mcp_servers", "reconnect_mcp_server"} {
+		if !r.Has(name) {
+			t.Fatalf("registry missing %q", name)
+		}
+	}
+}
+
+// TestRegistryExcludesMCPManageToolsWhenMCPNotConfigured verifies the tools
+// are absent entirely (not just non-functional) when no MCP manager is
+// passed to NewRegistry, keeping the tool list clean for workspaces without
+// MCP configured.
+func TestRegistryExcludesMCPManageToolsWhenMCPNotConfigured(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+	for _, name := range []string{"list_mcp_servers", "reconnect_mcp_server"} {
+		if r.Has(name) {
+			t.Fatalf("registry should not include %q without an MCP manager", name)
+		}
+	}
+}

--- a/cometmind/internal/tools/mcp_tool.go
+++ b/cometmind/internal/tools/mcp_tool.go
@@ -5,10 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	mcppkg "github.com/cometline/cometmind/internal/mcp"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// mcpCallToolTimeout bounds a single MCP tool call, mirroring the timeout
+// pattern used by other built-in tools (grep.go, runcommand.go, webfetch.go).
+// Without this, a zombie MCP session (see internal/mcp keepalive handling)
+// could otherwise hang for the full duration of the parent turn's context.
+const mcpCallToolTimeout = 60 * time.Second
 
 type mcpTool struct {
 	serverID    string
@@ -62,7 +69,9 @@ func (t mcpTool) Execute(ctx context.Context, input json.RawMessage) (Result, er
 			return Result{OK: false, Output: "invalid tool input: " + err.Error()}, nil
 		}
 	}
-	res, err := t.session.CallTool(ctx, &mcp.CallToolParams{
+	callCtx, cancel := context.WithTimeout(ctx, mcpCallToolTimeout)
+	defer cancel()
+	res, err := t.session.CallTool(callCtx, &mcp.CallToolParams{
 		Name:      t.toolName,
 		Arguments: args,
 	})

--- a/cometmind/internal/tools/registry.go
+++ b/cometmind/internal/tools/registry.go
@@ -69,6 +69,8 @@ func NewRegistry(workspaceRoot string, opts ...RegistryOptions) *Registry {
 		}
 	}
 	if opt.MCP != nil {
+		add(listMCPServersTool{mgr: opt.MCP})
+		add(reconnectMCPServerTool{mgr: opt.MCP})
 		for _, tool := range mcpToolsFromManager(opt.MCP) {
 			add(tool)
 		}


### PR DESCRIPTION
- Introduced a default keepalive interval for MCP sessions to proactively detect dead connections.
- Added a generation tracking mechanism in the manager to handle connection state changes safely.
- Implemented a bounded automatic reconnect strategy for handling unexpected session closures.
- Set a timeout for MCP tool calls to prevent hanging sessions during execution.
