### PR TITLE
[main] feat: harden job completion and add scheduled job agent tools

### DIFF
--- a/cometline/src/lib/jobs/build-job-execution-prompt.test.ts
+++ b/cometline/src/lib/jobs/build-job-execution-prompt.test.ts
@@ -11,18 +11,21 @@ describe('buildJobExecutionPrompt', () => {
 		expect(prompt).toContain('Please work on: Fix auth');
 		expect(prompt).toContain('Definition of done: tests pass');
 		expect(prompt).toContain('after each meaningful milestone');
+		expect(prompt).toContain('protocol violation');
 		expect(prompt).toContain('job_id "job-1"');
 		expect(prompt).not.toContain('Previous progress');
 	});
 
-	it('includes previous progress when present', () => {
+	it('includes resume-first protocol when progress is present', () => {
 		const prompt = buildJobExecutionPrompt({
 			id: 'job-2',
 			description: 'Ship feature',
 			progress: 'Middleware done; tests red.'
 		});
-		expect(prompt).toContain('Previous progress (from an earlier attempt):');
+		expect(prompt).toContain('Previous progress (authoritative resume state):');
 		expect(prompt).toContain('Middleware done; tests red.');
-		expect(prompt).toContain('Continue from here.');
+		expect(prompt).toContain('Resume protocol (mandatory order):');
+		expect(prompt).toContain('call complete_job immediately');
+		expect(prompt).not.toContain('Continue from here.');
 	});
 });

--- a/cometline/src/lib/jobs/build-job-execution-prompt.ts
+++ b/cometline/src/lib/jobs/build-job-execution-prompt.ts
@@ -6,8 +6,8 @@ export type JobExecutionPromptInput = Pick<JobResource, 'id' | 'description'> &
 export function buildJobExecutionPrompt(job: JobExecutionPromptInput): string {
 	const dod = job.definition_of_done?.trim() || '(none specified)';
 	const progress = job.progress?.trim();
-	const progressBlock = progress
-		? `\nPrevious progress (from an earlier attempt):\n${progress}\n\nContinue from here.\n`
-		: '';
-	return `Please work on: ${job.description}\n\nDefinition of done: ${dod}${progressBlock}\nWhile working, call update_job with progress after each meaningful milestone (and before long tool runs) so another session can resume if this one stops. When finished, call complete_job with a final progress summary.\n\n(Use job_id "${job.id}" when calling job tools.)`;
+	if (progress) {
+		return `Please work on: ${job.description}\n\nDefinition of done: ${dod}\n\nPrevious progress (authoritative resume state):\n${progress}\n\nResume protocol (mandatory order):\n1. If previous progress already satisfies Definition of Done, call complete_job immediately with a final summary. Do NOT re-do finished work and stop on text only.\n2. Otherwise continue ONLY remaining work, call update_job with progress after each meaningful milestone, then complete_job or release_job.\n3. Ending without complete_job or release_job is a protocol violation.\n\n(Use job_id "${job.id}" when calling job tools.)`;
+	}
+	return `Please work on: ${job.description}\n\nDefinition of done: ${dod}\n\nWhile working, call update_job with progress after each meaningful milestone (and before long tool runs) so another session can resume if this one stops. When finished, call complete_job with a final progress summary. Ending without complete_job or release_job is a protocol violation.\n\n(Use job_id "${job.id}" when calling job tools.)`;
 }

--- a/cometmind/README.md
+++ b/cometmind/README.md
@@ -94,7 +94,8 @@ Registered per workspace in `internal/tools/registry.go`:
 | `promote_skill_draft` | Promote a draft into the managed skills directory |
 | `delegate_coding_task` | Spawn an ACP child session (sync or async) |
 | `spawn_general_agent` / `wait_subagents` | Launch and wait for general subagents |
-| `list_jobs`, `create_job`, `claim_job`, `update_job`, `complete_job`, `release_job`, `propose_job` | Interact with durable jobs |
+| `list_jobs`, `create_job`, `claim_job`, `update_job`, `complete_job`, `release_job`, `propose_job` | Interact with durable immediate jobs |
+| `list_scheduled_jobs`, `create_scheduled_job`, `update_scheduled_job`, `delete_scheduled_job` | Create/list/edit/delete deferred or recurring schedules (`cron_expr` or `run_at`/`run_at_iso`); do not put schedules in a normal job's DoD |
 | `recall_task_outcome` | Retrieve remembered task outcomes |
 
 File tools are workspace-scoped through `internal/tools/sandbox/pathcheck.go`.

--- a/cometmind/internal/agent/job_progress_hook.go
+++ b/cometmind/internal/agent/job_progress_hook.go
@@ -11,22 +11,33 @@ import (
 
 const defaultJobProgressNudgeAfterTools = 3
 
+// defaultJobCompletionGateBudget is how many times the runner may refuse a
+// text-only stop and force another step while a session still holds an
+// ongoing job without complete_job/release_job.
+const defaultJobCompletionGateBudget = 2
+
 // OngoingJobLookup resolves the ongoing job assigned to a session, if any.
 type OngoingJobLookup interface {
 	JobForSession(ctx context.Context, sessionID string) (jobs.Job, bool, error)
 }
 
 // JobProgressTracker nudges the model to call update_job after several tool
-// calls without a progress write during an ongoing job turn.
+// calls without a progress write during an ongoing job turn, and enforces a
+// terminal job tool before a text-only stop is accepted.
 type JobProgressTracker struct {
-	JobID             string
-	SinceLastProgress int
-	active            bool
-	threshold         int
+	JobID                string
+	SinceLastProgress    int
+	active               bool
+	threshold            int
+	completionGateBudget int
+	completionGateUsed   int
 }
 
 func newJobProgressTracker(ctx context.Context, lookup OngoingJobLookup, sessionID string) *JobProgressTracker {
-	t := &JobProgressTracker{threshold: defaultJobProgressNudgeAfterTools}
+	t := &JobProgressTracker{
+		threshold:            defaultJobProgressNudgeAfterTools,
+		completionGateBudget: defaultJobCompletionGateBudget,
+	}
 	if lookup == nil || strings.TrimSpace(sessionID) == "" {
 		return t
 	}
@@ -37,6 +48,29 @@ func newJobProgressTracker(ctx context.Context, lookup OngoingJobLookup, session
 	t.JobID = job.ID
 	t.active = true
 	return t
+}
+
+// NeedsCompletionGate reports whether the turn still holds an ongoing job
+// that has not yet been completed or released via a terminal job tool.
+func (t *JobProgressTracker) NeedsCompletionGate() bool {
+	return t != nil && t.active && strings.TrimSpace(t.JobID) != ""
+}
+
+// TryConsumeCompletionGate returns true when the runner should refuse a
+// text-only stop and inject a completion-gate system block for another step.
+// Returns false when no job is held or the per-turn budget is exhausted.
+func (t *JobProgressTracker) TryConsumeCompletionGate() bool {
+	if !t.NeedsCompletionGate() {
+		return false
+	}
+	if t.completionGateBudget <= 0 {
+		t.completionGateBudget = defaultJobCompletionGateBudget
+	}
+	if t.completionGateUsed >= t.completionGateBudget {
+		return false
+	}
+	t.completionGateUsed++
+	return true
 }
 
 // ObserveTool records a tool call. It returns true when a progress nudge should
@@ -87,6 +121,19 @@ func FormatJobProgressNudgeBlock(jobID string) string {
 	}
 	return fmt.Sprintf(
 		"This session is working job %q. You have run several tools without updating job progress. Call `update_job` with a brief `progress` summary of what is done and what remains before continuing.",
+		jobID,
+	)
+}
+
+// FormatJobCompletionGateBlock returns a system-prompt block that forces a
+// terminal job tool before the turn may end.
+func FormatJobCompletionGateBlock(jobID string) string {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"PROTOCOL: This session still holds job %q. You may not end this turn with text only. Call `complete_job` with a final progress summary if Definition of Done is met, or `release_job` with a reason if it is not. Ending without one of those tools is a protocol violation.",
 		jobID,
 	)
 }

