### PR TITLE
[main] feat: hot-reload settings and tidy cometmind data dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ make build            # Build SDK, CometMind binary, and Cometline renderer
 make package          # Build CometMind sidecar and package Electron app
 make dev              # Build CometMind sidecar and launch Electron dev app
 make port             # Show process listening on 127.0.0.1:7700
-make clean-log        # Remove ~/.cometmind/cometline.log
+make clean-log        # Remove ~/.cometmind/logs/cometline*.log
 ```
 
 ### Comet SDK (Go library)
@@ -120,7 +120,7 @@ Recent example: `memory_compaction_completed` was added this way to report manua
 
 ### CometMind
 
-- **Settings:** `~/.cometmind/cometline-settings.json` (created by `go run . init` or Cometline; managed by Settings UI)
+- **Settings:** `~/.cometmind/cometline-settings.json` (runtime; agent tools + CometMind). Desktop UI state: `~/.cometmind/cometline-desktop.json` (Electron only).
 - **Legacy config:** `~/.cometmind/config.toml` (read only when JSON settings are missing)
 - **Database:** `~/.cometmind/cometmind.db` (SQLite, pure Go via `modernc.org/sqlite`)
 - **API:** `http://127.0.0.1:7700` (localhost only)
@@ -142,11 +142,12 @@ go run . gateway run --platform discord # Start Discord gateway
 
 ### Desktop settings
 
-- **Location:** `~/.cometmind/cometline-settings.json`
-- **Managed via:** Settings UI in Cometline
-- **Contents:** Provider configs, active provider, appearance, shortcuts, app settings
+- **Location:** `~/.cometmind/cometline-settings.json` (runtime) + `~/.cometmind/cometline-desktop.json` (appearance/shortcuts/app)
+- **Managed via:** Settings UI in Cometline (Electron merges/splits both files)
+- **Contents (settings):** Provider configs, active provider, cometmind runtime
+- **Contents (desktop):** appearance, shortcuts, app/persona; agent tools never write this file
 
-Settings are synced to CometMind on save. The desktop app now prefers in-place reload for provider and many runtime changes, and falls back to restart when required (for example memory settings, memory provider changes, retention interval changes, job reconcile interval changes, or process-level changes such as host, port, and Discord token updates).
+Settings are synced to CometMind on save. The desktop app prefers in-place reload for provider and nearly all runtime changes (including memory, storage cleanup interval, jobs reconcile interval, and autonomy). Changes under `cometmind.gateway` recycle gateway process(es) only. Full main-sidecar restart remains for true process-level bind changes such as host and port.
 
 ## Key Features
 
@@ -338,7 +339,7 @@ Cometline can improve itself using the same agent runtime:
 
 ### Sidecar won't start
 
-- Check `~/.cometmind/cometline.log` for sidecar errors
+- Check `~/.cometmind/logs/cometline.log` for sidecar errors
 - Verify CometMind binary exists in `cometmind/dist/cometmind`
 - Run `make port` to see if port 7700 is already in use
 
