### PR TITLE
[main] feat: add gateway stop command

### DIFF
--- a/cometmind/cmd/gateway.go
+++ b/cometmind/cmd/gateway.go
@@ -106,6 +106,9 @@ func runGateway(_ *cobra.Command, _ []string) error {
 		adapter.SetClearHandler(func(ctx context.Context, msg gateway.InboundMessage) (string, error) {
 			return router.HandleClearSlash(ctx, msg)
 		})
+		adapter.SetStopHandler(func(ctx context.Context, msg gateway.InboundMessage) (string, error) {
+			return router.HandleStopSlash(ctx, msg)
+		})
 		adapter.SetWorkspaceSuggestHandler(func(ctx context.Context, query string) ([]string, error) {
 			return router.SuggestWorkspacePaths(ctx, query, 25)
 		})

--- a/cometmind/internal/gateway/discord/adapter.go
+++ b/cometmind/internal/gateway/discord/adapter.go
@@ -26,6 +26,7 @@ type Adapter struct {
 	onThread             func(context.Context, string, string, string) error
 	onChange             func(context.Context, gateway.InboundMessage, string) (string, error)
 	onClear              func(context.Context, gateway.InboundMessage) (string, error)
+	onStop               func(context.Context, gateway.InboundMessage) (string, error)
 	onSuggest            func(context.Context, string) ([]string, error)
 	onJobs               func(context.Context, gateway.InboundMessage, string) (string, string, error)
 	jobSuggest           func(context.Context, string) ([]jobs.Job, error)
@@ -102,6 +103,11 @@ func (a *Adapter) SetChangeWorkspaceHandler(fn func(context.Context, gateway.Inb
 // SetClearHandler registers the callback used for /clear slash commands.
 func (a *Adapter) SetClearHandler(fn func(context.Context, gateway.InboundMessage) (string, error)) {
 	a.onClear = fn
+}
+
+// SetStopHandler registers the callback used for /stop slash commands.
+func (a *Adapter) SetStopHandler(fn func(context.Context, gateway.InboundMessage) (string, error)) {
+	a.onStop = fn
 }
 
 // SetWorkspaceSuggestHandler registers autocomplete suggestions for /change path.
@@ -205,6 +211,10 @@ func applicationCommands() []*discordgo.ApplicationCommand {
 		{
 			Name:        "clear",
 			Description: "Clear this channel's CometMind conversation transcript",
+		},
+		{
+			Name:        "stop",
+			Description: "Stop the active CometMind turn in this channel",
 		},
 		{
 			Name:        "change",

--- a/cometmind/internal/gateway/discord/commands.go
+++ b/cometmind/internal/gateway/discord/commands.go
@@ -179,6 +179,21 @@ func (a *Adapter) handleClearCommand(s *discordgo.Session, i *discordgo.Interact
 	respondEphemeral(s, i, text)
 }
 
+func (a *Adapter) handleStopCommand(s *discordgo.Session, i *discordgo.InteractionCreate, _ discordgo.ApplicationCommandInteractionData) {
+	if a.onStop == nil {
+		respondEphemeral(s, i, "Stopping turns is not configured.")
+		return
+	}
+
+	msg := routingInboundMessage(s, i)
+	text, err := a.onStop(context.Background(), msg)
+	if err != nil {
+		respondEphemeral(s, i, fmt.Sprintf("Failed to stop turn: %v", err))
+		return
+	}
+	respondEphemeral(s, i, text)
+}
+
 func (a *Adapter) handleJobsCommand(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) {
 	jobID := ""
 	for _, opt := range data.Options {

--- a/cometmind/internal/gateway/discord/interactions.go
+++ b/cometmind/internal/gateway/discord/interactions.go
@@ -21,6 +21,8 @@ func (a *Adapter) onInteractionCreate(s *discordgo.Session, i *discordgo.Interac
 			a.handleCreateSkillCommand(s, i, data)
 		case "clear":
 			a.handleClearCommand(s, i, data)
+		case "stop":
+			a.handleStopCommand(s, i, data)
 		case "change":
 			a.handleChangeCommand(s, i, data)
 		case "jobs":

--- a/cometmind/internal/gateway/router.go
+++ b/cometmind/internal/gateway/router.go
@@ -128,6 +128,12 @@ func (r *Router) HandleInbound(ctx context.Context, msg InboundMessage) error {
 		}
 	})
 	var text string
+	if errors.Is(err, context.Canceled) {
+		// /stop intentionally cancels the runtime context. The slash command
+		// already acknowledges that action ephemerally, so do not emit a noisy
+		// provider cancellation error into the conversation channel.
+		return nil
+	}
 	if err != nil {
 		text = fmt.Sprintf("Error: %v", err)
 		logging.L().Error("gateway.agent_turn.failed",
@@ -314,6 +320,32 @@ func (r *Router) HandleClearSlash(ctx context.Context, msg InboundMessage) (stri
 		return "", err
 	}
 	return "Cleared this CometMind conversation transcript.", nil
+}
+
+// HandleStopSlash cancels the active turn for the session mapped to the
+// current platform channel or thread. It does not alter the transcript.
+func (r *Router) HandleStopSlash(ctx context.Context, msg InboundMessage) (string, error) {
+	if r == nil || r.Sessions == nil {
+		return "", fmt.Errorf("gateway router is not configured")
+	}
+	if !r.allowed(msg) {
+		return "", fmt.Errorf("not allowed")
+	}
+	if r.Turns == nil {
+		return "No active turn to stop.", nil
+	}
+
+	mapped, err := r.Sessions.LookupGatewaySession(ctx, msg.Platform, msg.UserID, msg.ChannelID, msg.ThreadID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "No active turn to stop.", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !r.Turns.Stop(mapped.CometmindSessionID) {
+		return "No active turn to stop.", nil
+	}
+	return "Stopping the active turn.", nil
 }
 
 // SuggestWorkspacePaths returns workspace roots matching query for autocomplete UIs.

--- a/cometmind/internal/gateway/run_tracker.go
+++ b/cometmind/internal/gateway/run_tracker.go
@@ -47,6 +47,17 @@ func (m *TurnRunTracker) Start(parent context.Context, sessionID string) (contex
 	return ctx, finish, nil
 }
 
+// Stop cancels the active turn for sessionID and reports whether one existed.
+func (m *TurnRunTracker) Stop(sessionID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	handle, ok := m.cancels[sessionID]
+	if ok {
+		handle.cancel()
+	}
+	return ok
+}
+
 // Running reports whether a session has an in-flight gateway turn.
 func (m *TurnRunTracker) Running(sessionID string) bool {
 	m.mu.Lock()

--- a/cometmind/internal/gateway/run_tracker_test.go
+++ b/cometmind/internal/gateway/run_tracker_test.go
@@ -1,0 +1,37 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTurnRunTrackerStopCancelsActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewTurnRunTracker()
+	ctx, finish, err := tracker.Start(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if !tracker.Stop("session-1") {
+		t.Fatal("Stop() = false, want true")
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("Stop() did not cancel the turn context")
+	}
+	finish()
+	if tracker.Stop("session-1") {
+		t.Fatal("second Stop() = true, want false")
+	}
+}
+
+func TestTurnRunTrackerStopMissingTurn(t *testing.T) {
+	t.Parallel()
+
+	if NewTurnRunTracker().Stop("missing") {
+		t.Fatal("Stop() = true for missing session")
+	}
+}


### PR DESCRIPTION
## Background

Gateway turns can run for a long time, but users need an explicit way to stop the active turn without changing the default message handling behavior.

[342e25d](https://github.com/Cometline/cometline/commit/342e25d3b83259883985be023b07fb20c4628993): Adds the Discord /stop slash command, routes it to the session-specific turn tracker, and keeps intentional context cancellation from producing a noisy channel error. The change leaves queueing and automatic follow-up interruption out of scope.