--- a/cometmind/internal/agent/job_progress_hook_test.go
+++ b/cometmind/internal/agent/job_progress_hook_test.go
@@ -86,3 +86,49 @@ func TestFormatJobProgressNudgeBlock(t *testing.T) {
 		t.Fatalf("block = %q, want update_job mention", block)
 	}
 }
+
+func TestJobProgressTracker_CompletionGateBudget(t *testing.T) {
+	t.Parallel()
+	tracker := &JobProgressTracker{
+		JobID:                "job-1",
+		active:               true,
+		completionGateBudget: defaultJobCompletionGateBudget,
+	}
+	if !tracker.NeedsCompletionGate() {
+		t.Fatal("expected active job to need completion gate")
+	}
+	if !tracker.TryConsumeCompletionGate() {
+		t.Fatal("first gate consume should succeed")
+	}
+	if !tracker.TryConsumeCompletionGate() {
+		t.Fatal("second gate consume should succeed")
+	}
+	if tracker.TryConsumeCompletionGate() {
+		t.Fatal("third gate consume should fail after budget")
+	}
+
+	tracker.ObserveTool("complete_job", json.RawMessage(`{"job_id":"job-1"}`))
+	if tracker.NeedsCompletionGate() {
+		t.Fatal("gate should be inactive after complete_job")
+	}
+	if tracker.TryConsumeCompletionGate() {
+		t.Fatal("inactive tracker must not consume gate")
+	}
+}
+
+func TestFormatJobCompletionGateBlock(t *testing.T) {
+	t.Parallel()
+	block := FormatJobCompletionGateBlock("job-xyz")
+	if block == "" {
+		t.Fatal("expected non-empty block")
+	}
+	if !strings.Contains(block, "job-xyz") {
+		t.Fatalf("block = %q, want job id", block)
+	}
+	if !strings.Contains(block, "complete_job") || !strings.Contains(block, "release_job") {
+		t.Fatalf("block = %q, want terminal tools", block)
+	}
+	if FormatJobCompletionGateBlock("") != "" {
+		t.Fatal("empty job id should yield empty block")
+	}
+}

--- a/cometmind/internal/agent/runner.go
+++ b/cometmind/internal/agent/runner.go
@@ -109,6 +109,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 	outputTruncationContinuations := 0
 	truncationContinue := false
 	jobProgressNudge := false
+	jobCompletionGate := false
 	jobTracker := newJobProgressTracker(ctx, r.Jobs, turn.ID)
 	subagentWaitNudge := false
 	pendingSubagentResults := ""
@@ -136,7 +137,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 			emitStatus(event.PhaseContinuing)
 		}
 
-		baseSystem := r.buildSystemPrompt(sess.ContextSummary, truncationContinue, jobProgressNudge, jobTracker.JobID, subagentWaitNudge, pendingSubagentResults)
+		baseSystem := r.buildSystemPrompt(sess.ContextSummary, truncationContinue, jobProgressNudge, jobCompletionGate, jobTracker.JobID, subagentWaitNudge, pendingSubagentResults)
 		if r.Compactor != nil && sess.ID != "" {
 			updated, err := r.Compactor.MaybeCompact(
 				ctx,
@@ -149,7 +150,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 			)
 			if err == nil {
 				sess = updated
-				baseSystem = r.buildSystemPrompt(sess.ContextSummary, truncationContinue, jobProgressNudge, jobTracker.JobID, subagentWaitNudge, pendingSubagentResults)
+				baseSystem = r.buildSystemPrompt(sess.ContextSummary, truncationContinue, jobProgressNudge, jobCompletionGate, jobTracker.JobID, subagentWaitNudge, pendingSubagentResults)
 			}
 		}
 
@@ -174,6 +175,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 		system := baseSystem
 		truncationContinue = false
 		jobProgressNudge = false
+		jobCompletionGate = false
 		if r.Memory != nil && r.Memory.Enabled() && steps == 0 {
 			decision := memory.DecideRetrieval(msgs)
 			logging.L().Info("memory.retrieve.policy", "session", turn.ID, "retrieve", decision.Retrieve, "reason", decision.Reason, "score", decision.Score, "text_bytes", decision.TextBytes)
@@ -318,6 +320,18 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 				steps++
 				continue
 			}
+			if jobTracker.TryConsumeCompletionGate() {
+				jobCompletionGate = true
+				logging.L().Info(
+					"agent.job_completion_gate",
+					"session", turn.ID,
+					"job_id", jobTracker.JobID,
+					"gate_used", jobTracker.completionGateUsed,
+					"gate_budget", jobTracker.completionGateBudget,
+				)
+				steps++
+				continue
+			}
 			return completeTurn()
 		}
 		if len(result.ToolCalls) == 0 {
@@ -341,6 +355,18 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 			} else if waited {
 				pendingSubagentResults = collected
 				subagentWaitNudge = false
+				steps++
+				continue
+			}
+			if jobTracker.TryConsumeCompletionGate() {
+				jobCompletionGate = true
+				logging.L().Info(
+					"agent.job_completion_gate",
+					"session", turn.ID,
+					"job_id", jobTracker.JobID,
+					"gate_used", jobTracker.completionGateUsed,
+					"gate_budget", jobTracker.completionGateBudget,
+				)
 				steps++
 				continue
 			}
@@ -492,7 +518,7 @@ func (r *Runner) systemPrompt() string {
 	return base + r.SkillIndex + r.JobIndex
 }
 