@@ -365,7 +366,7 @@ Cometline can improve itself using the same agent runtime:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (10327 symbols, 28470 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (10327 symbols, 28474 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ make build            # Build SDK, CometMind binary, and Cometline renderer
 make package          # Build CometMind sidecar and package Electron app
 make dev              # Build CometMind sidecar and launch Electron dev app
 make port             # Show process listening on 127.0.0.1:7700
-make clean-log        # Remove ~/.cometmind/cometline.log
+make clean-log        # Remove ~/.cometmind/logs/cometline*.log
 ```
 
 ### Comet SDK (Go library)
@@ -120,7 +120,7 @@ Recent example: `memory_compaction_completed` was added this way to report manua
 
 ### CometMind
 
-- **Settings:** `~/.cometmind/cometline-settings.json` (created by `go run . init` or Cometline; managed by Settings UI)
+- **Settings:** `~/.cometmind/cometline-settings.json` (runtime; agent tools + CometMind). Desktop UI state: `~/.cometmind/cometline-desktop.json` (Electron only).
 - **Legacy config:** `~/.cometmind/config.toml` (read only when JSON settings are missing)
 - **Database:** `~/.cometmind/cometmind.db` (SQLite, pure Go via `modernc.org/sqlite`)
 - **API:** `http://127.0.0.1:7700` (localhost only)
@@ -142,11 +142,12 @@ go run . gateway run --platform discord # Start Discord gateway
 
 ### Desktop settings
 
-- **Location:** `~/.cometmind/cometline-settings.json`
-- **Managed via:** Settings UI in Cometline
-- **Contents:** Provider configs, active provider, appearance, shortcuts, app settings
+- **Location:** `~/.cometmind/cometline-settings.json` (runtime) + `~/.cometmind/cometline-desktop.json` (appearance/shortcuts/app)
+- **Managed via:** Settings UI in Cometline (Electron merges/splits both files)
+- **Contents (settings):** Provider configs, active provider, cometmind runtime
+- **Contents (desktop):** appearance, shortcuts, app/persona; agent tools never write this file
 
-Settings are synced to CometMind on save. The desktop app now prefers in-place reload for provider and many runtime changes, and falls back to restart when required (for example memory settings, memory provider changes, retention interval changes, job reconcile interval changes, or process-level changes such as host, port, and Discord token updates).
+Settings are synced to CometMind on save. The desktop app prefers in-place reload for provider and nearly all runtime changes (including memory, storage cleanup interval, jobs reconcile interval, and autonomy). Changes under `cometmind.gateway` recycle gateway process(es) only. Full main-sidecar restart remains for true process-level bind changes such as host and port.
 
 ## Key Features
 
@@ -338,7 +339,7 @@ Cometline can improve itself using the same agent runtime:
 
 ### Sidecar won't start
 
-- Check `~/.cometmind/cometline.log` for sidecar errors
+- Check `~/.cometmind/logs/cometline.log` for sidecar errors
 - Verify CometMind binary exists in `cometmind/dist/cometmind`
 - Run `make port` to see if port 7700 is already in use
 
@@ -365,7 +366,7 @@ Cometline can improve itself using the same agent runtime:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (10327 symbols, 28470 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (10327 symbols, 28474 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@printf "  make package          Build CometMind and package the Electron app\n"
 	@printf "  make dev              Build CometMind and launch Electron dev app\n"
 	@printf "  make port             Show process listening on 127.0.0.1:7700\n"
-	@printf "  make clean-log        Remove CometMind sidecar + gateway logs\n"
+	@printf "  make clean-log        Remove CometMind sidecar + gateway logs under ~/.cometmind/logs/\n"
 	@printf "\nmake dev reads all provider settings from ~/.cometmind/cometline-settings.json\n"
 	@printf "(configured in the in-app Settings panel). Optional one-off overrides:\n"
 	@printf "  COMETMIND_PROVIDER, COMETMIND_MODEL, COMETMIND_BASE_URL, COMETMIND_API_KEY\n"
@@ -94,5 +94,8 @@ port:
 	lsof -nP -iTCP:7700 -sTCP:LISTEN || true
 
 clean-log:
+	rm -f "$(HOME)/.cometmind/logs/cometline.log" "$(HOME)/.cometmind/logs/cometline.log.1"
+	rm -f "$(HOME)/.cometmind/logs/cometline-gateway.log" "$(HOME)/.cometmind/logs/cometline-gateway.log.1"
+	# Legacy root-level paths (pre-logs/ migration)
 	rm -f "$(HOME)/.cometmind/cometline.log" "$(HOME)/.cometmind/cometline.log.1"
 	rm -f "$(HOME)/.cometmind/cometline-gateway.log" "$(HOME)/.cometmind/cometline-gateway.log.1"

--- a/cometline/README.md
+++ b/cometline/README.md
@@ -166,7 +166,7 @@ make check              # SDK + CometMind tests + svelte-check
 make build              # SDK + CometMind binary + renderer
 make package            # packaged Electron app with embedded sidecar
 make port               # show process on 127.0.0.1:7700
-make clean-log          # remove ~/.cometmind/cometline.log
+make clean-log          # remove ~/.cometmind/logs/cometline*.log (+ legacy root paths)
 ```
 
 Packaged apps embed the CometMind binary as an Electron extra resource and serve the renderer over a custom `app://` protocol.
@@ -181,8 +181,8 @@ Packaged apps embed the CometMind binary as an Electron extra resource and serve
 | `~/.cometmind/cometline-settings.json`  | Single settings file (providers, CometMind runtime, appearance, shortcuts) |
 | `~/.cometmind/config.toml`              | Legacy only; CometMind migrates from this if JSON is absent                |
 | `~/.cometmind/cometline-workspace.json` | Selected workspace path                                                    |
-| `~/.cometmind/cometline.log`            | Sidecar stdout/stderr (rotates at 10 MB while running → `.log.1`)          |
-| `~/.cometmind/cometline-gateway.log`    | Discord gateway log (same rotation)                                        |
+| `~/.cometmind/logs/cometline.log`            | Sidecar stdout/stderr (rotates at 10 MB while running → `.log.1`)          |
+| `~/.cometmind/logs/cometline-gateway.log`    | Discord gateway log (same rotation)                                        |
 | `~/.cometmind/mcp-oauth/{server}.json`  | MCP OAuth access/refresh token cache                                        |
 | `~/.cometmind/mcp-oauth/{server}.client.json` | MCP OAuth registered-client metadata                                  |
 

--- a/cometline/docs/COMETLINE_ARCHITECTURE.md
+++ b/cometline/docs/COMETLINE_ARCHITECTURE.md
@@ -235,8 +235,8 @@ Never commit real provider API keys to docs, Makefiles, source files, or tests.
 | `~/.cometmind/cometline-settings.json`  | Single settings file (desktop UI + CometMind runtime)                       |
 | `~/.cometmind/config.toml`              | Legacy; read once for migration if JSON is missing                          |
 | `~/.cometmind/cometline-workspace.json` | Selected workspace path                                                     |
-| `~/.cometmind/cometline.log`            | Electron-spawned CometMind logs (rotates at 10 MB while running → `.log.1`) |
-| `~/.cometmind/cometline-gateway.log`    | Discord gateway logs (same rotation)                                        |
+| `~/.cometmind/logs/cometline.log`            | Electron-spawned CometMind logs (rotates at 10 MB while running → `.log.1`) |
+| `~/.cometmind/logs/cometline-gateway.log`    | Discord gateway logs (same rotation)                                        |
 | `~/.cometmind/mcp-oauth/{server}.json`  | MCP OAuth access/refresh token cache                                        |
 | `~/.cometmind/mcp-oauth/{server}.client.json` | MCP OAuth registered client metadata                                  |
 

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -690,10 +690,36 @@ function resolveSystemPromptPath(personaId = 'minako', settings = undefined) {
 	return resolveBuiltinSoulPath(personaId);
 }
 
-function getLogPath() {
-	const dir = path.join(os.homedir(), '.cometmind');
+function getLogsDir() {
+	const dir = path.join(os.homedir(), '.cometmind', 'logs');
 	if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-	return path.join(dir, 'cometline.log');
+	return dir;
+}
+
+/** Move legacy root-level log files into ~/.cometmind/logs/ once. */
+function migrateLegacyLogPaths() {
+	const root = path.join(os.homedir(), '.cometmind');
+	const logsDir = getLogsDir();
+	for (const name of [
+		'cometline.log',
+		'cometline.log.1',
+		'cometline-gateway.log',
+		'cometline-gateway.log.1'
+	]) {
+		const from = path.join(root, name);
+		const to = path.join(logsDir, name);
+		if (!fs.existsSync(from) || fs.existsSync(to)) continue;
+		try {
+			fs.renameSync(from, to);
+		} catch (err) {
+			console.warn(`Failed to migrate log ${name}:`, err);
+		}
+	}
+}
+
+function getLogPath() {
+	migrateLegacyLogPaths();
+	return path.join(getLogsDir(), 'cometline.log');
 }
 
 function getSettingsPath() {

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -702,6 +702,89 @@ function getSettingsPath() {
 	return path.join(dir, 'cometline-settings.json');
 }
 
+function getDesktopSettingsPath() {
+	const dir = path.join(os.homedir(), '.cometmind');
+	if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+	return path.join(dir, 'cometline-desktop.json');
+}
+
+const DESKTOP_TOP_LEVEL_KEYS = ['appearance', 'shortcuts', 'app'];
+
+function readJsonFileIfExists(filePath) {
+	if (!fs.existsSync(filePath)) return null;
+	try {
+		return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+	} catch {
+		return null;
+	}
+}
+
+function cloneJson(value) {
+	return JSON.parse(JSON.stringify(value ?? null));
+}
+
+/** Peel desktop-owned keys from a monolithic settings document. */
+function splitSettingsDocument(merged) {
+	const settings = cloneJson(merged ?? {});
+	const desktop = {};
+	for (const key of DESKTOP_TOP_LEVEL_KEYS) {
+		if (settings[key] !== undefined) {
+			desktop[key] = settings[key];
+			delete settings[key];
+		}
+	}
+	const prompt = settings?.cometmind?.systemPromptPath;
+	if (prompt !== undefined) {
+		desktop.systemPromptPath = prompt;
+		// Keep stamp on runtime settings so CometMind Load can ignore desktop file.
+	}
+	return { settings, desktop };
+}
+
+function mergeSettingsDocuments(settingsDoc, desktopDoc) {
+	const out = cloneJson(settingsDoc ?? {});
+	const desktop = desktopDoc ?? {};
+	for (const key of DESKTOP_TOP_LEVEL_KEYS) {
+		if (desktop[key] !== undefined) {
+			out[key] = cloneJson(desktop[key]);
+		}
+	}
+	if (desktop.systemPromptPath !== undefined) {
+		out.cometmind = { ...(out.cometmind ?? {}), systemPromptPath: desktop.systemPromptPath };
+	}
+	return out;
+}
+
+function hasDesktopKeys(doc) {
+	if (!doc || typeof doc !== 'object') return false;
+	return DESKTOP_TOP_LEVEL_KEYS.some((key) => doc[key] !== undefined);
+}
+
+/** One-shot migrate: peel appearance/shortcuts/app into cometline-desktop.json. */
+function migrateSplitSettingsIfNeeded() {
+	const settingsPath = getSettingsPath();
+	const desktopPath = getDesktopSettingsPath();
+	const saved = readJsonFileIfExists(settingsPath) ?? {};
+	if (!hasDesktopKeys(saved)) {
+		if (saved?.cometmind?.systemPromptPath !== undefined) {
+			const existingDesktop = readJsonFileIfExists(desktopPath) ?? {};
+			if (existingDesktop.systemPromptPath === undefined) {
+				writeJsonFileAtomic(
+					desktopPath,
+					{ ...existingDesktop, systemPromptPath: saved.cometmind.systemPromptPath },
+					0o600
+				);
+			}
+		}
+		return;
+	}
+	const existingDesktop = readJsonFileIfExists(desktopPath) ?? {};
+	const { settings, desktop } = splitSettingsDocument(saved);
+	const nextDesktop = { ...existingDesktop, ...desktop };
+	writeJsonFileAtomic(desktopPath, nextDesktop, 0o600);
+	writeJsonFileAtomic(settingsPath, settings, 0o600);
+}
+
 function settingsNormalizeOptions(personaId = 'minako', settings = undefined) {
 	return {
 		fallbackWorkspacePath: readStoredWorkspacePath() || getDefaultWorkspacePath(),
@@ -1404,15 +1487,10 @@ function readProviderSettings() {
 }
 
 function readSavedProviderSettings() {
-	let saved = {};
-	const settingsPath = getSettingsPath();
-	if (fs.existsSync(settingsPath)) {
-		try {
-			saved = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-		} catch {
-			saved = {};
-		}
-	}
+	migrateSplitSettingsIfNeeded();
+	const settingsDoc = readJsonFileIfExists(getSettingsPath()) ?? {};
+	const desktopDoc = readJsonFileIfExists(getDesktopSettingsPath()) ?? {};
+	const saved = mergeSettingsDocuments(settingsDoc, desktopDoc);
 
 	const personaId = readSavedPersonaId(saved);
 	return parseAndNormalizeSettings(saved, settingsNormalizeOptions(personaId, saved));
@@ -1452,8 +1530,9 @@ function writeProviderSettings(settings) {
 			settingsNormalizeOptions(personaId, { app: appSettings })
 		)
 	);
-	const settingsPath = getSettingsPath();
-	writeJsonFileAtomic(settingsPath, next, 0o600);
+	const { settings: runtimeDoc, desktop: desktopDoc } = splitSettingsDocument(next);
+	writeJsonFileAtomic(getSettingsPath(), runtimeDoc, 0o600);
+	writeJsonFileAtomic(getDesktopSettingsPath(), desktopDoc, 0o600);
 	return next;
 }
 
@@ -3788,6 +3867,10 @@ ipcMain.handle('cometline:save-provider-settings', async (_event, settings, opti
 		reload = { action: 'restart', healthy };
 	} else if (runtimeAction === 'reload') {
 		reload = await reloadCometMind();
+	} else if (runtimeAction === 'gateway') {
+		// Gateway process recycle only; main serve stays up. sync below applies it.
+		const healthy = await waitForHealth();
+		reload = { action: 'gateway', healthy };
 	}
 	await syncDiscordGatewayFromSettings(saved);
 	applyOpenAtLoginSetting(saved.app?.openAtLogin);

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -4623,7 +4623,9 @@ function defaultCometMindStorageSettings() {
     maxSessionsPerWorkspace: 0,
     archivedMemoryPurgeDays: 90,
     deletedJobPurgeDays: 30,
-    vacuumAfterPurge: true
+    vacuumAfterPurge: true,
+    toolOutputRetentionDays: 7,
+    agentTmpRetentionDays: 3
   };
 }
 function defaultCometMindSettings(workspacePath = "") {
@@ -4817,7 +4819,15 @@ function normalizeCometMindSettings(input, fallbackWorkspacePath = "") {
         storage.deletedJobPurgeDays,
         defaults.storage.deletedJobPurgeDays
       ),
-      vacuumAfterPurge: typeof storage.vacuumAfterPurge === "boolean" ? storage.vacuumAfterPurge : defaults.storage.vacuumAfterPurge
+      vacuumAfterPurge: typeof storage.vacuumAfterPurge === "boolean" ? storage.vacuumAfterPurge : defaults.storage.vacuumAfterPurge,
+      toolOutputRetentionDays: normalizeNonNegativeInt(
+        storage.toolOutputRetentionDays,
+        defaults.storage.toolOutputRetentionDays
+      ),
+      agentTmpRetentionDays: normalizeNonNegativeInt(
+        storage.agentTmpRetentionDays,
+        defaults.storage.agentTmpRetentionDays
+      )
     },
     gateway: {
       discord: {
@@ -5308,7 +5318,9 @@ var providerSettingsSchema = external_exports.object({
       maxSessionsPerWorkspace: external_exports.number().int().min(0),
       archivedMemoryPurgeDays: external_exports.number().int().min(0),
       deletedJobPurgeDays: external_exports.number().int().min(0),
-      vacuumAfterPurge: external_exports.boolean()
+      vacuumAfterPurge: external_exports.boolean(),
+      toolOutputRetentionDays: external_exports.number().int().min(0),
+      agentTmpRetentionDays: external_exports.number().int().min(0)
     }),
     gateway: external_exports.object({
       discord: external_exports.object({

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -294,7 +294,7 @@ declare global {
 	 * every save silently succeeded.
 	 */
 	interface RuntimeReloadOutcome {
-		action: 'reload' | 'restart' | 'restart-fallback';
+		action: 'reload' | 'restart' | 'restart-fallback' | 'gateway';
 		healthy: boolean;
 		/** Present when action is 'restart-fallback': why the in-place reload failed. */
 		error?: string;
@@ -373,7 +373,7 @@ declare global {
 			saveProviderSettings?: (
 				settings: ProviderSettings,
 				options?: {
-					runtimeAction?: 'none' | 'reload' | 'restart';
+					runtimeAction?: 'none' | 'reload' | 'restart' | 'gateway';
 					restartCometMind?: boolean;
 				}
 			) => Promise<SaveProviderSettingsResult>;

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -187,6 +187,8 @@ declare global {
 		archivedMemoryPurgeDays: number;
 		deletedJobPurgeDays: number;
 		vacuumAfterPurge: boolean;
+		toolOutputRetentionDays: number;
+		agentTmpRetentionDays: number;
 	}
 
 	interface CometMindJobsNotificationSettings {

--- a/cometline/src/lib/components/RuntimeOverlay.svelte
+++ b/cometline/src/lib/components/RuntimeOverlay.svelte
@@ -24,7 +24,7 @@
 			</div>
 			<p class="error-message">{connectionState.message}</p>
 			<p class="error-hint">
-				Check <code>~/.cometmind/cometline.log</code> for sidecar errors, then retry.
+				Check <code>~/.cometmind/logs/cometline.log</code> for sidecar errors, then retry.
 			</p>
 			<button type="button" class="retry-button" onclick={retry}>
 				<RefreshCw size={14} aria-hidden="true" />

--- a/cometline/src/lib/components/settings/SettingsCometMindPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsCometMindPanel.svelte
@@ -354,7 +354,7 @@
 					<option value="debug">Debug</option>
 				</select>
 				<p class="settings-field-hint">
-					Controls what CometMind writes to <code>~/.cometmind/cometline.log</code> and
+					Controls what CometMind writes to <code>~/.cometmind/logs/cometline.log</code> and
 					<code>cometline-gateway.log</code>. Applied on Save via in-place reload.
 				</p>
 			</label>

--- a/cometline/src/lib/components/settings/SettingsCometMindPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsCometMindPanel.svelte
@@ -355,7 +355,7 @@
 				</select>
 				<p class="settings-field-hint">
 					Controls what CometMind writes to <code>~/.cometmind/cometline.log</code> and
-					<code>cometline-gateway.log</code>. CometMind restarts when you save changes.
+					<code>cometline-gateway.log</code>. Applied on Save via in-place reload.
 				</p>
 			</label>
 		</div>
@@ -670,6 +670,10 @@
 				/>
 			</label>
 			<SettingsPersistenceHint tier="action" detail="Job notification settings" />
+			<SettingsPersistenceHint
+				tier="pending"
+				detail="Queue / lease / reconcile fields — Save reloads CometMind in place"
+			/>
 		</div>
 
 		<div class="settings-section">
@@ -707,7 +711,7 @@
 			</label>
 			<SettingsPersistenceHint
 				tier="pending"
-				detail="Included in Save changes — restarts CometMind"
+				detail="Included in Save changes — reloads CometMind in place"
 			/>
 		</div>
 
@@ -736,7 +740,7 @@
 			</label>
 			<SettingsPersistenceHint
 				tier="pending"
-				detail="Included in Save changes — restarts CometMind"
+				detail="Included in Save changes — reloads CometMind in place"
 			/>
 		</div>
 
@@ -851,6 +855,10 @@
 				<input type="checkbox" bind:checked={cometmind.gateway.discord.requireMention} />
 				<span>Require @mention in server channels</span>
 			</label>
+			<SettingsPersistenceHint
+				tier="pending"
+				detail="Included in Save changes — restarts gateway process only (serve stays up)"
+			/>
 		</div>
 	</div>
 </section>

--- a/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
@@ -110,10 +110,13 @@
 				<h3>Storage & retention</h3>
 				<p>Control how long CometMind keeps archived sessions and memory before purging.</p>
 			</div>
-			<SettingsPersistenceHint tier="pending" detail="Included in Save changes" />
+			<SettingsPersistenceHint
+				tier="pending"
+				detail="Included in Save changes — reloads CometMind in place"
+			/>
 			<p class="settings-field-hint">
 				Automatic cleanup runs on a CometMind schedule. Set a retention field to 0 to
-				disable that rule.
+				disable that rule. Interval changes apply on Save without restarting the sidecar.
 			</p>
 
 			<label class="field">

--- a/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
@@ -60,6 +60,20 @@
 			deletedJobPurgeDays: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
 		});
 	}
+
+	function onToolOutputRetentionInput(event: Event) {
+		const value = Number((event.currentTarget as HTMLInputElement).value);
+		patchStorage({
+			toolOutputRetentionDays: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+		});
+	}
+
+	function onAgentTmpRetentionInput(event: Event) {
+		const value = Number((event.currentTarget as HTMLInputElement).value);
+		patchStorage({
+			agentTmpRetentionDays: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+		});
+	}
 </script>
 
 <section class="general-panel settings-panel-frame">
@@ -213,12 +227,54 @@
 				</small>
 			</label>
 
+			<label class="field">
+				<span>Purge tool-output files (days)</span>
+				<input
+					type="number"
+					min="0"
+					step="1"
+					value={storage.toolOutputRetentionDays}
+					oninput={onToolOutputRetentionInput}
+				/>
+				<small>
+					{#if storage.toolOutputRetentionDays === 0}
+						Disabled — spilled tool output under <code>~/.cometmind/tool-output/</code> stays on
+						disk.
+					{:else}
+						Delete <code>tool-output/</code> files older than {storage.toolOutputRetentionDays}
+						days.
+					{/if}
+				</small>
+			</label>
+
+			<label class="field">
+				<span>Purge agent-tmp files (days)</span>
+				<input
+					type="number"
+					min="0"
+					step="1"
+					value={storage.agentTmpRetentionDays}
+					oninput={onAgentTmpRetentionInput}
+				/>
+				<small>
+					{#if storage.agentTmpRetentionDays === 0}
+						Disabled — <code>~/.cometmind/agent-tmp/</code> files stay on disk.
+					{:else}
+						Delete <code>agent-tmp/</code> files older than {storage.agentTmpRetentionDays} days.
+					{/if}
+				</small>
+			</label>
+
 			<SettingsToggle
 				label="Vacuum database after purge"
 				description="Reclaim disk space in cometmind.db after sessions or memories are deleted."
 				checked={storage.vacuumAfterPurge}
 				onchange={(enabled) => patchStorage({ vacuumAfterPurge: enabled })}
 			/>
+
+			<p class="settings-field-hint">
+				Sidecar logs live under <code>~/.cometmind/logs/</code> (10MB rotate).
+			</p>
 
 			<p class="discord-note">
 				Deleting a session also removes its Discord channel mapping. The next message in

--- a/cometline/src/lib/components/settings/SettingsMemoryPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsMemoryPanel.svelte
@@ -334,7 +334,7 @@
 		<div class="settings-panel-body">
 			{#if loadError}
 				<p class="load-error">
-					{loadError}. Showing defaults — restart CometMind (Save in Settings → Providers)
+					{loadError}. Showing defaults — reload CometMind (Save in Settings → Providers)
 					or run
 					<code>make build-cometmind</code> if endpoints are missing.
 					<button class="link-button" type="button" onclick={reload}>Retry</button>

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -119,6 +119,10 @@ export interface CometMindStorageSettings {
 	archivedMemoryPurgeDays: number;
 	deletedJobPurgeDays: number;
 	vacuumAfterPurge: boolean;
+	/** Delete ~/.cometmind/tool-output files older than N days. 0 disables. */
+	toolOutputRetentionDays: number;
+	/** Delete ~/.cometmind/agent-tmp files older than N days. 0 disables. */
+	agentTmpRetentionDays: number;
 }
 
 export type MCPTransport = 'stdio' | 'http' | 'sse';
@@ -496,7 +500,9 @@ export function defaultCometMindStorageSettings(): CometMindStorageSettings {
 		maxSessionsPerWorkspace: 0,
 		archivedMemoryPurgeDays: 90,
 		deletedJobPurgeDays: 30,
-		vacuumAfterPurge: true
+		vacuumAfterPurge: true,
+		toolOutputRetentionDays: 7,
+		agentTmpRetentionDays: 3
 	};
 }
 
@@ -714,7 +720,15 @@ export function normalizeCometMindSettings(
 			vacuumAfterPurge:
 				typeof storage.vacuumAfterPurge === 'boolean'
 					? storage.vacuumAfterPurge
-					: defaults.storage.vacuumAfterPurge
+					: defaults.storage.vacuumAfterPurge,
+			toolOutputRetentionDays: normalizeNonNegativeInt(
+				storage.toolOutputRetentionDays,
+				defaults.storage.toolOutputRetentionDays
+			),
+			agentTmpRetentionDays: normalizeNonNegativeInt(
+				storage.agentTmpRetentionDays,
+				defaults.storage.agentTmpRetentionDays
+			)
 		},
 		gateway: {
 			discord: {
@@ -1331,7 +1345,9 @@ const providerSettingsSchema = z.object({
 			maxSessionsPerWorkspace: z.number().int().min(0),
 			archivedMemoryPurgeDays: z.number().int().min(0),
 			deletedJobPurgeDays: z.number().int().min(0),
-			vacuumAfterPurge: z.boolean()
+			vacuumAfterPurge: z.boolean(),
+			toolOutputRetentionDays: z.number().int().min(0),
+			agentTmpRetentionDays: z.number().int().min(0)
 		}),
 		gateway: z.object({
 			discord: z.object({

--- a/cometline/src/lib/settings/settings-save.test.ts
+++ b/cometline/src/lib/settings/settings-save.test.ts
@@ -13,15 +13,15 @@ describe('runtimeActionForSettingsSave', () => {
 		expect(runtimeActionForSettingsSave(persisted, next)).toBe('reload');
 	});
 
-	it('returns restart for memory settings changes', () => {
+	it('returns reload for memory settings changes', () => {
 		const persisted = defaultSettings();
 		const next = defaultSettings();
 		next.cometmind.memory.extractionModel = 'text-embedding-3-large';
 
-		expect(runtimeActionForSettingsSave(persisted, next)).toBe('restart');
+		expect(runtimeActionForSettingsSave(persisted, next)).toBe('reload');
 	});
 
-	it('returns restart when a memory provider entry changes', () => {
+	it('returns reload when a memory provider entry changes', () => {
 		const persisted = defaultSettings();
 		const next = defaultSettings();
 		next.cometmind.memory.embedding.providerId = 'openai';
@@ -29,7 +29,39 @@ describe('runtimeActionForSettingsSave', () => {
 			provider.id === 'openai' ? { ...provider, baseURL: 'http://localhost:11434/v1' } : provider
 		);
 
-		expect(runtimeActionForSettingsSave(persisted, next)).toBe('restart');
+		expect(runtimeActionForSettingsSave(persisted, next)).toBe('reload');
+	});
+
+	it('returns reload for storage cleanup / jobs reconcile / autonomy changes', () => {
+		const persisted = defaultSettings();
+		const storage = defaultSettings();
+		storage.cometmind.storage.cleanupIntervalMinutes = 99;
+		expect(runtimeActionForSettingsSave(persisted, storage)).toBe('reload');
+
+		const jobs = defaultSettings();
+		jobs.cometmind.jobs.reconcileIntervalSeconds = 42;
+		expect(runtimeActionForSettingsSave(persisted, jobs)).toBe('reload');
+
+		const autonomy = defaultSettings();
+		autonomy.cometmind.autonomy.enabled = !persisted.cometmind.autonomy.enabled;
+		expect(runtimeActionForSettingsSave(persisted, autonomy)).toBe('reload');
+	});
+
+	it('returns gateway for gateway-only changes', () => {
+		const persisted = defaultSettings();
+		const next = defaultSettings();
+		next.cometmind.gateway.discord.enabled = !persisted.cometmind.gateway.discord.enabled;
+
+		expect(runtimeActionForSettingsSave(persisted, next)).toBe('gateway');
+	});
+
+	it('returns reload when gateway changes together with other cometmind fields', () => {
+		const persisted = defaultSettings();
+		const next = defaultSettings();
+		next.cometmind.gateway.discord.enabled = !persisted.cometmind.gateway.discord.enabled;
+		next.cometmind.memory.enabled = !persisted.cometmind.memory.enabled;
+
+		expect(runtimeActionForSettingsSave(persisted, next)).toBe('reload');
 	});
 });
 
@@ -37,6 +69,7 @@ describe('saveStatusMessage', () => {
 	it('reports reload distinctly from restart when no reload outcome is known', () => {
 		expect(saveStatusMessage('agent', 'reload')).toBe('Changes saved. CometMind reloaded.');
 		expect(saveStatusMessage('agent', 'restart')).toBe('Changes saved. CometMind restarted.');
+		expect(saveStatusMessage('agent', 'gateway')).toBe('Changes saved. Gateway restarted.');
 		expect(saveStatusMessage('agent', 'none')).toBe('Changes saved.');
 	});
 

--- a/cometline/src/lib/settings/settings-save.ts
+++ b/cometline/src/lib/settings/settings-save.ts
@@ -1,27 +1,38 @@
 import type { ProviderSettings } from '$lib/types';
 import type { SettingsSection } from '$lib/components/settings/settings-controller.svelte';
 
-export type RuntimeApplyAction = 'none' | 'reload' | 'restart';
+export type RuntimeApplyAction = 'none' | 'reload' | 'restart' | 'gateway';
 
-function providerChangedIds(persisted: ProviderSettings, next: ProviderSettings): Set<string> {
-	const changed = new Set<string>();
-	const before = new Map(persisted.providers.map((provider) => [provider.id, JSON.stringify(provider)]));
-	const after = new Map(next.providers.map((provider) => [provider.id, JSON.stringify(provider)]));
-	for (const id of new Set([...before.keys(), ...after.keys()])) {
-		if (before.get(id) !== after.get(id)) changed.add(id);
-	}
-	return changed;
+function gatewayChanged(persisted: ProviderSettings, next: ProviderSettings): boolean {
+	return (
+		JSON.stringify(persisted.cometmind.gateway ?? null) !==
+		JSON.stringify(next.cometmind.gateway ?? null)
+	);
 }
 
-function memoryProviderIds(settings: ProviderSettings): Set<string> {
-	const ids = new Set<string>();
-	const extraction = settings.cometmind.memory.extractionProviderId;
-	const embedding = settings.cometmind.memory.embedding.providerId;
-	if (extraction) ids.add(extraction);
-	if (embedding) ids.add(embedding);
-	return ids;
+function processLevelServeChanged(persisted: ProviderSettings, next: ProviderSettings): boolean {
+	// Host/port are process-level for the main sidecar; keep restart if present.
+	const before = persisted.cometmind as ProviderSettings['cometmind'] & {
+		host?: string;
+		port?: number;
+	};
+	const after = next.cometmind as ProviderSettings['cometmind'] & {
+		host?: string;
+		port?: number;
+	};
+	return before.host !== after.host || before.port !== after.port;
 }
 
+/**
+ * Classify how CometMind should apply a settings save.
+ *
+ * Most cometmind/provider changes hot-reload. Changes under `cometmind.gateway`
+ * (any platform) trigger a gateway-only recycle (main serve stays up). Full
+ * serve restart is reserved for true process-level bind changes (host/port).
+ *
+ * When gateway changes together with other runtime fields, return `reload`
+ * (Electron still syncs gateways on every save).
+ */
 export function runtimeActionForSettingsSave(
 	persisted: ProviderSettings,
 	next: ProviderSettings
@@ -30,34 +41,19 @@ export function runtimeActionForSettingsSave(
 	const cometmindChanged = JSON.stringify(persisted.cometmind) !== JSON.stringify(next.cometmind);
 	if (!providersChanged && !cometmindChanged) return 'none';
 
-	if (JSON.stringify(persisted.cometmind.memory) !== JSON.stringify(next.cometmind.memory)) {
-		return 'restart';
-	}
-	if (
-		persisted.cometmind.storage.cleanupIntervalMinutes !==
-			next.cometmind.storage.cleanupIntervalMinutes
-	) {
-		return 'restart';
-	}
-	if (
-		persisted.cometmind.jobs.reconcileIntervalSeconds !==
-			next.cometmind.jobs.reconcileIntervalSeconds
-	) {
-		return 'restart';
-	}
-	if (JSON.stringify(persisted.cometmind.autonomy) !== JSON.stringify(next.cometmind.autonomy)) {
+	if (processLevelServeChanged(persisted, next)) {
 		return 'restart';
 	}
 
-	const changedProviderIds = providerChangedIds(persisted, next);
-	if (changedProviderIds.size > 0) {
-		const memoryProviders = new Set([
-			...memoryProviderIds(persisted),
-			...memoryProviderIds(next)
-		]);
-		for (const id of changedProviderIds) {
-			if (memoryProviders.has(id)) return 'restart';
-		}
+	const gatewaysChanged = gatewayChanged(persisted, next);
+	const withoutGateway = (settings: ProviderSettings) => {
+		const { gateway: _gateway, ...rest } = settings.cometmind;
+		return rest;
+	};
+	const otherCometmindEqual =
+		JSON.stringify(withoutGateway(persisted)) === JSON.stringify(withoutGateway(next));
+	if (gatewaysChanged && otherCometmindEqual && !providersChanged) {
+		return 'gateway';
 	}
 
 	return 'reload';
@@ -74,9 +70,8 @@ export function runtimeActionForSettingsSave(
  */
 function runtimeNoteFor(runtimeAction: RuntimeApplyAction, reload?: RuntimeReloadOutcome | null): string {
 	if (reload === undefined) {
-		// No reload info available (e.g. browser/dev fallback without Electron
-		// IPC) — fall back to the pre-#4 behavior of trusting runtimeAction.
 		if (runtimeAction === 'restart') return ' CometMind restarted.';
+		if (runtimeAction === 'gateway') return ' Gateway restarted.';
 		if (runtimeAction === 'reload') return ' CometMind reloaded.';
 		return '';
 	}
@@ -90,6 +85,9 @@ function runtimeNoteFor(runtimeAction: RuntimeApplyAction, reload?: RuntimeReloa
 		return reload.action === 'restart'
 			? ' CometMind restarted but is not responding yet. Check the CometMind log.'
 			: ' CometMind reloaded but is not responding yet. Check the CometMind log.';
+	}
+	if (runtimeAction === 'gateway' || reload.action === 'gateway') {
+		return ' Gateway restarted.';
 	}
 	return reload.action === 'restart' ? ' CometMind restarted.' : ' CometMind reloaded.';
 }

--- a/cometmind/internal/autonomy/worker.go
+++ b/cometmind/internal/autonomy/worker.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cometline/cometmind/internal/agent"
@@ -49,6 +50,7 @@ type Worker struct {
 	NewRunner RunnerFactory
 	Guard     RunGuard
 
+	mu     sync.RWMutex
 	Config config.AutonomousJobsConfig
 
 	// DefaultModelID/DefaultProviderID are used for sessions the worker
@@ -60,29 +62,64 @@ type Worker struct {
 	sem chan struct{}
 }
 
-// Run starts the poll loop and blocks until ctx is canceled. It is a no-op
-// (returns immediately) if the worker is disabled in config.
+// Run starts the poll loop and blocks until ctx is canceled.
+// Enabled/interval are re-read each cycle so Reload can update autonomy live.
 func (w *Worker) Run(ctx context.Context) {
-	if w == nil || !w.Config.Enabled {
+	if w == nil {
 		return
 	}
-	w.ensureSemaphore()
-
-	interval := time.Duration(w.Config.PollIntervalSeconds) * time.Second
-	if interval <= 0 {
-		interval = 30 * time.Second
-	}
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
 	for {
+		cfg := w.configSnapshot()
+		if !cfg.Enabled {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				continue
+			}
+		}
+		w.ensureSemaphore()
+		interval := time.Duration(cfg.PollIntervalSeconds) * time.Second
+		if interval <= 0 {
+			interval = 30 * time.Second
+		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(interval):
 			w.pollOnce(ctx)
 		}
 	}
+}
+
+// UpdateConfig replaces autonomy settings used by the next poll cycle.
+func (w *Worker) UpdateConfig(cfg config.AutonomousJobsConfig, defaultModelID, defaultProviderID string) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.Config = cfg
+	if strings.TrimSpace(defaultModelID) != "" {
+		w.DefaultModelID = defaultModelID
+	}
+	if strings.TrimSpace(defaultProviderID) != "" {
+		w.DefaultProviderID = defaultProviderID
+	}
+	// Force semaphore rebuild if concurrency changed.
+	max := cfg.MaxConcurrent
+	if max <= 0 {
+		max = 1
+	}
+	if w.sem == nil || cap(w.sem) != max {
+		w.sem = make(chan struct{}, max)
+	}
+}
+
+func (w *Worker) configSnapshot() config.AutonomousJobsConfig {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.Config
 }
 
 // pollOnce lists ready jobs and attempts to claim+run as many as the
@@ -110,6 +147,8 @@ func (w *Worker) pollOnce(ctx context.Context) {
 }
 
 func (w *Worker) ensureSemaphore() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.sem != nil {
 		return
 	}

--- a/cometmind/internal/autonomy/worker_test.go
+++ b/cometmind/internal/autonomy/worker_test.go
@@ -150,16 +150,29 @@ func newWorker(t *testing.T, fx workerFixture, provider cometsdk.Provider, cfg c
 
 func TestWorkerRunDisabledReturnsWithoutPolling(t *testing.T) {
 	fx := newWorkerFixture(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	job, err := fx.jobs.Create(ctx, jobs.CreateInput{Description: "stay queued", WorkspacePath: fx.root})
 	if err != nil {
 		t.Fatal(err)
 	}
 	w := newWorker(t, fx, &staticProvider{}, config.AutonomousJobsConfig{Enabled: false})
 
-	w.Run(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.Run(ctx)
+	}()
+	// Disabled workers idle until cancel (so Reload can enable them live).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("disabled worker did not exit after cancel")
+	}
 
-	got, err := fx.jobs.Get(ctx, job.ID)
+	got, err := fx.jobs.Get(context.Background(), job.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cometmind/internal/config/cometline_settings.go
+++ b/cometmind/internal/config/cometline_settings.go
@@ -87,6 +87,10 @@ type cometlineStorageJSON struct {
 	ArchivedMemoryPurgeDays int  `json:"archivedMemoryPurgeDays"`
 	DeletedJobPurgeDays     int  `json:"deletedJobPurgeDays"`
 	VacuumAfterPurge        bool `json:"vacuumAfterPurge"`
+	// Pointers so omitted keys (pre-upgrade settings) get defaults, while
+	// explicit 0 still means "disable".
+	ToolOutputRetentionDays *int `json:"toolOutputRetentionDays"`
+	AgentTmpRetentionDays   *int `json:"agentTmpRetentionDays"`
 }
 
 type cometlineMCPOAuthJSON struct {
@@ -294,14 +298,7 @@ func adaptCometlineSettings(raw cometlineSettingsJSON) (*Config, error) {
 				APIKey:     cm.Memory.Embedding.APIKey,
 			},
 		},
-		Storage: StorageConfig{
-			CleanupIntervalMinutes:  cm.Storage.CleanupIntervalMinutes,
-			RetentionDays:           cm.Storage.RetentionDays,
-			MaxSessionsPerWorkspace: cm.Storage.MaxSessionsPerWorkspace,
-			ArchivedMemoryPurgeDays: cm.Storage.ArchivedMemoryPurgeDays,
-			DeletedJobPurgeDays:     cm.Storage.DeletedJobPurgeDays,
-			VacuumAfterPurge:        cm.Storage.VacuumAfterPurge,
-		},
+		Storage: adaptStorageConfig(cm.Storage),
 		Jobs: JobsConfig{
 			Notifications: JobNotificationSettings{
 				Enabled:     cm.Jobs.Notifications.Enabled,
@@ -405,6 +402,37 @@ func adaptMCPJSON(raw cometlineMCPJSON) MCPConfig {
 		}
 	}
 	return out
+}
+
+func adaptStorageConfig(cm cometlineStorageJSON) StorageConfig {
+	def := defaultStorageConfig()
+	s := StorageConfig{
+		CleanupIntervalMinutes:  cm.CleanupIntervalMinutes,
+		RetentionDays:           cm.RetentionDays,
+		MaxSessionsPerWorkspace: cm.MaxSessionsPerWorkspace,
+		ArchivedMemoryPurgeDays: cm.ArchivedMemoryPurgeDays,
+		DeletedJobPurgeDays:     cm.DeletedJobPurgeDays,
+		VacuumAfterPurge:        cm.VacuumAfterPurge,
+	}
+	// Omitted keys (pre-upgrade JSON) get defaults when other storage rules
+	// are present; explicit 0 still means disable.
+	hasOther := s.RetentionDays != 0 ||
+		s.CleanupIntervalMinutes != 0 ||
+		s.MaxSessionsPerWorkspace != 0 ||
+		s.ArchivedMemoryPurgeDays != 0 ||
+		s.DeletedJobPurgeDays != 0 ||
+		s.VacuumAfterPurge
+	if cm.ToolOutputRetentionDays != nil {
+		s.ToolOutputRetentionDays = *cm.ToolOutputRetentionDays
+	} else if hasOther {
+		s.ToolOutputRetentionDays = def.ToolOutputRetentionDays
+	}
+	if cm.AgentTmpRetentionDays != nil {
+		s.AgentTmpRetentionDays = *cm.AgentTmpRetentionDays
+	} else if hasOther {
+		s.AgentTmpRetentionDays = def.AgentTmpRetentionDays
+	}
+	return s
 }
 
 func copyStringMapGo(in map[string]string) map[string]string {

--- a/cometmind/internal/config/config.go
+++ b/cometmind/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cometline/cometmind/internal/logging"
 	"github.com/cometline/cometmind/internal/paths"
+	"github.com/cometline/cometmind/internal/settingsapply"
 	"github.com/spf13/viper"
 )
 
@@ -69,6 +70,7 @@ type GatewayConfig struct {
 }
 
 // Config holds user-visible runtime settings loaded from ~/.cometmind/cometline-settings.json and environment.
+// Desktop-only UI state lives in cometline-desktop.json and is not loaded here.
 type Config struct {
 	Provider           string               `mapstructure:"provider"`
 	Model              string               `mapstructure:"model"`
@@ -124,6 +126,10 @@ func Load() (*Config, error) {
 	}
 
 	def := Defaults()
+
+	if err := settingsapply.MigrateSplitFilesIfNeeded(); err != nil {
+		logging.L().Warn("config.settings_split_migrate_failed", "error", err)
+	}
 
 	var cfg *Config
 	switch {

--- a/cometmind/internal/config/storage.go
+++ b/cometmind/internal/config/storage.go
@@ -16,6 +16,10 @@ type StorageConfig struct {
 	SubagentRetentionDays int `json:"subagent_retention_days" mapstructure:"subagent_retention_days"`
 	// DeletedJobPurgeDays hard-deletes soft-deleted jobs older than this many days. 0 disables.
 	DeletedJobPurgeDays int `json:"deleted_job_purge_days" mapstructure:"deleted_job_purge_days"`
+	// ToolOutputRetentionDays deletes files under ~/.cometmind/tool-output older than N days. 0 disables.
+	ToolOutputRetentionDays int `json:"tool_output_retention_days" mapstructure:"tool_output_retention_days"`
+	// AgentTmpRetentionDays deletes files under ~/.cometmind/agent-tmp older than N days. 0 disables.
+	AgentTmpRetentionDays int `json:"agent_tmp_retention_days" mapstructure:"agent_tmp_retention_days"`
 }
 
 func defaultStorageConfig() StorageConfig {
@@ -27,6 +31,8 @@ func defaultStorageConfig() StorageConfig {
 		VacuumAfterPurge:        true,
 		SubagentRetentionDays:   7,
 		DeletedJobPurgeDays:     30,
+		ToolOutputRetentionDays: 7,
+		AgentTmpRetentionDays:   3,
 	}
 }
 
@@ -45,14 +51,20 @@ func (s StorageConfig) MemoryPurgeEnabled() bool {
 	return s.ArchivedMemoryPurgeDays > 0
 }
 
+// RuntimeFilesEnabled reports whether tool-output / agent-tmp age cleanup is active.
+func (s StorageConfig) RuntimeFilesEnabled() bool {
+	return s.ToolOutputRetentionDays > 0 || s.AgentTmpRetentionDays > 0
+}
+
 // EffectiveStorageConfig returns storage settings with defaults when nothing is configured.
 func (c *Config) EffectiveStorageConfig() StorageConfig {
 	if !c.storageConfigured() {
 		return defaultStorageConfig()
 	}
 	s := c.Storage
+	def := defaultStorageConfig()
 	if s.CleanupIntervalMinutes == 0 {
-		s.CleanupIntervalMinutes = defaultStorageConfig().CleanupIntervalMinutes
+		s.CleanupIntervalMinutes = def.CleanupIntervalMinutes
 	}
 	return s
 }
@@ -65,5 +77,7 @@ func (c *Config) storageConfigured() bool {
 		s.ArchivedMemoryPurgeDays != 0 ||
 		s.SubagentRetentionDays != 0 ||
 		s.DeletedJobPurgeDays != 0 ||
+		s.ToolOutputRetentionDays != 0 ||
+		s.AgentTmpRetentionDays != 0 ||
 		s.VacuumAfterPurge
 }

--- a/cometmind/internal/config/storage_test.go
+++ b/cometmind/internal/config/storage_test.go
@@ -32,3 +32,58 @@ func TestEffectiveStorageConfig_ExplicitDisable(t *testing.T) {
 		t.Fatalf("cleanup_interval_minutes=%d want 60", got.CleanupIntervalMinutes)
 	}
 }
+
+func TestEffectiveStorageConfig_DefaultsIncludeRuntimeFiles(t *testing.T) {
+	cfg := &Config{}
+	got := cfg.EffectiveStorageConfig()
+	if got.ToolOutputRetentionDays != 7 {
+		t.Fatalf("tool_output_retention_days=%d want 7", got.ToolOutputRetentionDays)
+	}
+	if got.AgentTmpRetentionDays != 3 {
+		t.Fatalf("agent_tmp_retention_days=%d want 3", got.AgentTmpRetentionDays)
+	}
+}
+
+func TestEffectiveStorageConfig_ExplicitDisableRuntimeFiles(t *testing.T) {
+	cfg := &Config{Storage: StorageConfig{
+		VacuumAfterPurge:        true,
+		ToolOutputRetentionDays: 0,
+		AgentTmpRetentionDays:   0,
+	}}
+	got := cfg.EffectiveStorageConfig()
+	if got.ToolOutputRetentionDays != 0 {
+		t.Fatalf("tool_output_retention_days=%d want 0", got.ToolOutputRetentionDays)
+	}
+	if got.AgentTmpRetentionDays != 0 {
+		t.Fatalf("agent_tmp_retention_days=%d want 0", got.AgentTmpRetentionDays)
+	}
+}
+
+func TestAdaptStorageConfig_OmittedRuntimeKeysGetDefaults(t *testing.T) {
+	got := adaptStorageConfig(cometlineStorageJSON{
+		RetentionDays:    90,
+		VacuumAfterPurge: true,
+	})
+	if got.ToolOutputRetentionDays != 7 {
+		t.Fatalf("tool_output_retention_days=%d want 7", got.ToolOutputRetentionDays)
+	}
+	if got.AgentTmpRetentionDays != 3 {
+		t.Fatalf("agent_tmp_retention_days=%d want 3", got.AgentTmpRetentionDays)
+	}
+}
+
+func TestAdaptStorageConfig_ExplicitZeroDisables(t *testing.T) {
+	zero := 0
+	got := adaptStorageConfig(cometlineStorageJSON{
+		RetentionDays:           90,
+		VacuumAfterPurge:        true,
+		ToolOutputRetentionDays: &zero,
+		AgentTmpRetentionDays:   &zero,
+	})
+	if got.ToolOutputRetentionDays != 0 {
+		t.Fatalf("tool_output_retention_days=%d want 0", got.ToolOutputRetentionDays)
+	}
+	if got.AgentTmpRetentionDays != 0 {
+		t.Fatalf("agent_tmp_retention_days=%d want 0", got.AgentTmpRetentionDays)
+	}
+}

--- a/cometmind/internal/memory/service.go
+++ b/cometmind/internal/memory/service.go
@@ -68,13 +68,50 @@ func NewService(dbConn *sql.DB, settings Settings, provider cometsdk.Provider, s
 	}, nil
 }
 
-// UpdateSettings replaces runtime memory settings.
-func (s *Service) UpdateSettings(settings Settings) {
+// UpdateSettings replaces runtime memory settings and rebuilds the embedder
+// when embedding credentials/model change.
+func (s *Service) UpdateSettings(settings Settings) error {
+	if s == nil {
+		return fmt.Errorf("memory service is nil")
+	}
+	if settings.MaxRetrieved <= 0 {
+		settings.MaxRetrieved = 5
+	}
+	if settings.SimilarityThreshold <= 0 {
+		settings.SimilarityThreshold = 0.5
+	}
+	needEmbedder := !embeddingSettingsEqual(s.settings.Embedding, settings.Embedding)
 	s.settings = settings
 	s.retriever.settings = settings
 	s.extractor.settings = settings
 	s.updater.settings = settings
 	s.compactor.settings = settings
+	if !needEmbedder {
+		return nil
+	}
+	embedder, err := NewEmbedder(settings.Embedding)
+	if err != nil {
+		return err
+	}
+	s.retriever.embedder = embedder
+	s.updater.embedder = embedder
+	s.compactor.embedder = embedder
+	return nil
+}
+
+// SetProvider replaces the LLM used for extraction/compaction/updates.
+func (s *Service) SetProvider(p cometsdk.Provider) {
+	if s == nil {
+		return
+	}
+	s.provider = p
+	s.extractor.provider = p
+	s.updater.provider = p
+	s.compactor.provider = p
+}
+
+func embeddingSettingsEqual(a, b EmbeddingSettings) bool {
+	return a.Provider == b.Provider && a.Model == b.Model && a.BaseURL == b.BaseURL && a.APIKey == b.APIKey
 }
 
 func (s *Service) Settings() Settings { return s.settings }

--- a/cometmind/internal/paths/paths.go
+++ b/cometmind/internal/paths/paths.go
@@ -77,6 +77,44 @@ func DBPath() (string, error) {
 	return filepath.Join(d, "cometmind.db"), nil
 }
 
+// LogsDir returns ~/.cometmind/logs (created if missing).
+func LogsDir() (string, error) {
+	d, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(d, "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// ToolOutputDir returns ~/.cometmind/tool-output (created if missing).
+func ToolOutputDir() (string, error) {
+	d, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(d, "tool-output")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// AgentTmpDir returns ~/.cometmind/agent-tmp (created if missing).
+func AgentTmpDir() (string, error) {
+	d, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(d, "agent-tmp")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
 
 // MCPOAuthDir returns ~/.cometmind/mcp-oauth (created if missing).
 func MCPOAuthDir() (string, error) {

--- a/cometmind/internal/paths/paths.go
+++ b/cometmind/internal/paths/paths.go
@@ -45,13 +45,22 @@ func LegacyConfigPath() (string, error) {
 	return filepath.Join(d, "config.toml"), nil
 }
 
-// SettingsPath returns ~/.cometmind/cometline-settings.json.
+// SettingsPath returns ~/.cometmind/cometline-settings.json (agent-editable runtime settings).
 func SettingsPath() (string, error) {
 	d, err := DataDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(d, "cometline-settings.json"), nil
+}
+
+// DesktopSettingsPath returns ~/.cometmind/cometline-desktop.json (Electron-only UI state).
+func DesktopSettingsPath() (string, error) {
+	d, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "cometline-desktop.json"), nil
 }
 
 // ConfigPath returns ~/.cometmind/cometline-settings.json (legacy name retained for callers).
@@ -67,6 +76,7 @@ func DBPath() (string, error) {
 	}
 	return filepath.Join(d, "cometmind.db"), nil
 }
+
 
 // MCPOAuthDir returns ~/.cometmind/mcp-oauth (created if missing).
 func MCPOAuthDir() (string, error) {

--- a/cometmind/internal/paths/paths_test.go
+++ b/cometmind/internal/paths/paths_test.go
@@ -30,10 +30,24 @@ func TestProcessPathsUseDataDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessMetaPath() error = %v", err)
 	}
+	settingsPath, err := SettingsPath()
+	if err != nil {
+		t.Fatalf("SettingsPath() error = %v", err)
+	}
+	desktopPath, err := DesktopSettingsPath()
+	if err != nil {
+		t.Fatalf("DesktopSettingsPath() error = %v", err)
+	}
 	if pidPath != filepath.Join(override, "serve.pid") {
 		t.Fatalf("pid path = %q", pidPath)
 	}
 	if metaPath != filepath.Join(override, "serve.json") {
 		t.Fatalf("meta path = %q", metaPath)
+	}
+	if settingsPath != filepath.Join(override, "cometline-settings.json") {
+		t.Fatalf("settings path = %q", settingsPath)
+	}
+	if desktopPath != filepath.Join(override, "cometline-desktop.json") {
+		t.Fatalf("desktop path = %q", desktopPath)
 	}
 }

--- a/cometmind/internal/processctl/processctl.go
+++ b/cometmind/internal/processctl/processctl.go
@@ -53,6 +53,12 @@ func KnownModes() []string {
 	return []string{ModeServe, ModeGatewayDiscord}
 }
 
+// GatewayModes returns process modes for gateway platforms (not serve).
+// Add new platforms here when additional gateways ship.
+func GatewayModes() []string {
+	return []string{ModeGatewayDiscord}
+}
+
 func TargetModes(args []string) ([]string, error) {
 	if len(args) == 0 {
 		return KnownModes(), nil

--- a/cometmind/internal/retention/retention.go
+++ b/cometmind/internal/retention/retention.go
@@ -15,12 +15,14 @@ import (
 
 // Result summarizes one retention pass.
 type Result struct {
-	SessionsDeleted    int
-	SubagentsDeleted   int
-	MemoriesPurged     int
-	MemoryEventsPurged int
-	JobsPurged         int
-	Vacuumed           bool
+	SessionsDeleted     int
+	SubagentsDeleted    int
+	MemoriesPurged      int
+	MemoryEventsPurged  int
+	JobsPurged          int
+	ToolOutputDeleted   int
+	AgentTmpDeleted     int
+	Vacuumed            bool
 }
 
 // Runner performs session retention and memory purge.

--- a/cometmind/internal/retention/runtime_files.go
+++ b/cometmind/internal/retention/runtime_files.go
@@ -1,0 +1,61 @@
+package retention
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cometline/cometmind/internal/config"
+	"github.com/cometline/cometmind/internal/logging"
+	"github.com/cometline/cometmind/internal/paths"
+)
+
+// PurgeRuntimeFiles deletes aged files under tool-output/ and agent-tmp/.
+// It never removes the directories themselves. Errors are logged and skipped.
+func PurgeRuntimeFiles(cfg config.StorageConfig) (toolOutputDeleted, agentTmpDeleted int) {
+	if cfg.ToolOutputRetentionDays > 0 {
+		dir, err := paths.ToolOutputDir()
+		if err != nil {
+			logging.L().Warn("retention.tool_output.dir_failed", "error", err)
+		} else {
+			toolOutputDeleted = purgeDirByAge(dir, time.Duration(cfg.ToolOutputRetentionDays)*24*time.Hour)
+		}
+	}
+	if cfg.AgentTmpRetentionDays > 0 {
+		dir, err := paths.AgentTmpDir()
+		if err != nil {
+			logging.L().Warn("retention.agent_tmp.dir_failed", "error", err)
+		} else {
+			agentTmpDeleted = purgeDirByAge(dir, time.Duration(cfg.AgentTmpRetentionDays)*24*time.Hour)
+		}
+	}
+	return toolOutputDeleted, agentTmpDeleted
+}
+
+func purgeDirByAge(dir string, maxAge time.Duration) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logging.L().Warn("retention.runtime_files.read_failed", "dir", dir, "error", err)
+		}
+		return 0
+	}
+	cutoff := time.Now().Add(-maxAge)
+	deleted := 0
+	for _, ent := range entries {
+		info, err := ent.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		path := filepath.Join(dir, ent.Name())
+		if err := os.RemoveAll(path); err != nil {
+			logging.L().Warn("retention.runtime_files.remove_failed", "path", path, "error", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted
+}

--- a/cometmind/internal/retention/runtime_files_test.go
+++ b/cometmind/internal/retention/runtime_files_test.go
@@ -1,0 +1,61 @@
+package retention
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cometline/cometmind/internal/config"
+)
+
+func TestPurgeRuntimeFilesByAge(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", dir)
+
+	toolDir := filepath.Join(dir, "tool-output")
+	tmpDir := filepath.Join(dir, "agent-tmp")
+	if err := os.MkdirAll(toolDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	oldTool := filepath.Join(toolDir, "old.txt")
+	newTool := filepath.Join(toolDir, "new.txt")
+	oldTmp := filepath.Join(tmpDir, "old.txt")
+	if err := os.WriteFile(oldTool, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newTool, []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldTmp, []byte("z"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * 24 * time.Hour)
+	if err := os.Chtimes(oldTool, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(oldTmp, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	to, at := PurgeRuntimeFiles(config.StorageConfig{
+		ToolOutputRetentionDays: 7,
+		AgentTmpRetentionDays:   3,
+	})
+	if to != 1 || at != 1 {
+		t.Fatalf("deleted tool=%d tmp=%d want 1,1", to, at)
+	}
+	if _, err := os.Stat(oldTool); !os.IsNotExist(err) {
+		t.Fatal("old tool-output should be gone")
+	}
+	if _, err := os.Stat(newTool); err != nil {
+		t.Fatal("new tool-output should remain")
+	}
+	if _, err := os.Stat(oldTmp); !os.IsNotExist(err) {
+		t.Fatal("old agent-tmp should be gone")
+	}
+}

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -60,6 +60,7 @@ type Runtime struct {
 	isRunning     func(sessionID string) bool
 	retentionMu   sync.Mutex
 	reloadMu      sync.Mutex
+	autonomyWorker *autonomy.Worker
 }
 
 // New builds a Runtime from the environment and filesystem.
@@ -226,94 +227,95 @@ func (r *Runtime) SetSessionRunningChecker(fn func(sessionID string) bool) {
 }
 
 // StartJobsMaintenance runs periodic orphan reconcile and optional purge.
+// The reconcile interval is re-read each cycle so Reload can change it live.
 func (r *Runtime) StartJobsMaintenance(ctx context.Context) {
 	if r == nil || r.Jobs == nil {
 		return
 	}
-	interval := time.Duration(r.jobSettingsSnapshot().ReconcileIntervalS) * time.Second
-	if interval <= 0 {
-		interval = jobs.DefaultReconcileInterval
-	}
 	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
 		for {
+			interval := time.Duration(r.jobSettingsSnapshot().ReconcileIntervalS) * time.Second
+			if interval <= 0 {
+				interval = jobs.DefaultReconcileInterval
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				if _, err := r.Jobs.Reconcile(ctx, r.isRunning); err != nil {
-					logging.L().Warn("jobs.reconcile.failed", "error", err)
+			case <-time.After(interval):
+			}
+			if _, err := r.Jobs.Reconcile(ctx, r.isRunning); err != nil {
+				logging.L().Warn("jobs.reconcile.failed", "error", err)
+			}
+			settings := r.jobSettingsSnapshot()
+			if stale, err := r.Jobs.StaleOngoing(ctx, time.Duration(settings.StaleReviewMinutes)*time.Minute); err != nil {
+				logging.L().Warn("jobs.stale_review.failed", "error", err)
+			} else {
+				for _, job := range stale {
+					logging.L().Warn("jobs.stale_ongoing", "job_id", job.ID, "assigned_session_id", job.AssignedSessionID, "updated_at", job.UpdatedAt)
 				}
-				settings := r.jobSettingsSnapshot()
-				if stale, err := r.Jobs.StaleOngoing(ctx, time.Duration(settings.StaleReviewMinutes)*time.Minute); err != nil {
-					logging.L().Warn("jobs.stale_review.failed", "error", err)
-				} else {
-					for _, job := range stale {
-						logging.L().Warn("jobs.stale_ongoing", "job_id", job.ID, "assigned_session_id", job.AssignedSessionID, "updated_at", job.UpdatedAt)
-					}
+			}
+			cfg := r.Config.EffectiveStorageConfig()
+			if cfg.JobPurgeEnabled() {
+				if _, err := r.Jobs.PurgeDeleted(ctx, cfg.DeletedJobPurgeDays); err != nil {
+					logging.L().Warn("jobs.purge.failed", "error", err)
 				}
-				cfg := r.Config.EffectiveStorageConfig()
-				if cfg.JobPurgeEnabled() {
-					if _, err := r.Jobs.PurgeDeleted(ctx, cfg.DeletedJobPurgeDays); err != nil {
-						logging.L().Warn("jobs.purge.failed", "error", err)
-					}
-				}
-				if _, err := r.Jobs.ArchiveDone(ctx, settings.DoneArchiveDays); err != nil {
-					logging.L().Warn("jobs.done_archive.failed", "error", err)
-				}
-				if _, err := r.Jobs.PurgeArchived(ctx, settings.ArchivedPurgeDays); err != nil {
-					logging.L().Warn("jobs.archive_purge.failed", "error", err)
-				}
+			}
+			if _, err := r.Jobs.ArchiveDone(ctx, settings.DoneArchiveDays); err != nil {
+				logging.L().Warn("jobs.done_archive.failed", "error", err)
+			}
+			if _, err := r.Jobs.PurgeArchived(ctx, settings.ArchivedPurgeDays); err != nil {
+				logging.L().Warn("jobs.archive_purge.failed", "error", err)
 			}
 		}
 	}()
 }
 
 // StartRetentionMaintenance runs full storage retention on the configured interval.
+// Interval and enablement are re-read each cycle so Reload can change them live.
 func (r *Runtime) StartRetentionMaintenance(ctx context.Context) {
 	if r == nil {
 		return
 	}
-	cfg := r.Config.EffectiveStorageConfig()
-	if !cfg.RetentionEnabled() && !cfg.MemoryPurgeEnabled() && !cfg.JobPurgeEnabled() {
-		return
-	}
-	interval := time.Duration(cfg.CleanupIntervalMinutes) * time.Minute
-	if interval <= 0 {
-		interval = time.Hour
-	}
 	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
 		for {
+			cfg := r.Config.EffectiveStorageConfig()
+			enabled := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || cfg.JobPurgeEnabled()
+			interval := time.Duration(cfg.CleanupIntervalMinutes) * time.Minute
+			if interval <= 0 {
+				interval = time.Hour
+			}
+			if !enabled {
+				interval = 2 * time.Minute
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				result, err := r.RunRetention(ctx)
-				if err != nil {
-					logging.L().Warn("retention.failed", "error", err)
-					continue
-				}
-				if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 {
-					logging.L().Info("retention.completed",
-						"sessions_deleted", result.SessionsDeleted,
-						"subagents_deleted", result.SubagentsDeleted,
-						"memories_purged", result.MemoriesPurged,
-						"memory_events_purged", result.MemoryEventsPurged,
-						"jobs_purged", result.JobsPurged,
-						"vacuumed", result.Vacuumed,
-					)
-				}
+			case <-time.After(interval):
+			}
+			if !enabled {
+				continue
+			}
+			result, err := r.RunRetention(ctx)
+			if err != nil {
+				logging.L().Warn("retention.failed", "error", err)
+				continue
+			}
+			if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 {
+				logging.L().Info("retention.completed",
+					"sessions_deleted", result.SessionsDeleted,
+					"subagents_deleted", result.SubagentsDeleted,
+					"memories_purged", result.MemoriesPurged,
+					"memory_events_purged", result.MemoryEventsPurged,
+					"jobs_purged", result.JobsPurged,
+					"vacuumed", result.Vacuumed,
+				)
 			}
 		}
 	}()
 }
 
 // StartAutonomousJobWorker starts the background worker that claims and
-// executes ready jobs without a human opening a chat session first. It is a
-// no-op if autonomy is disabled in config (Worker.Run checks this itself).
+// executes ready jobs without a human opening a chat session first.
 func (r *Runtime) StartAutonomousJobWorker(ctx context.Context, guard autonomy.RunGuard) {
 	if r == nil || r.Jobs == nil || r.Sessions == nil {
 		return
@@ -328,6 +330,7 @@ func (r *Runtime) StartAutonomousJobWorker(ctx context.Context, guard autonomy.R
 		DefaultModelID:    r.autonomyModelID(),
 		DefaultProviderID: r.autonomyProviderID(),
 	}
+	r.autonomyWorker = w
 	go w.Run(ctx)
 }
 
@@ -402,14 +405,73 @@ func (r *Runtime) Reload(ctx context.Context) error {
 	if r.acpMgr != nil {
 		r.acpMgr.UpdateConfig(cfg.ACPSettings())
 	}
-	if r.Memory != nil {
-		r.Memory.UpdateSettings(cfg.MemorySettings())
+	if err := r.reloadMemory(cfg); err != nil {
+		return err
 	}
 	r.SetJobSettings(cfg.JobsSettings())
+	if r.autonomyWorker != nil {
+		r.autonomyWorker.UpdateConfig(
+			cfg.EffectiveAutonomousJobsSettings(),
+			r.autonomyModelIDFrom(cfg),
+			r.autonomyProviderIDFrom(cfg),
+		)
+	}
 	*r.Config = *cfg
 	r.SystemPrompt = systemPrompt
 	logging.L().Info("runtime.reloaded")
 	return nil
+}
+
+func (r *Runtime) reloadMemory(cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if !cfg.MemoryRuntimeEnabled() {
+		if r.Memory != nil {
+			_ = r.Memory.UpdateSettings(cfg.MemorySettings())
+		}
+		return nil
+	}
+	p, err := provider.New(cfg)
+	if err != nil {
+		return fmt.Errorf("reload memory provider: %w", err)
+	}
+	if r.Memory == nil {
+		mem, err := memory.NewService(r.DB, cfg.MemorySettings(), p, r.Sessions)
+		if err != nil {
+			return fmt.Errorf("create memory on reload: %w", err)
+		}
+		r.Memory = mem
+		if r.autonomyWorker != nil {
+			r.autonomyWorker.Memory = mem
+		}
+		return nil
+	}
+	if err := r.Memory.UpdateSettings(cfg.MemorySettings()); err != nil {
+		return fmt.Errorf("reload memory settings: %w", err)
+	}
+	r.Memory.SetProvider(p)
+	return nil
+}
+
+func (r *Runtime) autonomyProviderIDFrom(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if providerID := strings.TrimSpace(cfg.Autonomy.ProviderID); providerID != "" {
+		return providerID
+	}
+	return cfg.Provider
+}
+
+func (r *Runtime) autonomyModelIDFrom(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if modelID := strings.TrimSpace(cfg.Autonomy.ModelID); modelID != "" {
+		return modelID
+	}
+	return cfg.Model
 }
 
 // WorkspaceForCommand resolves the current directory (or the explicit workspace
@@ -555,6 +617,7 @@ func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry sk
 		JobSourceChannelID: sourceChannelID,
 		BrowserSearchURL:   os.Getenv("COMETLINE_BROWSER_SEARCH_URL"),
 		BrowserSearchToken: os.Getenv("COMETLINE_BROWSER_SEARCH_TOKEN"),
+		SettingsRuntime:    r,
 		RunnerFactory: func(child session.Session, workspaceRoot string, maxSteps int, mode tools.SubagentMode) (tools.AgentLoopRunner, error) {
 			return r.SubagentRunnerFor(child, workspaceRoot, maxSteps, mode)
 		},

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -177,19 +177,36 @@ func (r *Runtime) StartScheduler(ctx context.Context) {
 }
 
 func runRetention(ctx context.Context, db *sql.DB, sessions *session.Service, mem *memory.Service, jobSvc *jobs.Service, cfg config.StorageConfig, isRunning func(string) bool) (retention.Result, error) {
-	if !cfg.RetentionEnabled() && !cfg.MemoryPurgeEnabled() && !cfg.JobPurgeEnabled() {
-		return retention.Result{}, nil
+	var out retention.Result
+	needDB := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || cfg.JobPurgeEnabled()
+	if needDB {
+		rr := &retention.Runner{
+			DB:          db,
+			Sessions:    sessions,
+			Memory:      mem,
+			Jobs:        jobSvc,
+			Config:      cfg,
+			IsRunning:   isRunning,
+			VacuumAsync: true,
+		}
+		var err error
+		out, err = rr.Run(ctx)
+		if err != nil {
+			return out, err
+		}
 	}
-	rr := &retention.Runner{
-		DB:          db,
-		Sessions:    sessions,
-		Memory:      mem,
-		Jobs:        jobSvc,
-		Config:      cfg,
-		IsRunning:   isRunning,
-		VacuumAsync: true,
+	if cfg.RuntimeFilesEnabled() {
+		to, at := retention.PurgeRuntimeFiles(cfg)
+		out.ToolOutputDeleted = to
+		out.AgentTmpDeleted = at
+		if to > 0 || at > 0 {
+			logging.L().Info("retention.runtime_files",
+				"tool_output_deleted", to,
+				"agent_tmp_deleted", at,
+			)
+		}
 	}
-	return rr.Run(ctx)
+	return out, nil
 }
 
 // RunRetention executes the configured storage retention rules once.
@@ -279,7 +296,7 @@ func (r *Runtime) StartRetentionMaintenance(ctx context.Context) {
 	go func() {
 		for {
 			cfg := r.Config.EffectiveStorageConfig()
-			enabled := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || cfg.JobPurgeEnabled()
+			enabled := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || cfg.JobPurgeEnabled() || cfg.RuntimeFilesEnabled()
 			interval := time.Duration(cfg.CleanupIntervalMinutes) * time.Minute
 			if interval <= 0 {
 				interval = time.Hour
@@ -300,13 +317,15 @@ func (r *Runtime) StartRetentionMaintenance(ctx context.Context) {
 				logging.L().Warn("retention.failed", "error", err)
 				continue
 			}
-			if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 {
+			if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 || result.ToolOutputDeleted > 0 || result.AgentTmpDeleted > 0 {
 				logging.L().Info("retention.completed",
 					"sessions_deleted", result.SessionsDeleted,
 					"subagents_deleted", result.SubagentsDeleted,
 					"memories_purged", result.MemoriesPurged,
 					"memory_events_purged", result.MemoryEventsPurged,
 					"jobs_purged", result.JobsPurged,
+					"tool_output_deleted", result.ToolOutputDeleted,
+					"agent_tmp_deleted", result.AgentTmpDeleted,
 					"vacuumed", result.Vacuumed,
 				)
 			}

--- a/cometmind/internal/settingsapply/classify.go
+++ b/cometmind/internal/settingsapply/classify.go
@@ -1,0 +1,251 @@
+// Package settingsapply classifies and redacts Cometline settings documents
+// for agent tools and shared apply semantics with the desktop UI.
+package settingsapply
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ApplyAction describes how a settings change should be applied at runtime.
+type ApplyAction string
+
+const (
+	ApplyNone        ApplyAction = "none"
+	ApplyReload      ApplyAction = "reload"
+	ApplyGateway     ApplyAction = "gateway"
+	ApplyUnsupported ApplyAction = "unsupported"
+)
+
+// SecretSentinel is the placeholder written into redacted settings for secret fields.
+// On patch, this value (or "***") means "keep the previous secret".
+const SecretSentinel = "__REDACTED__"
+
+// FieldMeta describes one agent-editable settings path.
+type FieldMeta struct {
+	Path        string      `json:"path"`
+	Secret      bool        `json:"secret"`
+	ApplyClass  ApplyAction `json:"apply_class"`
+	Description string      `json:"description"`
+}
+
+// Catalog lists agent-facing editable paths and their apply semantics.
+func Catalog() []FieldMeta {
+	return []FieldMeta{
+		{Path: "providers", Secret: false, ApplyClass: ApplyReload, Description: "LLM provider configs (API keys are secret leaf fields)"},
+		{Path: "providers[].apiKey", Secret: true, ApplyClass: ApplyReload, Description: "Provider API key"},
+		{Path: "activeProviderId", Secret: false, ApplyClass: ApplyReload, Description: "Active provider id"},
+		{Path: "defaultModelId", Secret: false, ApplyClass: ApplyReload, Description: "Default model id for new sessions"},
+		{Path: "defaultProviderId", Secret: false, ApplyClass: ApplyReload, Description: "Default provider id for new sessions"},
+		{Path: "cometmind.acp", Secret: false, ApplyClass: ApplyReload, Description: "Coding-harness delegation"},
+		{Path: "cometmind.skills", Secret: false, ApplyClass: ApplyReload, Description: "Agent Skills discovery"},
+		{Path: "cometmind.memory", Secret: false, ApplyClass: ApplyReload, Description: "Memory retrieval/extraction/embedding"},
+		{Path: "cometmind.memory.embedding.apiKey", Secret: true, ApplyClass: ApplyReload, Description: "Embedding API key override"},
+		{Path: "cometmind.storage", Secret: false, ApplyClass: ApplyReload, Description: "Storage retention and cleanup"},
+		{Path: "cometmind.mcp", Secret: false, ApplyClass: ApplyReload, Description: "MCP servers"},
+		{Path: "cometmind.jobs", Secret: false, ApplyClass: ApplyReload, Description: "Jobs queue settings"},
+		{Path: "cometmind.autonomy", Secret: false, ApplyClass: ApplyReload, Description: "Autonomous job worker"},
+		{Path: "cometmind.scheduler", Secret: false, ApplyClass: ApplyReload, Description: "Scheduled jobs"},
+		{Path: "cometmind.maxTokens", Secret: false, ApplyClass: ApplyReload, Description: "Max output tokens"},
+		{Path: "cometmind.contextWindowLimit", Secret: false, ApplyClass: ApplyReload, Description: "Context window limit"},
+		{Path: "cometmind.titleProviderId", Secret: false, ApplyClass: ApplyReload, Description: "Title generation provider"},
+		{Path: "cometmind.titleModelId", Secret: false, ApplyClass: ApplyReload, Description: "Title generation model"},
+		{Path: "cometmind.gateway", Secret: false, ApplyClass: ApplyGateway, Description: "Gateway platforms (restarts gateway process(es) only; serve stays up)"},
+		{Path: "cometmind.gateway.discord", Secret: false, ApplyClass: ApplyGateway, Description: "Discord gateway platform settings"},
+		{Path: "cometmind.gateway.discord.botToken", Secret: true, ApplyClass: ApplyGateway, Description: "Discord bot token"},
+		{Path: "cometmind.systemPromptPath", Secret: false, ApplyClass: ApplyUnsupported, Description: "Packaged prompt path — lives in cometline-desktop.json; use Settings UI"},
+		{Path: "cometmind.host", Secret: false, ApplyClass: ApplyUnsupported, Description: "Listen host — not in settings files (Electron/CLI bind)"},
+		{Path: "cometmind.port", Secret: false, ApplyClass: ApplyUnsupported, Description: "Listen port — not in settings files (Electron/CLI bind)"},
+		{Path: "app", Secret: false, ApplyClass: ApplyUnsupported, Description: "Desktop app/persona — lives in cometline-desktop.json"},
+		{Path: "appearance", Secret: false, ApplyClass: ApplyUnsupported, Description: "Desktop appearance — lives in cometline-desktop.json"},
+		{Path: "shortcuts", Secret: false, ApplyClass: ApplyUnsupported, Description: "Desktop shortcuts — lives in cometline-desktop.json"},
+	}
+}
+
+// ClassifyResult is the apply plan for a settings transition.
+type ClassifyResult struct {
+	Action      ApplyAction `json:"action"`
+	Gateway     bool        `json:"gateway"`
+	Unsupported []string    `json:"unsupported,omitempty"`
+}
+
+// Classify compares before/after settings JSON objects and returns how to apply.
+// Unsupported path changes win. Gateway may combine with Reload when
+// cometmind.gateway and other runtime fields both change.
+func Classify(before, after map[string]any) (ClassifyResult, error) {
+	out := ClassifyResult{Action: ApplyNone}
+	if before == nil {
+		before = map[string]any{}
+	}
+	if after == nil {
+		after = map[string]any{}
+	}
+	beforeCanon, err := canonicalize(before)
+	if err != nil {
+		return out, err
+	}
+	afterCanon, err := canonicalize(after)
+	if err != nil {
+		return out, err
+	}
+	if beforeCanon == afterCanon {
+		return out, nil
+	}
+
+	var unsupported []string
+	if changedAt(before, after, "cometmind", "host") || changedAt(before, after, "cometmind", "port") {
+		unsupported = append(unsupported, "cometmind.host/port")
+	}
+	if changedAt(before, after, "cometmind", "systemPromptPath") {
+		unsupported = append(unsupported, "cometmind.systemPromptPath")
+	}
+	if changedAt(before, after, "app") {
+		unsupported = append(unsupported, "app")
+	}
+	if changedAt(before, after, "appearance") {
+		unsupported = append(unsupported, "appearance")
+	}
+	if changedAt(before, after, "shortcuts") {
+		unsupported = append(unsupported, "shortcuts")
+	}
+	if len(unsupported) > 0 {
+		out.Action = ApplyUnsupported
+		out.Unsupported = unsupported
+		return out, nil
+	}
+
+	gatewayChanged := changedAt(before, after, "cometmind", "gateway")
+	out.Gateway = gatewayChanged
+
+	cometmindSansGatewayEqual := equalSans(before["cometmind"], after["cometmind"], "gateway")
+	providersEqual := canonicalizeEqual(before["providers"], after["providers"])
+	otherTopEqual := true
+	for _, key := range []string{"activeProviderId", "defaultModelId", "defaultProviderId"} {
+		if changedAt(before, after, key) {
+			otherTopEqual = false
+			break
+		}
+	}
+	// Also treat other top-level keys (except appearance/shortcuts/app already rejected)
+	// as reload-worthy when they change.
+	for k := range after {
+		switch k {
+		case "providers", "activeProviderId", "defaultModelId", "defaultProviderId", "cometmind", "appearance", "shortcuts", "app":
+			continue
+		default:
+			if changedAt(before, after, k) {
+				otherTopEqual = false
+			}
+		}
+	}
+
+	serveNeedsReload := !(cometmindSansGatewayEqual && providersEqual && otherTopEqual)
+	if serveNeedsReload {
+		out.Action = ApplyReload
+		return out, nil
+	}
+	if gatewayChanged {
+		out.Action = ApplyGateway
+		return out, nil
+	}
+	out.Action = ApplyReload
+	return out, nil
+}
+
+func canonicalize(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func canonicalizeEqual(a, b any) bool {
+	ca, err := canonicalize(a)
+	if err != nil {
+		return false
+	}
+	cb, err := canonicalize(b)
+	if err != nil {
+		return false
+	}
+	return ca == cb
+}
+
+func changedAt(before, after map[string]any, path ...string) bool {
+	return !canonicalizeEqual(getPath(before, path...), getPath(after, path...))
+}
+
+func getPath(root any, path ...string) any {
+	cur := root
+	for _, key := range path {
+		m, ok := asMap(cur)
+		if !ok {
+			return nil
+		}
+		cur = m[key]
+	}
+	return cur
+}
+
+func equalSans(before, after any, dropKey string) bool {
+	bm, bok := asMap(before)
+	am, aok := asMap(after)
+	if !bok && !aok {
+		return true
+	}
+	bc := cloneMap(bm)
+	ac := cloneMap(am)
+	delete(bc, dropKey)
+	delete(ac, dropKey)
+	return canonicalizeEqual(bc, ac)
+}
+
+func asMap(v any) (map[string]any, bool) {
+	if v == nil {
+		return nil, false
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+	// json.Unmarshal into map[string]any is the expected shape; tolerate typed maps via re-marshal.
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, false
+	}
+	return m, true
+}
+
+func cloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// IsSecretSentinel reports whether value means "keep previous secret".
+func IsSecretSentinel(v any) bool {
+	s, ok := v.(string)
+	if !ok {
+		return false
+	}
+	s = strings.TrimSpace(s)
+	return s == SecretSentinel || s == "***"
+}
+
+// FormatUnsupported explains why a patch cannot be applied by agent tools.
+func FormatUnsupported(paths []string) string {
+	if len(paths) == 0 {
+		return "unsupported settings change; use the Settings UI (desktop keys live in cometline-desktop.json)"
+	}
+	return fmt.Sprintf("unsupported settings paths (use Settings UI / cometline-desktop.json): %s", strings.Join(paths, ", "))
+}

--- a/cometmind/internal/settingsapply/classify_test.go
+++ b/cometmind/internal/settingsapply/classify_test.go
@@ -1,0 +1,131 @@
+package settingsapply_test
+
+import (
+	"testing"
+
+	"github.com/cometline/cometmind/internal/settingsapply"
+)
+
+func TestClassifyReloadAndGateway(t *testing.T) {
+	before := map[string]any{
+		"providers": []any{
+			map[string]any{"id": "openai", "apiKey": "sk-old"},
+		},
+		"cometmind": map[string]any{
+			"memory": map[string]any{"enabled": true},
+			"gateway": map[string]any{
+				"discord": map[string]any{"enabled": false, "botToken": ""},
+			},
+		},
+	}
+	afterMemory := deepCopy(before)
+	afterMemory["cometmind"].(map[string]any)["memory"] = map[string]any{"enabled": false}
+	res, err := settingsapply.Classify(before, afterMemory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Action != settingsapply.ApplyReload || res.Gateway || len(res.Unsupported) != 0 {
+		t.Fatalf("memory change: %+v", res)
+	}
+
+	afterDiscord := deepCopy(before)
+	afterDiscord["cometmind"].(map[string]any)["gateway"] = map[string]any{
+		"discord": map[string]any{"enabled": true, "botToken": "tok"},
+	}
+	res, err = settingsapply.Classify(before, afterDiscord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Action != settingsapply.ApplyGateway || !res.Gateway {
+		t.Fatalf("gateway-only: %+v", res)
+	}
+
+	afterBoth := deepCopy(before)
+	afterBoth["cometmind"].(map[string]any)["memory"] = map[string]any{"enabled": false}
+	afterBoth["cometmind"].(map[string]any)["gateway"] = map[string]any{
+		"discord": map[string]any{"enabled": true, "botToken": "tok"},
+	}
+	res, err = settingsapply.Classify(before, afterBoth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Action != settingsapply.ApplyReload || !res.Gateway {
+		t.Fatalf("memory+gateway: %+v", res)
+	}
+
+	afterHost := deepCopy(before)
+	afterHost["cometmind"].(map[string]any)["host"] = "0.0.0.0"
+	res, err = settingsapply.Classify(before, afterHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Action != settingsapply.ApplyUnsupported || len(res.Unsupported) == 0 {
+		t.Fatalf("host change: %+v", res)
+	}
+
+	afterAppearance := deepCopy(before)
+	afterAppearance["appearance"] = map[string]any{"heroComposer": map[string]any{"presetId": "rose"}}
+	res, err = settingsapply.Classify(before, afterAppearance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Action != settingsapply.ApplyUnsupported {
+		t.Fatalf("appearance change: %+v", res)
+	}
+}
+
+func TestRedactAndMergePreserveSecrets(t *testing.T) {
+	doc := map[string]any{
+		"providers": []any{
+			map[string]any{"id": "openai", "apiKey": "sk-secret", "enabled": true},
+		},
+		"cometmind": map[string]any{
+			"memory": map[string]any{
+				"embedding": map[string]any{"apiKey": "emb-secret", "model": "m"},
+			},
+			"gateway": map[string]any{
+				"discord": map[string]any{"botToken": "discord-tok", "enabled": true},
+			},
+		},
+	}
+	redacted := settingsapply.RedactSecrets(doc)
+	providers := redacted["providers"].([]any)
+	p0 := providers[0].(map[string]any)
+	if p0["apiKey"] != settingsapply.SecretSentinel {
+		t.Fatalf("apiKey not redacted: %v", p0["apiKey"])
+	}
+	if p0["apiKey_has_value"] != true {
+		t.Fatalf("apiKey_has_value=%v", p0["apiKey_has_value"])
+	}
+
+	patch := map[string]any{
+		"providers": []any{
+			map[string]any{"id": "openai", "apiKey": settingsapply.SecretSentinel, "enabled": false},
+		},
+		"cometmind": map[string]any{
+			"memory": map[string]any{
+				"embedding": map[string]any{"apiKey": "***", "model": "m2"},
+			},
+		},
+	}
+	merged := settingsapply.MergePatch(doc, patch)
+	settingsapply.RestoreSecretsInProviders(merged, doc)
+	mp := merged["providers"].([]any)[0].(map[string]any)
+	if mp["apiKey"] != "sk-secret" {
+		t.Fatalf("apiKey not preserved: %v", mp["apiKey"])
+	}
+	if mp["enabled"] != false {
+		t.Fatalf("enabled not patched: %v", mp["enabled"])
+	}
+	emb := merged["cometmind"].(map[string]any)["memory"].(map[string]any)["embedding"].(map[string]any)
+	if emb["apiKey"] != "emb-secret" {
+		t.Fatalf("embedding apiKey not preserved: %v", emb["apiKey"])
+	}
+	if emb["model"] != "m2" {
+		t.Fatalf("embedding model not patched: %v", emb["model"])
+	}
+}
+
+func deepCopy(in map[string]any) map[string]any {
+	return settingsapply.MergePatch(map[string]any{}, in)
+}

--- a/cometmind/internal/settingsapply/redact.go
+++ b/cometmind/internal/settingsapply/redact.go
@@ -1,0 +1,242 @@
+package settingsapply
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// RedactSecrets walks a settings document and replaces known secret string
+// fields with SecretSentinel while recording has_value alongside each secret
+// as "<field>_has_value".
+func RedactSecrets(doc map[string]any) map[string]any {
+	out := deepCloneMap(doc)
+	redactProviders(out)
+	if cm, ok := asMap(out["cometmind"]); ok {
+		redactMemoryEmbedding(cm)
+		redactDiscord(cm)
+		out["cometmind"] = cm
+	}
+	return out
+}
+
+func redactProviders(doc map[string]any) {
+	arr, ok := doc["providers"].([]any)
+	if !ok {
+		return
+	}
+	for i, item := range arr {
+		m, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		redactStringField(m, "apiKey")
+		arr[i] = m
+	}
+	doc["providers"] = arr
+}
+
+func redactMemoryEmbedding(cm map[string]any) {
+	mem, ok := asMap(cm["memory"])
+	if !ok {
+		return
+	}
+	emb, ok := asMap(mem["embedding"])
+	if !ok {
+		return
+	}
+	redactStringField(emb, "apiKey")
+	mem["embedding"] = emb
+	cm["memory"] = mem
+}
+
+func redactDiscord(cm map[string]any) {
+	gw, ok := asMap(cm["gateway"])
+	if !ok {
+		return
+	}
+	discord, ok := asMap(gw["discord"])
+	if !ok {
+		return
+	}
+	redactStringField(discord, "botToken")
+	gw["discord"] = discord
+	cm["gateway"] = gw
+}
+
+func redactStringField(m map[string]any, key string) {
+	raw, exists := m[key]
+	has := false
+	if exists {
+		if s, ok := raw.(string); ok {
+			has = strings.TrimSpace(s) != ""
+		} else if raw != nil {
+			has = true
+		}
+	}
+	m[key] = SecretSentinel
+	m[key+"_has_value"] = has
+}
+
+func deepCloneMap(m map[string]any) map[string]any {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return cloneMap(m)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return cloneMap(m)
+	}
+	return out
+}
+
+// MergePatch deep-merges patch into base. Secret sentinel strings keep the
+// previous value. *_has_value keys in the patch are ignored (read-only metadata).
+func MergePatch(base, patch map[string]any) map[string]any {
+	out := deepCloneMap(base)
+	mergeInto(out, patch)
+	stripHasValueKeys(out)
+	return out
+}
+
+func mergeInto(dst, patch map[string]any) {
+	for k, pv := range patch {
+		if stringsHasSuffix(k, "_has_value") {
+			continue
+		}
+		if IsSecretSentinel(pv) {
+			continue
+		}
+		dv, exists := dst[k]
+		pm, pIsMap := asMap(pv)
+		dm, dIsMap := asMap(dv)
+		if pIsMap && dIsMap {
+			mergeInto(dm, pm)
+			dst[k] = dm
+			continue
+		}
+		if pIsMap && !exists {
+			dst[k] = deepCloneMap(pm)
+			continue
+		}
+		// Arrays and scalars: replace wholesale (including provider list).
+		dst[k] = deepCloneValue(pv)
+	}
+}
+
+// RestoreSecretsInProviders merges provider apiKeys by id when patch used sentinels.
+// Call after MergePatch when providers were replaced as an array of objects that
+// still contain sentinels (MergePatch already skipped sentinel leafs inside maps,
+// but a full providers array replace may carry sentinel apiKeys that need restore).
+func RestoreSecretsInProviders(merged, before map[string]any) {
+	beforeByID := providerAPIKeysByID(before)
+	arr, ok := merged["providers"].([]any)
+	if !ok {
+		return
+	}
+	for i, item := range arr {
+		m, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		id, _ := m["id"].(string)
+		if IsSecretSentinel(m["apiKey"]) {
+			if prev, ok := beforeByID[id]; ok {
+				m["apiKey"] = prev
+			} else {
+				m["apiKey"] = ""
+			}
+		}
+		delete(m, "apiKey_has_value")
+		arr[i] = m
+	}
+	merged["providers"] = arr
+
+	if cm, ok := asMap(merged["cometmind"]); ok {
+		if mem, ok := asMap(cm["memory"]); ok {
+			if emb, ok := asMap(mem["embedding"]); ok {
+				if IsSecretSentinel(emb["apiKey"]) {
+					if bcm, ok := asMap(before["cometmind"]); ok {
+						if bmem, ok := asMap(bcm["memory"]); ok {
+							if bemb, ok := asMap(bmem["embedding"]); ok {
+								emb["apiKey"] = bemb["apiKey"]
+							}
+						}
+					}
+				}
+				delete(emb, "apiKey_has_value")
+				mem["embedding"] = emb
+			}
+			cm["memory"] = mem
+		}
+		if gw, ok := asMap(cm["gateway"]); ok {
+			if discord, ok := asMap(gw["discord"]); ok {
+				if IsSecretSentinel(discord["botToken"]) {
+					if bcm, ok := asMap(before["cometmind"]); ok {
+						if bgw, ok := asMap(bcm["gateway"]); ok {
+							if bdiscord, ok := asMap(bgw["discord"]); ok {
+								discord["botToken"] = bdiscord["botToken"]
+							}
+						}
+					}
+				}
+				delete(discord, "botToken_has_value")
+				gw["discord"] = discord
+			}
+			cm["gateway"] = gw
+		}
+		merged["cometmind"] = cm
+	}
+}
+
+func providerAPIKeysByID(doc map[string]any) map[string]any {
+	out := map[string]any{}
+	arr, ok := doc["providers"].([]any)
+	if !ok {
+		return out
+	}
+	for _, item := range arr {
+		m, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		id, _ := m["id"].(string)
+		if id == "" {
+			continue
+		}
+		out[id] = m["apiKey"]
+	}
+	return out
+}
+
+func stripHasValueKeys(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if stringsHasSuffix(k, "_has_value") {
+				delete(t, k)
+				continue
+			}
+			stripHasValueKeys(child)
+		}
+	case []any:
+		for _, child := range t {
+			stripHasValueKeys(child)
+		}
+	}
+}
+
+func stringsHasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+func deepCloneValue(v any) any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return v
+	}
+	return out
+}

--- a/cometmind/internal/settingsapply/split.go
+++ b/cometmind/internal/settingsapply/split.go
@@ -1,0 +1,176 @@
+package settingsapply
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/cometline/cometmind/internal/paths"
+)
+
+// Desktop top-level keys that belong in cometline-desktop.json, not the runtime settings file.
+var desktopTopLevelKeys = []string{"appearance", "shortcuts", "app"}
+
+// HasDesktopKeys reports whether doc still carries desktop-owned top-level keys.
+func HasDesktopKeys(doc map[string]any) bool {
+	if doc == nil {
+		return false
+	}
+	for _, key := range desktopTopLevelKeys {
+		if _, ok := doc[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// SplitDocument peels a merged ProviderSettings-shaped document into runtime settings
+// and desktop documents. systemPromptPath is copied into both: desktop is the UI
+// source of truth; settings keeps a stamp so CometMind Load can ignore the desktop file.
+func SplitDocument(merged map[string]any) (settings, desktop map[string]any) {
+	settings = deepCloneMap(merged)
+	desktop = map[string]any{}
+
+	for _, key := range desktopTopLevelKeys {
+		if v, ok := settings[key]; ok {
+			desktop[key] = deepCloneValue(v)
+			delete(settings, key)
+		}
+	}
+
+	if cm, ok := asMap(settings["cometmind"]); ok {
+		if prompt, ok := cm["systemPromptPath"]; ok {
+			desktop["systemPromptPath"] = deepCloneValue(prompt)
+			// Keep stamp on runtime settings for CometMind Load.
+			settings["cometmind"] = cm
+		}
+	}
+	return settings, desktop
+}
+
+// MergeDocuments combines runtime settings + desktop into one UI-facing document.
+// Desktop systemPromptPath wins over settings when both are set.
+func MergeDocuments(settings, desktop map[string]any) map[string]any {
+	out := deepCloneMap(settings)
+	if desktop == nil {
+		return out
+	}
+	for _, key := range desktopTopLevelKeys {
+		if v, ok := desktop[key]; ok {
+			out[key] = deepCloneValue(v)
+		}
+	}
+	if prompt, ok := desktop["systemPromptPath"]; ok {
+		cm, ok := asMap(out["cometmind"])
+		if !ok || cm == nil {
+			cm = map[string]any{}
+		} else {
+			cm = deepCloneMap(cm)
+		}
+		cm["systemPromptPath"] = deepCloneValue(prompt)
+		out["cometmind"] = cm
+	}
+	return out
+}
+
+// StripDesktopKeys returns a copy of doc without appearance/shortcuts/app.
+func StripDesktopKeys(doc map[string]any) map[string]any {
+	out := deepCloneMap(doc)
+	for _, key := range desktopTopLevelKeys {
+		delete(out, key)
+	}
+	return out
+}
+
+// DesktopKeysInPatch lists desktop-owned top-level keys present in patch.
+func DesktopKeysInPatch(patch map[string]any) []string {
+	if patch == nil {
+		return nil
+	}
+	var found []string
+	for _, key := range desktopTopLevelKeys {
+		if _, ok := patch[key]; ok {
+			found = append(found, key)
+		}
+	}
+	return found
+}
+
+// MigrateSplitFilesIfNeeded peels desktop keys from cometline-settings.json into
+// cometline-desktop.json when needed. Idempotent.
+func MigrateSplitFilesIfNeeded() error {
+	settingsPath, err := paths.SettingsPath()
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse settings for migrate: %w", err)
+	}
+	if !HasDesktopKeys(doc) {
+		// Still ensure desktop file exists if systemPromptPath should be mirrored.
+		return ensureDesktopPromptMirror(doc)
+	}
+
+	desktopPath, err := paths.DesktopSettingsPath()
+	if err != nil {
+		return err
+	}
+	existingDesktop := map[string]any{}
+	if raw, err := os.ReadFile(desktopPath); err == nil {
+		_ = json.Unmarshal(raw, &existingDesktop)
+	}
+
+	settingsDoc, peeled := SplitDocument(doc)
+	// Prefer freshly peeled desktop keys; keep any other desktop-only fields already present.
+	for k, v := range existingDesktop {
+		if _, taken := peeled[k]; !taken {
+			peeled[k] = v
+		}
+	}
+
+	if err := writeJSONFile(desktopPath, peeled); err != nil {
+		return err
+	}
+	return writeJSONFile(settingsPath, settingsDoc)
+}
+
+func ensureDesktopPromptMirror(settingsDoc map[string]any) error {
+	cm, ok := asMap(settingsDoc["cometmind"])
+	if !ok {
+		return nil
+	}
+	prompt, ok := cm["systemPromptPath"]
+	if !ok {
+		return nil
+	}
+	desktopPath, err := paths.DesktopSettingsPath()
+	if err != nil {
+		return err
+	}
+	desktop := map[string]any{}
+	if raw, err := os.ReadFile(desktopPath); err == nil {
+		_ = json.Unmarshal(raw, &desktop)
+	}
+	if _, exists := desktop["systemPromptPath"]; exists {
+		return nil
+	}
+	desktop["systemPromptPath"] = prompt
+	return writeJSONFile(desktopPath, desktop)
+}
+
+func writeJSONFile(path string, doc map[string]any) error {
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0o600)
+}

--- a/cometmind/internal/settingsapply/split_test.go
+++ b/cometmind/internal/settingsapply/split_test.go
@@ -1,0 +1,109 @@
+package settingsapply_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/settingsapply"
+)
+
+func TestSplitMergeRoundTrip(t *testing.T) {
+	merged := map[string]any{
+		"providers": []any{map[string]any{"id": "openai"}},
+		"appearance": map[string]any{
+			"heroComposer": map[string]any{"presetId": "blue"},
+		},
+		"shortcuts": map[string]any{"toggleMiniWindow": map[string]any{"key": "j"}},
+		"app":       map[string]any{"personaId": "minako", "openAtLogin": false},
+		"cometmind": map[string]any{
+			"systemPromptPath": "/tmp/SOUL.md",
+			"memory":           map[string]any{"enabled": true},
+		},
+	}
+	settings, desktop := settingsapply.SplitDocument(merged)
+	if _, ok := settings["appearance"]; ok {
+		t.Fatal("appearance should not remain in settings")
+	}
+	if desktop["app"].(map[string]any)["personaId"] != "minako" {
+		t.Fatalf("desktop app = %#v", desktop["app"])
+	}
+	if settings["cometmind"].(map[string]any)["systemPromptPath"] != "/tmp/SOUL.md" {
+		t.Fatal("settings should keep systemPromptPath stamp")
+	}
+	if desktop["systemPromptPath"] != "/tmp/SOUL.md" {
+		t.Fatal("desktop should own systemPromptPath")
+	}
+
+	again := settingsapply.MergeDocuments(settings, desktop)
+	if again["app"].(map[string]any)["personaId"] != "minako" {
+		t.Fatalf("merged app = %#v", again["app"])
+	}
+	if again["cometmind"].(map[string]any)["memory"].(map[string]any)["enabled"] != true {
+		t.Fatal("runtime memory lost")
+	}
+}
+
+func TestMigrateSplitFilesIfNeeded(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", dir)
+	settingsPath := filepath.Join(dir, "cometline-settings.json")
+	monolith := map[string]any{
+		"providers": []any{},
+		"appearance": map[string]any{
+			"heroComposer": map[string]any{"presetId": "rose"},
+		},
+		"app": map[string]any{"personaId": "minako"},
+		"cometmind": map[string]any{
+			"systemPromptPath": "/soul.md",
+			"maxTokens":        2048,
+		},
+	}
+	raw, _ := json.MarshalIndent(monolith, "", "  ")
+	if err := os.WriteFile(settingsPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := settingsapply.MigrateSplitFilesIfNeeded(); err != nil {
+		t.Fatal(err)
+	}
+
+	settingsRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settingsDoc map[string]any
+	if err := json.Unmarshal(settingsRaw, &settingsDoc); err != nil {
+		t.Fatal(err)
+	}
+	if settingsapply.HasDesktopKeys(settingsDoc) {
+		t.Fatalf("settings still has desktop keys: %#v", settingsDoc)
+	}
+
+	desktopRaw, err := os.ReadFile(filepath.Join(dir, "cometline-desktop.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var desktopDoc map[string]any
+	if err := json.Unmarshal(desktopRaw, &desktopDoc); err != nil {
+		t.Fatal(err)
+	}
+	if desktopDoc["appearance"] == nil || desktopDoc["app"] == nil {
+		t.Fatalf("desktop missing peeled keys: %#v", desktopDoc)
+	}
+
+	// Idempotent.
+	if err := settingsapply.MigrateSplitFilesIfNeeded(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDesktopKeysInPatch(t *testing.T) {
+	keys := settingsapply.DesktopKeysInPatch(map[string]any{
+		"appearance": map[string]any{},
+		"cometmind":  map[string]any{"maxTokens": 1},
+	})
+	if len(keys) != 1 || keys[0] != "appearance" {
+		t.Fatalf("keys=%v", keys)
+	}
+}

--- a/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
+++ b/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
@@ -11,9 +11,16 @@ Use this skill when the user wants help configuring Cometline or CometMind. This
 
 1. Identify what the user wants to configure before changing anything. If the request is ambiguous, ask one focused question.
 2. Prefer the Settings UI for user-facing configuration instructions. Mention exact sections such as Settings -> Providers, Settings -> CometMind -> Skills, Settings -> CometMind -> Coding task delegation, Settings -> CometMind -> Discord, or Settings -> CometMind -> Storage.
-3. Prefer CLI commands when the user wants the agent to inspect or modify settings directly. Use `cometmind settings path`, `cometmind settings show`, `cometmind settings export`, `cometmind settings import`, `cometmind settings reload`, and `cometmind process status|stop|restart` when available. If `cometmind` is not found, try `~/.cometmind/bin/cometmind`; the desktop app installs this shim on startup and also tries common PATH locations such as `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` when writable. In a development checkout, build it with `cd cometline && pnpm run build:sidecar` or run `cd cometmind && go run . settings path`.
-4. Treat provider API keys and exported settings as secrets. Warn the user before printing, exporting, or moving files that may contain API keys.
-5. After changing runtime settings that affect CometMind, tell the user whether CometMind can hot-reload or must restart. Provider changes, default model changes, system prompt changes, and many runtime settings can reload in place. Memory settings, memory provider changes, storage cleanup interval changes, job reconcile interval changes, host or port changes, and Discord token or session changes still require restart. The desktop app tries reload first and falls back to restart when needed.
+3. Prefer the settings tools when the agent should inspect or change settings itself:
+   - Runtime file: `~/.cometmind/cometline-settings.json` (providers, cometmind.*, defaults)
+   - Desktop file: `~/.cometmind/cometline-desktop.json` (appearance, shortcuts, app/persona) — **Electron only**; never edit via tools or shell
+   - `list_settings` — editable paths, secret flags, and apply class (`reload` / `gateway` / `unsupported`)
+   - `get_settings` — read the runtime settings file (or a dotted path subtree); secrets are redacted to `__REDACTED__` with `<field>_has_value`
+   - `patch_settings` — deep-merge a JSON patch into the runtime settings file (mode `0600`), then auto-apply (in-place reload and/or gateway process restart)
+   - Rejected via tools: `appearance`, `shortcuts`, `app`, `systemPromptPath`, host/port — tell the user to use the Settings UI
+   - When patching secrets, send a new string to set the key, or `__REDACTED__` / `***` to keep the previous value. Never ask the user to paste secrets into chat when a safer path exists.
+4. CLI fallbacks remain available (`cometmind settings path|show|export|import|reload`, `cometmind process status|stop|restart`) when tools are unavailable. If `cometmind` is not found, try `~/.cometmind/bin/cometmind`.
+5. After changes, almost all runtime fields hot-reload without killing the current chat turn. Changes under `cometmind.gateway` recycle **gateway process(es) only**. Full main-sidecar restart is reserved for true process-level bind changes (host/port) via the Settings UI.
 
 ## Provider Setup
 
@@ -31,12 +38,12 @@ Coding-harness delegation is configured under Settings -> CometMind -> Coding ta
 
 ## Discord Gateway
 
-Discord gateway configuration lives under Settings -> CometMind -> Discord. Confirm the bot token environment variable name, workspace path, allowed user IDs, and mention requirements. Do not ask the user to paste bot tokens into chat unless there is no safer option.
+Discord gateway configuration lives under Settings -> CometMind -> Discord. Confirm the bot token environment variable name, workspace path, allowed user IDs, and mention requirements. Do not ask the user to paste bot tokens into chat unless there is no safer option. Agent `patch_settings` on `cometmind.gateway` restarts gateway process(es) only — the main CometMind serve process (and the current chat turn) stays up.
 
 ## Memory And Storage
 
-Memory and storage settings live under Settings -> CometMind. Explain what will be stored locally, what may be archived, and how provider/model choices affect extraction or summarization if the user is tuning memory behavior.
+Memory and storage settings live under Settings -> CometMind. Explain what will be stored locally, what may be archived, and how provider/model choices affect extraction or summarization if the user is tuning memory behavior. Memory, storage cleanup interval, jobs reconcile interval, and autonomy changes apply via in-place reload.
 
 ## Troubleshooting
 
-If settings do not persist, check `~/.cometmind/cometline-settings.json` and file permissions. If the sidecar will not start, check `~/.cometmind/cometline.log`, port `7700`, and the packaged or development CometMind binary path.
+If settings do not persist, check `~/.cometmind/cometline-settings.json` and `~/.cometmind/cometline-desktop.json` plus file permissions. If the sidecar will not start, check `~/.cometmind/cometline.log`, port `7700`, and the packaged or development CometMind binary path. Note: `Reload` reconnects MCP servers, so in-flight MCP tool calls can fail even though the chat turn continues.

--- a/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
+++ b/cometmind/internal/skills/builtin/setup-cometline/SKILL.md
@@ -46,4 +46,4 @@ Memory and storage settings live under Settings -> CometMind. Explain what will 
 
 ## Troubleshooting
 
-If settings do not persist, check `~/.cometmind/cometline-settings.json` and `~/.cometmind/cometline-desktop.json` plus file permissions. If the sidecar will not start, check `~/.cometmind/cometline.log`, port `7700`, and the packaged or development CometMind binary path. Note: `Reload` reconnects MCP servers, so in-flight MCP tool calls can fail even though the chat turn continues.
+If settings do not persist, check `~/.cometmind/cometline-settings.json` and `~/.cometmind/cometline-desktop.json` plus file permissions. If the sidecar will not start, check `~/.cometmind/logs/cometline.log`, port `7700`, and the packaged or development CometMind binary path. Note: `Reload` reconnects MCP servers, so in-flight MCP tool calls can fail even though the chat turn continues.

--- a/cometmind/internal/tools/options.go
+++ b/cometmind/internal/tools/options.go
@@ -51,6 +51,7 @@ type RegistryOptions struct {
 	JobSourceChannelID string
 	BrowserSearchURL   string
 	BrowserSearchToken string
+	SettingsRuntime    SettingsRuntime
 }
 
 // SubagentToolConfig holds limits passed into subagent tools.

--- a/cometmind/internal/tools/registry.go
+++ b/cometmind/internal/tools/registry.go
@@ -118,6 +118,11 @@ func newRegistryWithSurface(workspaceRoot string, surface ToolSurface, opt Regis
 		add(UpdateMemory{Memory: opt.Memory, Events: opt.MemoryEvents})
 		add(DeleteMemory{Memory: opt.Memory, Events: opt.MemoryEvents})
 	}
+	if surface.Settings {
+		add(listSettingsTool{})
+		add(getSettingsTool{})
+		add(patchSettingsTool{Runtime: opt.SettingsRuntime})
+	}
 	return r
 }
 

--- a/cometmind/internal/tools/registry_test.go
+++ b/cometmind/internal/tools/registry_test.go
@@ -16,6 +16,7 @@ func TestNewSubagentRegistryExcludesWriteAndDelegateTools(t *testing.T) {
 	excluded := []string{
 		"edit_file", "write_file", "run_command", "write_skill", "write_skill_draft",
 		"delegate_coding_task", "spawn_general_agent", "wait_subagents",
+		"list_settings", "get_settings", "patch_settings",
 	}
 	for _, name := range excluded {
 		if r.Has(name) {
@@ -37,7 +38,7 @@ func TestNewSubagentRegistryCodingIncludesEditTools(t *testing.T) {
 			t.Errorf("coding subagent registry missing %q", name)
 		}
 	}
-	for _, name := range []string{"delegate_coding_task", "spawn_general_agent"} {
+	for _, name := range []string{"delegate_coding_task", "spawn_general_agent", "list_settings", "patch_settings"} {
 		if r.Has(name) {
 			t.Errorf("coding subagent registry should not include %q", name)
 		}
@@ -56,10 +57,13 @@ func TestNewRegistryCapturesWorkspaceAndExposesSpecs(t *testing.T) {
 	}
 
 	specs := r.CometSDK()
-	if len(specs) != 9 {
-		t.Fatalf("CometSDK() returned %d specs, want 9", len(specs))
+	if len(specs) != 12 {
+		t.Fatalf("CometSDK() returned %d specs, want 12", len(specs))
 	}
-	wantNames := []string{"read_file", "edit_file", "write_file", "list_dir", "glob", "grep", "run_command", "web_fetch", "web_search"}
+	wantNames := []string{
+		"read_file", "edit_file", "write_file", "list_dir", "glob", "grep", "run_command",
+		"web_fetch", "web_search", "list_settings", "get_settings", "patch_settings",
+	}
 	for i, name := range wantNames {
 		if specs[i].Name != name {
 			t.Errorf("spec[%d].Name = %q, want %q", i, specs[i].Name, name)

--- a/cometmind/internal/tools/settings_tools.go
+++ b/cometmind/internal/tools/settings_tools.go
@@ -1,0 +1,253 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cometline/cometmind/internal/config"
+	"github.com/cometline/cometmind/internal/paths"
+	"github.com/cometline/cometmind/internal/processctl"
+	"github.com/cometline/cometmind/internal/settingsapply"
+)
+
+// SettingsRuntime applies settings changes without killing the current agent turn.
+type SettingsRuntime interface {
+	Reload(ctx context.Context) error
+}
+
+type listSettingsTool struct{}
+
+func (listSettingsTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name: "list_settings",
+		Description: "List agent-editable paths in ~/.cometmind/cometline-settings.json (runtime). " +
+			"Desktop UI state (appearance, shortcuts, app/persona) lives in cometline-desktop.json and is unsupported here. " +
+			"Apply classes: reload, gateway, or unsupported.",
+		Parameters: json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
+func (listSettingsTool) Execute(_ context.Context, _ json.RawMessage) (Result, error) {
+	b, err := json.MarshalIndent(settingsapply.Catalog(), "", "  ")
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	return Result{OK: true, Output: string(b)}, nil
+}
+
+type getSettingsTool struct{}
+
+func (getSettingsTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name: "get_settings",
+		Description: "Read ~/.cometmind/cometline-settings.json (runtime only; not desktop UI). " +
+			"Optional dotted path subtree. Secret fields are redacted to " +
+			settingsapply.SecretSentinel + " with a sibling <field>_has_value boolean. Never expect raw API keys.",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"path":{"type":"string","description":"Optional dotted path such as cometmind.memory or providers. Empty returns the full document."}
+			}
+		}`),
+	}
+}
+
+func (getSettingsTool) Execute(_ context.Context, input json.RawMessage) (Result, error) {
+	var in struct {
+		Path string `json:"path"`
+	}
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return Result{OK: false, Output: "invalid tool input: " + err.Error()}, nil
+		}
+	}
+	doc, err := readSettingsDoc()
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	doc = settingsapply.StripDesktopKeys(doc)
+	redacted := settingsapply.RedactSecrets(doc)
+	view := any(redacted)
+	if p := strings.TrimSpace(in.Path); p != "" {
+		view, err = valueAtPath(redacted, p)
+		if err != nil {
+			return Result{OK: false, Output: err.Error()}, nil
+		}
+	}
+	b, err := json.MarshalIndent(view, "", "  ")
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	return Result{OK: true, Output: string(b)}, nil
+}
+
+type patchSettingsTool struct {
+	Runtime SettingsRuntime
+}
+
+func (patchSettingsTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name: "patch_settings",
+		Description: "Deep-merge a JSON patch into ~/.cometmind/cometline-settings.json (mode 0600), then apply: " +
+			"in-place Runtime.Reload for almost all fields, or gateway process restart when cometmind.gateway changes. " +
+			"Secret fields set to " + settingsapply.SecretSentinel + " or *** keep the previous value. " +
+			"Rejects appearance/shortcuts/app (cometline-desktop.json), systemPromptPath, and host/port. " +
+			"Does not restart the main CometMind serve process.",
+		Parameters: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"patch":{"type":"object","description":"Partial settings object to deep-merge"}
+			},
+			"required":["patch"]
+		}`),
+	}
+}
+
+func (t patchSettingsTool) Execute(ctx context.Context, input json.RawMessage) (Result, error) {
+	var in struct {
+		Patch map[string]any `json:"patch"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return Result{OK: false, Output: "invalid tool input: " + err.Error()}, nil
+	}
+	if in.Patch == nil {
+		return Result{OK: false, Output: "patch is required"}, nil
+	}
+	if desktopKeys := settingsapply.DesktopKeysInPatch(in.Patch); len(desktopKeys) > 0 {
+		return Result{OK: false, Output: settingsapply.FormatUnsupported(desktopKeys)}, nil
+	}
+
+	before, err := readSettingsDoc()
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	before = settingsapply.StripDesktopKeys(before)
+	merged := settingsapply.MergePatch(before, in.Patch)
+	settingsapply.RestoreSecretsInProviders(merged, before)
+	merged = settingsapply.StripDesktopKeys(merged)
+
+	plan, err := settingsapply.Classify(before, merged)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if plan.Action == settingsapply.ApplyUnsupported {
+		return Result{OK: false, Output: settingsapply.FormatUnsupported(plan.Unsupported)}, nil
+	}
+
+	formatted, err := encodeSettingsJSON(merged)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if err := config.ValidateCometlineSettingsJSON(formatted); err != nil {
+		return Result{OK: false, Output: "invalid settings after patch: " + err.Error()}, nil
+	}
+	settingsPath, err := paths.SettingsPath()
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if err := os.WriteFile(settingsPath, formatted, 0o600); err != nil {
+		return Result{OK: false, Output: "write settings: " + err.Error()}, nil
+	}
+
+	applied := []string{}
+	if plan.Action == settingsapply.ApplyNone && !plan.Gateway {
+		applied = append(applied, "none")
+	}
+	if plan.Action == settingsapply.ApplyReload {
+		if err := t.reload(ctx); err != nil {
+			return Result{OK: false, Output: fmt.Sprintf("settings written but reload failed: %v", err)}, nil
+		}
+		applied = append(applied, "reload")
+	}
+	if plan.Gateway || plan.Action == settingsapply.ApplyGateway {
+		if err := restartGateways(); err != nil {
+			return Result{OK: false, Output: fmt.Sprintf("settings written but gateway restart failed: %v", err)}, nil
+		}
+		applied = append(applied, "gateway")
+	}
+
+	out := map[string]any{
+		"ok":           true,
+		"apply":        applied,
+		"settingsPath": settingsPath,
+		"note":         "Secrets were preserved when patch used " + settingsapply.SecretSentinel + "/****. Main serve process was not restarted.",
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return Result{OK: true, Output: string(b)}, nil
+}
+
+func (t patchSettingsTool) reload(ctx context.Context) error {
+	if t.Runtime == nil {
+		return fmt.Errorf("settings runtime reload is not wired")
+	}
+	return t.Runtime.Reload(ctx)
+}
+
+func restartGateways() error {
+	var firstErr error
+	for _, mode := range processctl.GatewayModes() {
+		state, err := processctl.ReadState(mode)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !state.Running && !state.Present {
+			continue
+		}
+		if err := processctl.Restart(mode, 10*time.Second); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("restart %s: %w", mode, err)
+		}
+	}
+	return firstErr
+}
+
+func readSettingsDoc() (map[string]any, error) {
+	settingsPath, err := paths.SettingsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("settings file does not exist at %s", settingsPath)
+		}
+		return nil, err
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse settings: %w", err)
+	}
+	return doc, nil
+}
+
+func encodeSettingsJSON(doc map[string]any) ([]byte, error) {
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, '\n')
+	return b, nil
+}
+
+func valueAtPath(doc map[string]any, path string) (any, error) {
+	parts := strings.Split(path, ".")
+	var cur any = doc
+	for _, part := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("path %q not found", path)
+		}
+		next, ok := m[part]
+		if !ok {
+			return nil, fmt.Errorf("path %q not found", path)
+		}
+		cur = next
+	}
+	return cur, nil
+}

--- a/cometmind/internal/tools/settings_tools_test.go
+++ b/cometmind/internal/tools/settings_tools_test.go
@@ -1,0 +1,162 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/settingsapply"
+	"github.com/cometline/cometmind/internal/tools"
+)
+
+type stubReload struct {
+	calls int
+}
+
+func (s *stubReload) Reload(context.Context) error {
+	s.calls++
+	return nil
+}
+
+func TestSettingsToolsParentOnlyAndRedactionRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", dir)
+	settingsPath := filepath.Join(dir, "cometline-settings.json")
+	initial := map[string]any{
+		"providers": []any{
+			map[string]any{
+				"id":            "openai",
+				"name":          "OpenAI",
+				"method":        "openai",
+				"enabled":       true,
+				"baseURL":       "https://api.openai.com/v1",
+				"apiKey":        "sk-secret",
+				"selectedModel": "gpt-4o",
+				"models":        []any{"gpt-4o"},
+				"enabledModels": []any{"gpt-4o"},
+			},
+		},
+		"activeProviderId": "openai",
+		"cometmind": map[string]any{
+			"systemPromptPath":   "",
+			"maxTokens":          4096,
+			"contextWindowLimit": 0,
+			"acp":                map[string]any{"defaultHarness": "opencode"},
+			"skills":             map[string]any{"enabled": true},
+			"memory": map[string]any{
+				"enabled": false,
+				"embedding": map[string]any{
+					"provider": "openai",
+					"model":    "text-embedding-3-small",
+					"apiKey":   "",
+				},
+			},
+			"storage": map[string]any{},
+			"gateway": map[string]any{
+				"discord": map[string]any{"enabled": false},
+			},
+			"mcp":       map[string]any{"enabled": false, "servers": []any{}},
+			"jobs":      map[string]any{},
+			"autonomy":  map[string]any{"enabled": false},
+			"scheduler": map[string]any{"enabled": false},
+		},
+	}
+	raw, err := json.MarshalIndent(initial, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubReload{}
+	r := tools.NewRegistry(dir, tools.RegistryOptions{SettingsRuntime: stub})
+	for _, name := range []string{"list_settings", "get_settings", "patch_settings"} {
+		if !r.Has(name) {
+			t.Fatalf("parent registry missing %s", name)
+		}
+	}
+	sub := tools.NewSubagentRegistry(dir, nil, tools.SubagentModeCoding)
+	if sub.Has("patch_settings") {
+		t.Fatal("coding subagent must not expose patch_settings")
+	}
+
+	getRes, err := r.Execute(context.Background(), "get_settings", []byte(`{"path":"providers"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !getRes.OK {
+		t.Fatalf("get_settings: %s", getRes.Output)
+	}
+	if !contains(getRes.Output, settingsapply.SecretSentinel) {
+		t.Fatalf("expected redacted apiKey, got %s", getRes.Output)
+	}
+	if contains(getRes.Output, "sk-secret") {
+		t.Fatal("raw api key leaked from get_settings")
+	}
+
+	patch := map[string]any{
+		"patch": map[string]any{
+			"providers": []any{
+				map[string]any{
+					"id":            "openai",
+					"name":          "OpenAI",
+					"method":        "openai",
+					"enabled":       true,
+					"baseURL":       "https://api.openai.com/v1",
+					"apiKey":        settingsapply.SecretSentinel,
+					"selectedModel": "gpt-4o",
+					"models":        []any{"gpt-4o"},
+					"enabledModels": []any{"gpt-4o"},
+				},
+			},
+			"cometmind": map[string]any{
+				"maxTokens": 2048,
+			},
+		},
+	}
+	patchRaw, _ := json.Marshal(patch)
+	patchRes, err := r.Execute(context.Background(), "patch_settings", patchRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !patchRes.OK {
+		t.Fatalf("patch_settings: %s", patchRes.Output)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("reload calls=%d want 1", stub.calls)
+	}
+
+	written, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(string(written), "sk-secret") {
+		t.Fatal("expected previous api key preserved on disk")
+	}
+	if !contains(string(written), "2048") {
+		t.Fatal("expected maxTokens patch persisted")
+	}
+
+	deny, err := r.Execute(context.Background(), "patch_settings", []byte(`{"patch":{"appearance":{"heroComposer":{"presetId":"rose"}}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deny.OK {
+		t.Fatal("patch_settings should reject appearance (desktop file)")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})())
+}

--- a/cometmind/internal/tools/surface.go
+++ b/cometmind/internal/tools/surface.go
@@ -13,6 +13,7 @@ type ToolSurface struct {
 	Jobs     bool
 	Memory   bool
 	MCP      bool
+	Settings bool // list/get/patch_settings (parent only)
 	SkillMut bool // write/promote skill drafts (parent only)
 }
 
@@ -21,7 +22,7 @@ func ParentSurface(delegateEnabled bool) ToolSurface {
 	return ToolSurface{
 		Read: true, Edit: true, Run: true, Skills: true, SkillMut: true,
 		Spawn: true, Delegate: delegateEnabled,
-		Jobs: true, Memory: true, MCP: true,
+		Jobs: true, Memory: true, MCP: true, Settings: true,
 	}
 }
 

--- a/cometmind/internal/tools/surface_test.go
+++ b/cometmind/internal/tools/surface_test.go
@@ -12,7 +12,7 @@ func TestSurfaceForMode(t *testing.T) {
 		t.Fatalf("coding should edit/run without spawn/delegate: %+v", c)
 	}
 	p := ParentSurface(true)
-	if !p.Delegate || !p.Spawn || !p.Edit {
+	if !p.Delegate || !p.Spawn || !p.Edit || !p.Settings {
 		t.Fatalf("parent with delegate: %+v", p)
 	}
 	pOff := ParentSurface(false)

--- a/cometmind/internal/tools/tooloutput.go
+++ b/cometmind/internal/tools/tooloutput.go
@@ -54,15 +54,7 @@ func writeToolOutputFile(text string) (string, error) {
 }
 
 func toolOutputDir() (string, error) {
-	d, err := paths.DataDir()
-	if err != nil {
-		return "", err
-	}
-	dir := filepath.Join(d, "tool-output")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", err
-	}
-	return dir, nil
+	return paths.ToolOutputDir()
 }
 
 func headTailPreview(text string, headRunes, tailRunes int) string {

--- a/cometmind/server/memory_handlers.go
+++ b/cometmind/server/memory_handlers.go
@@ -188,7 +188,10 @@ func (a *App) handlePutMemorySettings(c *gin.Context) {
 	}
 	a.config.Memory = req
 	if a.memory != nil {
-		a.memory.UpdateSettings(a.config.MemorySettings())
+		if err := a.memory.UpdateSettings(a.config.MemorySettings()); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 	}
 	c.JSON(http.StatusOK, a.config.EffectiveMemoryConfig())
 }

--- a/docs/SETTINGS_AND_PERSISTENCE.md
+++ b/docs/SETTINGS_AND_PERSISTENCE.md
@@ -9,9 +9,13 @@ runtime while other state is desktop-only.
 
 ## Source Of Truth
 
-Current source of truth:
+Runtime settings (agent-editable + CometMind):
 
 - `~/.cometmind/cometline-settings.json`
+
+Desktop / UI-only settings (Electron only; agent tools never write):
+
+- `~/.cometmind/cometline-desktop.json` — `appearance`, `shortcuts`, `app` (persona, open-at-login, …), plus a copy of `systemPromptPath`
 
 Legacy fallback only:
 
@@ -19,18 +23,21 @@ Legacy fallback only:
 
 Current truth in code:
 
-- Electron reads and writes `cometline-settings.json`
-- CometMind loads JSON first, then falls back to legacy TOML only if JSON is missing
+- Electron merges both files for the Settings UI, and splits on every write
+- First read of a monolithic `cometline-settings.json` peels desktop keys into `cometline-desktop.json` (idempotent migration)
+- CometMind loads only `cometline-settings.json` (runtime); it ignores the desktop file (`systemPromptPath` is stamped into the settings file by Electron)
 
 Relevant files:
 
 - `cometline/electron/main.cjs`
 - `cometmind/internal/config/config.go`
+- `cometmind/internal/settingsapply/split.go`
 - `cometline/src/lib/stores/settings.svelte.ts`
 
 Rule:
 
 - Do not write new docs or features as if `config.toml` is still the primary config path.
+- Do not teach agents to edit `cometline-desktop.json` by hand or via tools.
 
 ## Persistence Categories
 
@@ -209,14 +216,14 @@ Key file:
 Electron IPC handler `saveProviderSettings`:
 
 - normalizes the incoming settings
-- writes `~/.cometmind/cometline-settings.json`
+- splits and writes `cometline-settings.json` (runtime) + `cometline-desktop.json` (UI)
 - applies `0600` permissions
 - refreshes global shortcuts
-- optionally restarts CometMind
+- optionally reloads/restarts CometMind or recycles gateway
 - syncs Discord gateway side effects
 - applies open-at-login
-- applies icon variant
-- returns normalized saved settings back to the renderer
+- applies persona
+- returns the merged normalized settings back to the renderer
 
 Key file:
 
@@ -238,21 +245,34 @@ Rule:
 
 ## Restart Rules
 
-CometMind restart is required when:
+Almost all CometMind runtime settings apply via in-place `Runtime.Reload` so the
+current chat turn survives. That includes:
 
-- memory settings, memory provider, or embedding provider swaps change
-- storage cleanup interval or job reconcile interval changes
-- process-level bind settings such as host or port change
-- Discord token/process environment changes
-- icon variant changed and packaged runtime prompt path or related native state must be refreshed
+- provider / default model / ACP / skills / MCP / prompt-related runtime knobs
+- memory settings and embedding/extraction provider rebuilds
+- storage cleanup interval and jobs reconcile interval
+- autonomy worker config
 
-CometMind can reload many settings in place for new work, including provider/default model changes, coding-harness selection, skills config, MCP config, log level, context window limit, and many runtime settings. The renderer still uses explicit restart/reconnect paths when a setting belongs to the restart-required class above.
+Discord gateway token / process-env fields recycle the **gateway process only**
+(`gateway` apply class via `cometmind.gateway`; today `gateway-discord`). The main
+`serve` sidecar stays up. New gateway platforms should plug into the same
+`cometmind.gateway.*` tree and `processctl.GatewayModes()`.
+
+Full main-sidecar restart remains only for true process-level bind changes such
+as listen host/port (Settings UI). Desktop-only fields (persona/icon, appearance,
+shortcuts, packaged prompt path) are not agent-tool apply targets.
+
+Agent tools `list_settings` / `get_settings` / `patch_settings` (parent registry
+only) read/write `cometline-settings.json` with API-key redaction and auto-apply
+reload / gateway restart. They reject desktop keys (`appearance`, `shortcuts`,
+`app`) that belong in `cometline-desktop.json`, plus unsupported process-level
+paths.
 
 CometMind restart is not required for:
 
 - shortcuts
 - open-at-login
-- Discord gateway enabled toggle
+- Discord gateway enabled toggle (gateway process sync only)
 - web panel width
 - intro/setup flags
 - MCP connection tests/reconnect/OAuth actions
@@ -260,10 +280,12 @@ CometMind restart is not required for:
 Operational detail:
 
 - Electron waits for the sidecar to exit before respawning it to avoid port `7700` reuse and SQLite WAL lock issues.
+- `Reload` reconnects MCP; in-flight MCP tool calls can fail even though the chat turn continues.
 
 Rule:
 
-- Do not casually mark settings as restart-free. Match the existing restart helpers and native side effects.
+- Prefer reload (and `gateway` apply for `cometmind.gateway`) over full serve restart. Match
+  `runtimeActionForSettingsSave` and `settingsapply.Classify`.
 
 ## Other Persisted Files
 
@@ -298,7 +320,7 @@ But the full durability path for every memory retrieval/lifecycle runtime settin
 
 Practical rule for contributors:
 
-- If you change memory settings, verify both immediate runtime behavior and restart-time durability.
+- If you change memory settings, verify both immediate runtime behavior after reload and persistence across process restarts.
 - Do not assume that because a setting round-trips through the API, it is already persisted in the same way as shared JSON settings.
 
 ## Files To Read Before Changing Settings

--- a/docs/SETTINGS_AND_PERSISTENCE.md
+++ b/docs/SETTINGS_AND_PERSISTENCE.md
@@ -295,8 +295,10 @@ Also persisted:
 
 - `~/.cometmind/cometline-workspace.json` - selected workspace path
 - `~/.cometmind/cometmind.db` - runtime SQLite database
-- `~/.cometmind/cometline.log` - CometMind sidecar log
-- `~/.cometmind/cometline-gateway.log` - Discord gateway log
+- `~/.cometmind/logs/cometline.log` - CometMind sidecar log (10MB rotate → `.log.1`)
+- `~/.cometmind/logs/cometline-gateway.log` - Discord gateway log (same rotation)
+- `~/.cometmind/tool-output/` - spilled tool output (`@runtime/tool-output`); age-purged by retention (default 7 days)
+- `~/.cometmind/agent-tmp/` - shared `@runtime/tmp`; age-purged by retention (default 3 days)
 - `~/.cometmind/mcp-oauth/{server}.json` - MCP OAuth access/refresh token cache
 - `~/.cometmind/mcp-oauth/{server}.client.json` - MCP OAuth registered client metadata
 


### PR DESCRIPTION
## Background

Saving settings still forced a full CometMind restart for many safe changes, and `~/.cometmind` mixed desktop UI state with runtime data while logs and spilled tool files piled up at the root. This follow-up makes nearly all runtime settings reload in place, gives the agent parent-only tools to inspect and patch settings, splits desktop UI into its own JSON file, and moves logs plus age-based cleanup for runtime files under clearer paths.

[e87368e](https://github.com/Cometline/cometline/commit/e87368e3828206035f96bef01fbd9d40f4ecd199): Settings classify/redact plus parent-only `list_settings` / `get_settings` / `patch_settings` tools land here, and Runtime reload covers memory, storage intervals, jobs, and autonomy without recycling the main sidecar. Gateway-only changes restart gateway processes; host and port remain true restart cases.

[e0cbdd4](https://github.com/Cometline/cometline/commit/e0cbdd461273e05b70f9208045f9a785a14d8b5f): CometMind migrates leftover desktop keys from `cometline-settings.json` into `cometline-desktop.json` on load so Electron and the agent no longer share one document for UI state.

[d09a937](https://github.com/Cometline/cometline/commit/d09a93782b3792a4aaefbb7561ad0ced0ab87bf5): Shared path helpers for `logs/`, `tool-output/`, and `agent-tmp/` keep runtime file locations consistent across the Go side.

[afd816d](https://github.com/Cometline/cometline/commit/afd816d1c3b0c9c332aefc0e0332b2dd0abd246b): Storage settings gain `toolOutputRetentionDays` (default 7) and `agentTmpRetentionDays` (default 3), with omitted keys upgraded safely while explicit zero still disables purge.

[b0188a5](https://github.com/Cometline/cometline/commit/b0188a553587f9b459cbcacffe7904c13c265583): The existing retention loop now deletes aged files under those runtime directories on each cleanup pass.

[3add6b4](https://github.com/Cometline/cometline/commit/3add6b4b2fa237845748154e3a1cfb3ea451b6af): Electron writes sidecar and gateway logs under `~/.cometmind/logs/`, migrates legacy root-level log files once, and `make clean-log` follows the new layout.

[a1c5cb3](https://github.com/Cometline/cometline/commit/a1c5cb3bb60570a3db965a1e2475d25a163752db): General settings expose the two runtime-file retention fields next to the other storage controls.

[99b6fec](https://github.com/Cometline/cometline/commit/99b6fec1b7f82e7da4e7d17c7d4cfda5ca912958): Docs and the setup skill point at the split settings files, logs subdirectory, and runtime-file retention behavior.

Made with [Cursor](https://cursor.com)