-func (r *Runner) buildSystemPrompt(contextSummary string, truncationContinue, jobProgressNudge bool, jobID string, subagentWaitNudge bool, pendingSubagentResults string) string {
+func (r *Runner) buildSystemPrompt(contextSummary string, truncationContinue, jobProgressNudge, jobCompletionGate bool, jobID string, subagentWaitNudge bool, pendingSubagentResults string) string {
 	base := r.systemPrompt()
 	var parts []string
 	if block := FormatSummaryPromptBlock(contextSummary); block != "" {
@@ -506,6 +532,11 @@ func (r *Runner) buildSystemPrompt(contextSummary string, truncationContinue, jo
 	}
 	if jobProgressNudge {
 		if block := FormatJobProgressNudgeBlock(jobID); block != "" {
+			parts = append(parts, block)
+		}
+	}
+	if jobCompletionGate {
+		if block := FormatJobCompletionGateBlock(jobID); block != "" {
 			parts = append(parts, block)
 		}
 	}

--- a/cometmind/internal/agent/runner_test.go
+++ b/cometmind/internal/agent/runner_test.go
@@ -704,15 +704,20 @@ func TestRunner_JobProgressNudgeInjectedAfterTools(t *testing.T) {
 		t.Fatalf("write hello.txt: %v", err)
 	}
 
+	// After the progress nudge step, the job completion gate refuses two more
+	// text-only stops before allowing the turn to end.
+	textStop := []cometsdk.Event{
+		cometsdk.TextDeltaEvent{Text: "done"},
+		cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+		cometsdk.DoneEvent{},
+	}
 	provider := &capturingSequentialFakeProvider{sequences: [][]cometsdk.Event{
 		toolStep("tc1", "read_file", `{"path":"hello.txt"}`),
 		toolStep("tc2", "read_file", `{"path":"hello.txt"}`),
 		toolStep("tc3", "read_file", `{"path":"hello.txt"}`),
-		{
-			cometsdk.TextDeltaEvent{Text: "done"},
-			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
-			cometsdk.DoneEvent{},
-		},
+		textStop,
+		textStop,
+		textStop,
 	}}
 
 	r := &Runner{
@@ -730,11 +735,12 @@ func TestRunner_JobProgressNudgeInjectedAfterTools(t *testing.T) {
 	if runErr != nil {
 		t.Fatalf("Run returned error: %v", runErr)
 	}
-	if provider.calls != 4 {
-		t.Fatalf("Stream called %d times, want 4", provider.calls)
+	// 3 tool steps + 1 progress-nudged stop + 2 completion-gate steps
+	if provider.calls != 6 {
+		t.Fatalf("Stream called %d times, want 6", provider.calls)
 	}
-	if len(provider.requests) < 4 {
-		t.Fatalf("captured %d requests, want 4", len(provider.requests))
+	if len(provider.requests) < 6 {
+		t.Fatalf("captured %d requests, want 6", len(provider.requests))
 	}
 
 	nudge := FormatJobProgressNudgeBlock("job-1")
@@ -745,6 +751,90 @@ func TestRunner_JobProgressNudgeInjectedAfterTools(t *testing.T) {
 		if strings.Contains(provider.requests[i].System, nudge) {
 			t.Fatalf("step %d system should not include nudge yet", i+1)
 		}
+	}
+	gate := FormatJobCompletionGateBlock("job-1")
+	if !strings.Contains(provider.requests[4].System, gate) {
+		t.Fatalf("step 5 system missing completion gate:\n%s", provider.requests[4].System)
+	}
+	if !strings.Contains(provider.requests[5].System, gate) {
+		t.Fatalf("step 6 system missing completion gate:\n%s", provider.requests[5].System)
+	}
+}
+
+func TestRunner_JobCompletionGateForcesTerminalToolPath(t *testing.T) {
+	dir := t.TempDir()
+	provider := &capturingSequentialFakeProvider{sequences: [][]cometsdk.Event{
+		{
+			cometsdk.TextDeltaEvent{Text: "I finished the work."},
+			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+			cometsdk.DoneEvent{},
+		},
+		{
+			cometsdk.TextDeltaEvent{Text: "still done"},
+			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+			cometsdk.DoneEvent{},
+		},
+		{
+			cometsdk.TextDeltaEvent{Text: "really done"},
+			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+			cometsdk.DoneEvent{},
+		},
+	}}
+
+	r := &Runner{
+		Provider: provider,
+		Sessions: &fakeStore{},
+		Registry: tools.NewRegistry(dir),
+		Jobs: &fakeOngoingJobLookup{
+			ok:  true,
+			job: jobs.Job{ID: "job-gate", Status: jobs.StatusOngoing},
+		},
+		MaxSteps: 10,
+	}
+
+	_, runErr := runAndDrain(t, r, session.AgentTurn{ID: "s-gate", ModelID: "m"})
+	if runErr != nil {
+		t.Fatalf("Run returned error: %v", runErr)
+	}
+	// First stop is gated twice, third stop ends the turn.
+	if provider.calls != 3 {
+		t.Fatalf("Stream called %d times, want 3", provider.calls)
+	}
+	gate := FormatJobCompletionGateBlock("job-gate")
+	if strings.Contains(provider.requests[0].System, gate) {
+		t.Fatal("first step should not include completion gate")
+	}
+	if !strings.Contains(provider.requests[1].System, gate) {
+		t.Fatalf("second step missing gate:\n%s", provider.requests[1].System)
+	}
+	if !strings.Contains(provider.requests[2].System, gate) {
+		t.Fatalf("third step missing gate:\n%s", provider.requests[2].System)
+	}
+}
+
+func TestRunner_JobCompletionGateSkippedWithoutOngoingJob(t *testing.T) {
+	dir := t.TempDir()
+	provider := &capturingSequentialFakeProvider{sequences: [][]cometsdk.Event{
+		{
+			cometsdk.TextDeltaEvent{Text: "hello"},
+			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+			cometsdk.DoneEvent{},
+		},
+	}}
+
+	r := &Runner{
+		Provider: provider,
+		Sessions: &fakeStore{},
+		Registry: tools.NewRegistry(dir),
+		Jobs:     &fakeOngoingJobLookup{ok: false},
+	}
+
+	_, runErr := runAndDrain(t, r, session.AgentTurn{ID: "s-plain", ModelID: "m"})
+	if runErr != nil {
+		t.Fatalf("Run returned error: %v", runErr)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("Stream called %d times, want 1 (no gate without job)", provider.calls)
 	}
 }
 

--- a/cometmind/internal/autonomy/worker.go
+++ b/cometmind/internal/autonomy/worker.go
@@ -193,7 +193,10 @@ func (w *Worker) finalizeJob(ctx context.Context, job jobs.Job, sess session.Ses
 		return
 	}
 	if ok && current.ID == job.ID && current.Status == jobs.StatusOngoing {
-		reason := "worker: run ended without explicit completion"
+		// Deterministic safety net: after the runner's hard completion gate is
+		// exhausted (or the turn crashed), still-ongoing means the model never
+		// issued a terminal job tool. Progress is preserved for resume.
+		reason := "worker: run ended without terminal job tool (complete_job/release_job)"
 		if runErr != nil {
 			reason = fmt.Sprintf("worker: run ended with error: %v", runErr)
 		}

--- a/cometmind/internal/autonomy/worker_test.go
+++ b/cometmind/internal/autonomy/worker_test.go
@@ -175,11 +175,13 @@ func TestWorkerRunJobReleasesWhenAgentDoesNotCompleteJob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// MaxSteps must exceed the runner completion-gate budget so a text-only
+	// model exhausts the gate and hits the worker finalize path cleanly.
 	w := newWorker(t, fx, &staticProvider{}, config.AutonomousJobsConfig{
 		Enabled:             true,
 		MaxConcurrent:       1,
 		PollIntervalSeconds: 1,
-		MaxStepsPerRun:      2,
+		MaxStepsPerRun:      10,
 	})
 
 	w.runJob(ctx, job)
@@ -211,7 +213,7 @@ func TestWorkerRunJobReleasesWhenAgentDoesNotCompleteJob(t *testing.T) {
 	}
 	var sawFailure bool
 	for _, ev := range events {
-		if ev.Action == jobs.EventFailed && ev.Detail == "worker: run ended without explicit completion" {
+		if ev.Action == jobs.EventFailed && ev.Detail == "worker: run ended without terminal job tool (complete_job/release_job)" {
 			sawFailure = true
 		}
 	}

--- a/cometmind/internal/jobs/execution_prompt.go
+++ b/cometmind/internal/jobs/execution_prompt.go
@@ -14,13 +14,23 @@ func ExecutionPrompt(job Job) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Please work on: %s\n\nDefinition of done: %s\n", job.Description, dod)
 	if progress := strings.TrimSpace(job.Progress); progress != "" {
-		b.WriteString("\nPrevious progress (from an earlier attempt):\n")
+		b.WriteString("\nPrevious progress (authoritative resume state):\n")
 		b.WriteString(progress)
-		b.WriteString("\n\nContinue from here.\n")
+		b.WriteString("\n\nResume protocol (mandatory order):\n")
+		b.WriteString("1. If previous progress already satisfies Definition of Done, call `complete_job` immediately with a final summary. Do NOT re-do finished work and stop on text only.\n")
+		b.WriteString("2. Otherwise continue ONLY remaining work, call `update_job` with `progress` after each meaningful milestone, then `complete_job` or `release_job`.\n")
+		b.WriteString("3. Ending without `complete_job` or `release_job` is a protocol violation.\n")
+	} else {
+		fmt.Fprintf(
+			&b,
+			"\nWhile working, call `update_job` with `progress` after each meaningful milestone (and before long tool runs) so another session can resume if this one stops. When finished, call `complete_job` with a final progress summary. Ending without `complete_job` or `release_job` is a protocol violation.\n\n(Use job_id %q when calling job tools.)",
+			job.ID,
+		)
+		return b.String()
 	}
 	fmt.Fprintf(
 		&b,
-		"\nWhile working, call `update_job` with `progress` after each meaningful milestone (and before long tool runs) so another session can resume if this one stops. When finished, call `complete_job` with a final progress summary.\n\n(Use job_id %q when calling job tools.)",
+		"\n(Use job_id %q when calling job tools.)",
 		job.ID,
 	)
 	return b.String()

--- a/cometmind/internal/jobs/execution_prompt_test.go
+++ b/cometmind/internal/jobs/execution_prompt_test.go
@@ -26,6 +26,9 @@ func TestExecutionPromptWithoutProgress(t *testing.T) {
 	if !strings.Contains(got, "after each meaningful milestone") {
 		t.Fatalf("missing periodic update guidance: %q", got)
 	}
+	if !strings.Contains(got, "protocol violation") {
+		t.Fatalf("missing protocol violation guidance: %q", got)
+	}
 	if !strings.Contains(got, `job_id "job-1"`) {
 		t.Fatalf("missing job id: %q", got)
 	}
@@ -38,13 +41,19 @@ func TestExecutionPromptWithProgress(t *testing.T) {
 		Description: "Ship feature",
 		Progress:    "Updated middleware; tests still failing.",
 	})
-	if !strings.Contains(got, "Previous progress (from an earlier attempt):") {
+	if !strings.Contains(got, "Previous progress (authoritative resume state):") {
 		t.Fatalf("missing progress header: %q", got)
 	}
 	if !strings.Contains(got, "Updated middleware; tests still failing.") {
 		t.Fatalf("missing progress body: %q", got)
 	}
-	if !strings.Contains(got, "Continue from here.") {
-		t.Fatalf("missing continue hint: %q", got)
+	if !strings.Contains(got, "Resume protocol (mandatory order):") {
+		t.Fatalf("missing resume protocol: %q", got)
+	}
+	if !strings.Contains(got, "call `complete_job` immediately") {
+		t.Fatalf("missing resume-first complete guidance: %q", got)
+	}
+	if strings.Contains(got, "Continue from here.") {
+		t.Fatalf("legacy continue hint should be gone: %q", got)
 	}
 }

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -534,6 +534,7 @@ func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry sk
 		MCP:                r.mcpMgr,
 		Orchestrator:       r.SubagentOrchestrator(),
 		Jobs:               r.Jobs,
+		Scheduler:          r.Scheduler,
 		Memory:             r.Memory,
 		SessionID:          sessionID,
 		JobPlatform:        platform,

--- a/cometmind/internal/tools/job_tools.go
+++ b/cometmind/internal/tools/job_tools.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 
 	"github.com/cometline/cometmind/internal/jobs"
+	"github.com/cometline/cometmind/internal/scheduler"
 )
 
-// JobsDeps provides job queue operations to agent tools.
+// JobsDeps provides job queue and scheduled-job operations to agent tools.
 type JobsDeps struct {
 	Service              *jobs.Service
+	Scheduler            *scheduler.Service
 	SessionID            string
 	SessionWorkspacePath string
 	SourcePlatform       string
@@ -71,8 +73,10 @@ type createJobTool struct {
 
 func (createJobTool) Spec() ToolSpec {
 	return ToolSpec{
-		Name:        "create_job",
-		Description: "Create a global todo job for later execution by any session.",
+		Name: "create_job",
+		Description: "Create an immediate todo job on the global queue for soon or manual claim. " +
+			"Do not use for delayed, tomorrow, or recurring work — use create_scheduled_job with cron_expr or run_at/run_at_iso instead. " +
+			"Never put schedule/time/cron only in description or definition_of_done.",
 		Parameters: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -337,21 +341,28 @@ func JobPromptIndex(sessionWorkspace, platform string) string {
 	if ws != "" {
 		wsLine = fmt.Sprintf(" Current session workspace: `%s`.", ws)
 	}
+	const scheduleGuide = "\n\n### Jobs vs scheduled jobs\n" +
+		"- Immediate work / put on the queue now → `propose_job` / `create_job`.\n" +
+		"- Run later or on a recurring schedule → `create_scheduled_job` with `cron_expr` or `run_at`/`run_at_iso` (never encode time/cron only in definition_of_done of a normal job).\n" +
+		"- Inspect / change schedules with `list_scheduled_jobs`, `update_scheduled_job`, `delete_scheduled_job` (pause with enabled=false).\n" +
+		"- `definition_of_done` is success criteria for the work, not the schedule."
 	if platform == jobs.PlatformDiscord {
 		return fmt.Sprintf(
-			"\n\n## Global Jobs\nUse `list_jobs` when the user asks about pending work. When the user wants to create a job, call `propose_job` first — Discord will post a workspace selection message with a dropdown and Confirm/Cancel buttons. Tell the user to use that message (or `/create-job`) to pick a workspace. Use `create_job` directly only when the user already named the workspace in the same message.%s To execute a job, `claim_job` first or use `/jobs`. While working a claimed job, call `update_job` with `progress` after each meaningful milestone. Call `complete_job` when done or `release_job` to abandon.",
+			"\n\n## Global Jobs\nUse `list_jobs` when the user asks about pending work. When the user wants to create a job, call `propose_job` first — Discord will post a workspace selection message with a dropdown and Confirm/Cancel buttons. Tell the user to use that message (or `/create-job`) to pick a workspace. Use `create_job` directly only when the user already named the workspace in the same message.%s To execute a job, `claim_job` first or use `/jobs`. While working a claimed job, call `update_job` with `progress` after each meaningful milestone. Call `complete_job` when done or `release_job` to abandon.%s",
 			wsLine,
+			scheduleGuide,
 		)
 	}
 	return fmt.Sprintf(
-		"\n\n## Global Jobs\nUse `list_jobs` when the user asks about pending work. When the user wants to create a job, call `propose_job` first so they can confirm the workspace in chat — do not call `create_job` directly unless the user already specified the workspace in the same message. Use `create_job` only after workspace is confirmed or explicitly stated.%s The chat UI pre-fills the current session workspace. To execute a job, `claim_job` first. While working a claimed job, call `update_job` with `progress` after each meaningful milestone so another session can resume. Call `complete_job` when done or `release_job` to abandon.",
+		"\n\n## Global Jobs\nUse `list_jobs` when the user asks about pending work. When the user wants to create a job, call `propose_job` first so they can confirm the workspace in chat — do not call `create_job` directly unless the user already specified the workspace in the same message. Use `create_job` only after workspace is confirmed or explicitly stated.%s The chat UI pre-fills the current session workspace. To execute a job, `claim_job` first. While working a claimed job, call `update_job` with `progress` after each meaningful milestone so another session can resume. Call `complete_job` when done or `release_job` to abandon.%s",
 		wsLine,
+		scheduleGuide,
 	)
 }
 
-// RegisterJobTools adds job tools when deps are configured.
+// RegisterJobTools adds job and scheduled-job tools when deps are configured.
 func RegisterJobTools(r *Registry, deps JobsDeps) {
-	if deps.Service == nil {
+	if r == nil {
 		return
 	}
 	add := func(t Tool) {
@@ -359,11 +370,19 @@ func RegisterJobTools(r *Registry, deps JobsDeps) {
 		r.byName[spec.Name] = t
 		r.order = append(r.order, t)
 	}
-	add(listJobsTool{deps: deps})
-	add(proposeJobTool{deps: deps})
-	add(createJobTool{deps: deps})
-	add(claimJobTool{deps: deps})
-	add(updateJobTool{deps: deps})
-	add(completeJobTool{deps: deps})
-	add(releaseJobTool{deps: deps})
+	if deps.Service != nil {
+		add(listJobsTool{deps: deps})
+		add(proposeJobTool{deps: deps})
+		add(createJobTool{deps: deps})
+		add(claimJobTool{deps: deps})
+		add(updateJobTool{deps: deps})
+		add(completeJobTool{deps: deps})
+		add(releaseJobTool{deps: deps})
+	}
+	if deps.Scheduler != nil {
+		add(listScheduledJobsTool{deps: deps})
+		add(createScheduledJobTool{deps: deps})
+		add(updateScheduledJobTool{deps: deps})
+		add(deleteScheduledJobTool{deps: deps})
+	}
 }

--- a/cometmind/internal/tools/options.go
+++ b/cometmind/internal/tools/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cometline/cometmind/internal/jobs"
 	mcppkg "github.com/cometline/cometmind/internal/mcp"
 	"github.com/cometline/cometmind/internal/memory"
+	"github.com/cometline/cometmind/internal/scheduler"
 	"github.com/cometline/cometmind/internal/session"
 	"github.com/cometline/cometmind/internal/skills"
 	"github.com/cometline/cometmind/internal/subagent"
@@ -32,6 +33,7 @@ type RegistryOptions struct {
 	RunnerFactory      ChildRunnerFactory
 	SubagentConfig     SubagentToolConfig
 	Jobs               *jobs.Service
+	Scheduler          *scheduler.Service
 	Memory             *memory.Service
 	SessionID          string
 	JobPlatform        string

--- a/cometmind/internal/tools/registry.go
+++ b/cometmind/internal/tools/registry.go
@@ -75,9 +75,10 @@ func NewRegistry(workspaceRoot string, opts ...RegistryOptions) *Registry {
 			add(tool)
 		}
 	}
-	if opt.Jobs != nil {
+	if opt.Jobs != nil || opt.Scheduler != nil {
 		RegisterJobTools(r, JobsDeps{
 			Service:              opt.Jobs,
+			Scheduler:            opt.Scheduler,
 			SessionID:            opt.SessionID,
 			SessionWorkspacePath: workspaceRoot,
 			SourcePlatform:       opt.JobPlatform,

--- a/cometmind/internal/tools/scheduled_job_tools.go
+++ b/cometmind/internal/tools/scheduled_job_tools.go
@@ -1,0 +1,310 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cometline/cometmind/internal/jobs"
+	"github.com/cometline/cometmind/internal/scheduler"
+)
+
+type listScheduledJobsTool struct{ deps JobsDeps }
+
+func (listScheduledJobsTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "list_scheduled_jobs",
+		Description: "List deferred/recurring scheduled jobs (cron or one-shot). Use this to inspect existing schedules; use list_jobs for the immediate work queue.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
+func (t listScheduledJobsTool) Execute(ctx context.Context, _ json.RawMessage) (Result, error) {
+	if t.deps.Scheduler == nil {
+		return Result{OK: false, Output: "scheduler service unavailable"}, nil
+	}
+	items, err := t.deps.Scheduler.List(ctx)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if len(items) == 0 {
+		return Result{OK: true, Output: "No scheduled jobs found."}, nil
+	}
+	var b strings.Builder
+	for _, j := range items {
+		fmt.Fprintf(&b, "- %s [enabled=%v] %s\n", j.ID, j.Enabled, j.Description)
+		if j.DefinitionOfDone != "" {
+			fmt.Fprintf(&b, "  DoD: %s\n", j.DefinitionOfDone)
+		}
+		if j.CronExpr != "" {
+			fmt.Fprintf(&b, "  schedule: cron %q\n", j.CronExpr)
+		} else if j.RunAt != nil {
+			fmt.Fprintf(&b, "  schedule: one-shot run_at=%d (%s)\n", *j.RunAt, formatMillis(*j.RunAt))
+		}
+		fmt.Fprintf(&b, "  next_run_at=%d (%s)\n", j.NextRunAt, formatMillis(j.NextRunAt))
+		if j.WorkspacePath != "" {
+			fmt.Fprintf(&b, "  workspace: %s\n", j.WorkspacePath)
+		}
+	}
+	return Result{OK: true, Output: strings.TrimSpace(b.String())}, nil
+}
+
+type createScheduledJobTool struct{ deps JobsDeps }
+
+func (createScheduledJobTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name: "create_scheduled_job",
+		Description: "Create a scheduled job (one-shot or recurring). Use for delayed or cron work — not create_job. " +
+			"Schedule only via cron_expr or run_at/run_at_iso (mutually exclusive). " +
+			"description is the work to do when it fires; definition_of_done is success criteria, not the schedule. " +
+			"When due, CometMind materializes a normal queue job automatically. Prefer run_at_iso with timezone offset (e.g. 2026-07-10T15:00:00+08:00).",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"description":{"type":"string","description":"Work to perform when the schedule fires (not the schedule itself)"},
+				"definition_of_done":{"type":"string","description":"Success criteria for the work, not time/cron"},
+				"workspace_path":{"type":"string"},
+				"cron_expr":{"type":"string","description":"Standard 5-field cron (minute hour day month weekday). Mutually exclusive with run_at/run_at_iso."},
+				"run_at":{"type":"integer","description":"One-shot Unix time in milliseconds. Mutually exclusive with cron_expr and run_at_iso."},
+				"run_at_iso":{"type":"string","description":"One-shot RFC3339/RFC3339Nano timestamp (prefer with offset). Mutually exclusive with cron_expr and run_at."}
+			},
+			"required":["description"]
+		}`),
+	}
+}
+
+func (t createScheduledJobTool) Execute(ctx context.Context, input json.RawMessage) (Result, error) {
+	if t.deps.Scheduler == nil {
+		return Result{OK: false, Output: "scheduler service unavailable"}, nil
+	}
+	var in struct {
+		Description      string `json:"description"`
+		DefinitionOfDone string `json:"definition_of_done"`
+		WorkspacePath    string `json:"workspace_path"`
+		CronExpr         string `json:"cron_expr"`
+		RunAt            int64  `json:"run_at"`
+		RunAtISO         string `json:"run_at_iso"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return Result{}, err
+	}
+	cronExpr := strings.TrimSpace(in.CronExpr)
+	runAt, err := parseScheduledRunAt(in.RunAt, in.RunAtISO)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if cronExpr != "" && runAt > 0 {
+		return Result{OK: false, Output: "provide either cron_expr or run_at/run_at_iso, not both"}, nil
+	}
+	if cronExpr == "" && runAt <= 0 {
+		return Result{OK: false, Output: "either cron_expr or run_at/run_at_iso is required"}, nil
+	}
+
+	platform := strings.TrimSpace(t.deps.SourcePlatform)
+	if platform == "" {
+		platform = jobs.PlatformDesktop
+	}
+	workspacePath := strings.TrimSpace(in.WorkspacePath)
+	if workspacePath == "" {
+		workspacePath = strings.TrimSpace(t.deps.SessionWorkspacePath)
+	}
+
+	item, err := t.deps.Scheduler.Create(ctx, scheduler.CreateInput{
+		Description:      in.Description,
+		DefinitionOfDone: in.DefinitionOfDone,
+		WorkspacePath:    workspacePath,
+		CreatedBy:        scheduler.CreatedByAgent,
+		SourceSessionID:  t.deps.SessionID,
+		SourcePlatform:   platform,
+		SourceChannelID:  t.deps.SourceChannelID,
+		CronExpr:         cronExpr,
+		RunAt:            runAt,
+	})
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+
+	return Result{OK: true, Output: formatScheduledJobResult("Created", item)}, nil
+}
+
+type updateScheduledJobTool struct{ deps JobsDeps }
+
+func (updateScheduledJobTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name: "update_scheduled_job",
+		Description: "Update an existing scheduled job (description, DoD, workspace, schedule, or enabled). " +
+			"Omit fields you do not want to change. To change the schedule, set either cron_expr or run_at/run_at_iso (not both). " +
+			"Set enabled=false to pause without deleting. Use list_scheduled_jobs to find the scheduled_job_id.",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"scheduled_job_id":{"type":"string","description":"ID of the scheduled job to update"},
+				"description":{"type":"string","description":"Work to perform when the schedule fires"},
+				"definition_of_done":{"type":"string","description":"Success criteria for the work, not time/cron"},
+				"workspace_path":{"type":"string"},
+				"cron_expr":{"type":"string","description":"Standard 5-field cron. Mutually exclusive with run_at/run_at_iso."},
+				"run_at":{"type":"integer","description":"One-shot Unix milliseconds. Mutually exclusive with cron_expr and run_at_iso."},
+				"run_at_iso":{"type":"string","description":"One-shot RFC3339 timestamp. Mutually exclusive with cron_expr and run_at."},
+				"enabled":{"type":"boolean","description":"false pauses the schedule; true re-enables it"}
+			},
+			"required":["scheduled_job_id"]
+		}`),
+	}
+}
+
+func (t updateScheduledJobTool) Execute(ctx context.Context, input json.RawMessage) (Result, error) {
+	if t.deps.Scheduler == nil {
+		return Result{OK: false, Output: "scheduler service unavailable"}, nil
+	}
+	var in struct {
+		ScheduledJobID   string `json:"scheduled_job_id"`
+		Description      string `json:"description"`
+		DefinitionOfDone string `json:"definition_of_done"`
+		WorkspacePath    string `json:"workspace_path"`
+		CronExpr         string `json:"cron_expr"`
+		RunAt            int64  `json:"run_at"`
+		RunAtISO         string `json:"run_at_iso"`
+		Enabled          *bool  `json:"enabled"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return Result{}, err
+	}
+	id := strings.TrimSpace(in.ScheduledJobID)
+	if id == "" {
+		return Result{OK: false, Output: "scheduled_job_id is required"}, nil
+	}
+	current, err := t.deps.Scheduler.Get(ctx, id)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+
+	description := firstNonEmpty(in.Description, current.Description)
+	dod := firstNonEmpty(in.DefinitionOfDone, current.DefinitionOfDone)
+	workspace := firstNonEmpty(in.WorkspacePath, current.WorkspacePath)
+	enabled := current.Enabled
+	if in.Enabled != nil {
+		enabled = *in.Enabled
+	}
+
+	cronExpr := current.CronExpr
+	var runAt int64
+	if current.CronExpr == "" && current.RunAt != nil {
+		runAt = *current.RunAt
+	}
+	newCron := strings.TrimSpace(in.CronExpr)
+	newRunAt, err := parseScheduledRunAt(in.RunAt, in.RunAtISO)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if newCron != "" && newRunAt > 0 {
+		return Result{OK: false, Output: "provide either cron_expr or run_at/run_at_iso, not both"}, nil
+	}
+	if newCron != "" || newRunAt > 0 {
+		cronExpr = newCron
+		runAt = newRunAt
+	}
+
+	item, err := t.deps.Scheduler.Update(ctx, id, scheduler.UpdateInput{
+		Description:      description,
+		DefinitionOfDone: dod,
+		WorkspacePath:    workspace,
+		CronExpr:         cronExpr,
+		RunAt:            runAt,
+		Enabled:          enabled,
+	})
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	return Result{OK: true, Output: formatScheduledJobResult("Updated", item)}, nil
+}
+
+type deleteScheduledJobTool struct{ deps JobsDeps }
+
+func (deleteScheduledJobTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "delete_scheduled_job",
+		Description: "Permanently delete a scheduled job by id. Does not delete already-materialized queue jobs. Use list_scheduled_jobs to find the id; use update_scheduled_job with enabled=false to pause instead of delete.",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"scheduled_job_id":{"type":"string","description":"ID of the scheduled job to delete"}
+			},
+			"required":["scheduled_job_id"]
+		}`),
+	}
+}
+
+func (t deleteScheduledJobTool) Execute(ctx context.Context, input json.RawMessage) (Result, error) {
+	if t.deps.Scheduler == nil {
+		return Result{OK: false, Output: "scheduler service unavailable"}, nil
+	}
+	var in struct {
+		ScheduledJobID string `json:"scheduled_job_id"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return Result{}, err
+	}
+	id := strings.TrimSpace(in.ScheduledJobID)
+	if id == "" {
+		return Result{OK: false, Output: "scheduled_job_id is required"}, nil
+	}
+	if err := t.deps.Scheduler.Delete(ctx, id); err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	return Result{OK: true, Output: fmt.Sprintf("Deleted scheduled job %s", id)}, nil
+}
+
+func formatScheduledJobResult(verb string, item scheduler.ScheduledJob) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s scheduled job %s\n", verb, item.ID)
+	fmt.Fprintf(&b, "description: %s\n", item.Description)
+	if item.DefinitionOfDone != "" {
+		fmt.Fprintf(&b, "definition_of_done: %s\n", item.DefinitionOfDone)
+	}
+	if item.CronExpr != "" {
+		fmt.Fprintf(&b, "schedule: cron %q\n", item.CronExpr)
+	} else if item.RunAt != nil {
+		fmt.Fprintf(&b, "schedule: one-shot run_at=%d (%s)\n", *item.RunAt, formatMillis(*item.RunAt))
+	}
+	fmt.Fprintf(&b, "next_run_at: %d (%s)\n", item.NextRunAt, formatMillis(item.NextRunAt))
+	if item.WorkspacePath != "" {
+		fmt.Fprintf(&b, "workspace: %s\n", item.WorkspacePath)
+	}
+	fmt.Fprintf(&b, "enabled: %v", item.Enabled)
+	return b.String()
+}
+
+func firstNonEmpty(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+// parseScheduledRunAt resolves a one-shot time from unix milliseconds and/or ISO8601.
+// Returns 0 when neither is set. Rejects both set or invalid ISO.
+func parseScheduledRunAt(runAtMs int64, runAtISO string) (int64, error) {
+	runAtISO = strings.TrimSpace(runAtISO)
+	if runAtMs > 0 && runAtISO != "" {
+		return 0, fmt.Errorf("provide either run_at or run_at_iso, not both")
+	}
+	if runAtISO == "" {
+		return runAtMs, nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, runAtISO); err == nil {
+		return t.UnixMilli(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, runAtISO); err == nil {
+		return t.UnixMilli(), nil
+	}
+	return 0, fmt.Errorf("invalid run_at_iso %q: use RFC3339 with offset (e.g. 2026-07-10T15:00:00+08:00)", runAtISO)
+}
+
+func formatMillis(ms int64) string {
+	if ms <= 0 {
+		return "n/a"
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}

--- a/cometmind/internal/tools/scheduled_job_tools_test.go
+++ b/cometmind/internal/tools/scheduled_job_tools_test.go
@@ -1,0 +1,308 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cometline/cometmind/internal/db"
+	"github.com/cometline/cometmind/internal/jobs"
+	"github.com/cometline/cometmind/internal/scheduler"
+	_ "modernc.org/sqlite"
+)
+
+func testSchedulerService(t *testing.T) *scheduler.Service {
+	t.Helper()
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := db.EnsureSchema(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+	return scheduler.NewService(conn)
+}
+
+func TestParseScheduledRunAt(t *testing.T) {
+	t.Parallel()
+	ms, err := parseScheduledRunAt(1_700_000_000_000, "")
+	if err != nil || ms != 1_700_000_000_000 {
+		t.Fatalf("run_at only: ms=%d err=%v", ms, err)
+	}
+	iso := "2026-07-10T15:00:00+08:00"
+	ms, err = parseScheduledRunAt(0, iso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ms != want.UnixMilli() {
+		t.Fatalf("iso ms=%d want %d", ms, want.UnixMilli())
+	}
+	if _, err := parseScheduledRunAt(1, iso); err == nil {
+		t.Fatal("expected error when both set")
+	}
+	if _, err := parseScheduledRunAt(0, "not-a-time"); err == nil {
+		t.Fatal("expected invalid iso error")
+	}
+	ms, err = parseScheduledRunAt(0, "")
+	if err != nil || ms != 0 {
+		t.Fatalf("empty: ms=%d err=%v", ms, err)
+	}
+}
+
+func TestCreateScheduledJobTool_Cron(t *testing.T) {
+	svc := testSchedulerService(t)
+	tool := createScheduledJobTool{deps: JobsDeps{
+		Scheduler:            svc,
+		SessionID:            "sess-1",
+		SessionWorkspacePath: "/default/ws",
+		SourcePlatform:       jobs.PlatformDesktop,
+	}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"description":"health check",
+		"definition_of_done":"report written",
+		"cron_expr":"0 9 * * 1-5"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("expected ok, got %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "Created scheduled job") {
+		t.Fatalf("output=%q", res.Output)
+	}
+	if !strings.Contains(res.Output, `cron "0 9 * * 1-5"`) {
+		t.Fatalf("missing cron in output: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "workspace: /default/ws") {
+		t.Fatalf("missing default workspace: %q", res.Output)
+	}
+	items, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items=%d want 1", len(items))
+	}
+	if items[0].CreatedBy != scheduler.CreatedByAgent {
+		t.Fatalf("created_by=%q", items[0].CreatedBy)
+	}
+	if items[0].CronExpr != "0 9 * * 1-5" {
+		t.Fatalf("cron=%q", items[0].CronExpr)
+	}
+	if items[0].WorkspacePath != "/default/ws" {
+		t.Fatalf("workspace=%q", items[0].WorkspacePath)
+	}
+}
+
+func TestCreateScheduledJobTool_OneShotISO(t *testing.T) {
+	svc := testSchedulerService(t)
+	tool := createScheduledJobTool{deps: JobsDeps{Scheduler: svc, SessionID: "s1"}}
+	iso := "2030-01-15T12:00:00Z"
+	body, _ := json.Marshal(map[string]any{
+		"description": "summarize logs",
+		"run_at_iso":  iso,
+	})
+	res, err := tool.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("expected ok, got %q", res.Output)
+	}
+	items, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].RunAt == nil {
+		t.Fatalf("items=%+v", items)
+	}
+	want, _ := time.Parse(time.RFC3339, iso)
+	if *items[0].RunAt != want.UnixMilli() {
+		t.Fatalf("run_at=%d want %d", *items[0].RunAt, want.UnixMilli())
+	}
+}
+
+func TestCreateScheduledJobTool_RejectBothScheduleKinds(t *testing.T) {
+	svc := testSchedulerService(t)
+	tool := createScheduledJobTool{deps: JobsDeps{Scheduler: svc}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"description":"bad",
+		"cron_expr":"0 9 * * *",
+		"run_at":2000000
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatal("expected failure when both cron and run_at set")
+	}
+}
+
+func TestCreateScheduledJobTool_RequiresSchedule(t *testing.T) {
+	svc := testSchedulerService(t)
+	tool := createScheduledJobTool{deps: JobsDeps{Scheduler: svc}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"description":"no schedule"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatal("expected failure without schedule")
+	}
+}
+
+func TestListScheduledJobsTool(t *testing.T) {
+	svc := testSchedulerService(t)
+	if _, err := svc.Create(context.Background(), scheduler.CreateInput{
+		Description: "nightly",
+		CronExpr:    "0 2 * * *",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tool := listScheduledJobsTool{deps: JobsDeps{Scheduler: svc}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("expected ok, got %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "nightly") || !strings.Contains(res.Output, "cron") {
+		t.Fatalf("output=%q", res.Output)
+	}
+}
+
+func TestUpdateScheduledJobTool_PartialAndScheduleSwitch(t *testing.T) {
+	svc := testSchedulerService(t)
+	created, err := svc.Create(context.Background(), scheduler.CreateInput{
+		Description:      "nightly",
+		DefinitionOfDone: "done",
+		WorkspacePath:    "/ws",
+		CronExpr:         "0 2 * * *",
+		CreatedBy:        scheduler.CreatedByAgent,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tool := updateScheduledJobTool{deps: JobsDeps{Scheduler: svc}}
+
+	// Partial: description + pause
+	res, err := tool.Execute(context.Background(), json.RawMessage(fmt.Sprintf(`{
+		"scheduled_job_id":%q,
+		"description":"nightly health",
+		"enabled":false
+	}`, created.ID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("expected ok, got %q", res.Output)
+	}
+	got, err := svc.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Description != "nightly health" || got.Enabled || got.CronExpr != "0 2 * * *" {
+		t.Fatalf("partial update=%+v", got)
+	}
+
+	// Switch cron → one-shot
+	iso := "2031-06-01T10:00:00Z"
+	body, _ := json.Marshal(map[string]any{
+		"scheduled_job_id": created.ID,
+		"run_at_iso":       iso,
+		"enabled":          true,
+	})
+	res, err = tool.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("expected ok, got %q", res.Output)
+	}
+	got, err = svc.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := time.Parse(time.RFC3339, iso)
+	if got.CronExpr != "" || got.RunAt == nil || *got.RunAt != want.UnixMilli() || !got.Enabled {
+		t.Fatalf("schedule switch=%+v", got)
+	}
+}
+
+func TestUpdateScheduledJobTool_RequiresID(t *testing.T) {
+	svc := testSchedulerService(t)
+	tool := updateScheduledJobTool{deps: JobsDeps{Scheduler: svc}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"description":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatal("expected failure without scheduled_job_id")
+	}
+}
+
+func TestDeleteScheduledJobTool(t *testing.T) {
+	svc := testSchedulerService(t)
+	created, err := svc.Create(context.Background(), scheduler.CreateInput{
+		Description: "to delete",
+		CronExpr:    "0 3 * * *",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tool := deleteScheduledJobTool{deps: JobsDeps{Scheduler: svc}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(fmt.Sprintf(`{"scheduled_job_id":%q}`, created.ID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "Deleted") {
+		t.Fatalf("res=%+v", res)
+	}
+	if _, err := svc.Get(context.Background(), created.ID); err == nil {
+		t.Fatal("expected not found after delete")
+	}
+	// second delete fails
+	res, err = tool.Execute(context.Background(), json.RawMessage(fmt.Sprintf(`{"scheduled_job_id":%q}`, created.ID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatal("expected delete of missing id to fail")
+	}
+}
+
+func TestJobPromptIndexMentionsScheduledJobs(t *testing.T) {
+	idx := JobPromptIndex("/tmp/ws", "")
+	if !strings.Contains(idx, "create_scheduled_job") {
+		t.Fatalf("expected create_scheduled_job guidance, got %q", idx)
+	}
+	if !strings.Contains(idx, "list_scheduled_jobs") {
+		t.Fatalf("expected list_scheduled_jobs guidance, got %q", idx)
+	}
+	if !strings.Contains(idx, "update_scheduled_job") || !strings.Contains(idx, "delete_scheduled_job") {
+		t.Fatalf("expected update/delete guidance, got %q", idx)
+	}
+	if !strings.Contains(idx, "Jobs vs scheduled jobs") {
+		t.Fatalf("expected disambiguation section, got %q", idx)
+	}
+}
+
+func TestCreateJobToolDescriptionDisambiguates(t *testing.T) {
+	spec := createJobTool{}.Spec()
+	if !strings.Contains(spec.Description, "create_scheduled_job") {
+		t.Fatalf("create_job should point to create_scheduled_job: %q", spec.Description)
+	}
+	if !strings.Contains(spec.Description, "immediate") {
+		t.Fatalf("create_job should say immediate: %q", spec.Description)
+	}
+}


### PR DESCRIPTION
## Background

Autonomous jobs often finished real work and wrote progress, then failed with "run ended without explicit completion" because the model never called `complete_job`. Retries failed quickly for the same reason. Separately, agents could not create real schedules, so timed work was stuffed into a normal job's definition of done and never materialized by the scheduler.

[ff077e7](https://github.com/Cometline/cometline/commit/ff077e73032a3baa0eead82d0df6074cbf413dfd): The agent runner now refuses a text-only stop while a session still holds an ongoing job, injects a completion-gate system prompt for up to two extra steps, and only then lets the turn end so the worker can fail with a clearer terminal-tool reason. Execution prompts also resume from prior progress with a mandatory complete-or-continue protocol so retries do not narrate "already done" and stop without tools.

[1ad7c4f](https://github.com/Cometline/cometline/commit/1ad7c4fc6c3d7a080bebd19eede3c9a07627807b): Agents gain list, create, update, and delete tools for scheduled jobs (`cron_expr` or `run_at`/`run_at_iso`), wired through the scheduler service. `create_job` and the job prompt index steer timed or recurring work away from the immediate queue and keep schedules out of definition_of_done.