### PR TITLE
[main] feat: enhance mini window session workflow

### DIFF
--- a/cometline/src/lib/actions/create-new-session.test.ts
+++ b/cometline/src/lib/actions/create-new-session.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '$lib/types';
+
+const mocks = vi.hoisted(() => ({
+	createSession: vi.fn(),
+	selectDefault: vi.fn(),
+	appendSession: vi.fn(),
+	commitActiveWorkspace: vi.fn(),
+	recordVisit: vi.fn(),
+	loadSettings: vi.fn(),
+	defaultModel: {
+		id: 'provider:model',
+		label: 'Model',
+		providerId: 'provider',
+		providerName: 'Provider',
+		providerMethod: 'openai' as const,
+		modelId: 'model'
+	}
+}));
+
+vi.mock('$lib/client/cometmind', () => ({ createSession: mocks.createSession }));
+vi.mock('$lib/stores/model.svelte', () => ({
+	modelStore: {
+		options: [mocks.defaultModel],
+		selected: mocks.defaultModel,
+		selectDefault: mocks.selectDefault
+	}
+}));
+vi.mock('$lib/stores/session.svelte', () => ({
+	sessionStore: { appendSession: mocks.appendSession }
+}));
+vi.mock('$lib/stores/settings.svelte', () => ({
+	settingsStore: { load: mocks.loadSettings }
+}));
+vi.mock('$lib/stores/shell.svelte', () => ({
+	shellStore: {
+		defaultWorkspacePath: '/default-workspace',
+		commitActiveWorkspace: mocks.commitActiveWorkspace
+	}
+}));
+vi.mock('$lib/stores/session-visit-history.svelte', () => ({
+	sessionVisitHistory: { recordVisit: mocks.recordVisit }
+}));
+
+import { createNewSession } from './create-new-session';
+
+const session: Session = {
+	id: 'session-1',
+	workspace_id: 'workspace-1',
+	workspace_path: '/default-workspace',
+	title: '',
+	model_id: 'model',
+	provider_id: 'provider',
+	status: 'active',
+	origin: 'user',
+	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+	pinned: false,
+	created_at: 0,
+	updated_at: 0
+};
+
+describe('createNewSession', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.createSession.mockResolvedValue(session);
+	});
+
+	it('creates and activates a persisted session with the configured default model', async () => {
+		await expect(createNewSession()).resolves.toEqual(session);
+
+		expect(mocks.selectDefault).toHaveBeenCalledOnce();
+		expect(mocks.createSession).toHaveBeenCalledWith({
+			workspace_path: '/default-workspace',
+			provider_id: 'provider',
+			model_id: 'model'
+		});
+		expect(mocks.appendSession).toHaveBeenCalledWith(session);
+		expect(mocks.commitActiveWorkspace).toHaveBeenCalledWith('/default-workspace');
+		expect(mocks.recordVisit).toHaveBeenCalledWith('session-1');
+	});
+});

--- a/cometline/src/lib/actions/create-new-session.ts
+++ b/cometline/src/lib/actions/create-new-session.ts
@@ -1,0 +1,29 @@
+import { createSession } from '$lib/client/cometmind';
+import { modelStore } from '$lib/stores/model.svelte';
+import { sessionStore } from '$lib/stores/session.svelte';
+import { settingsStore } from '$lib/stores/settings.svelte';
+import { shellStore } from '$lib/stores/shell.svelte';
+import { sessionVisitHistory } from '$lib/stores/session-visit-history.svelte';
+import type { Session } from '$lib/types';
+
+/** Create and activate a new persisted session using the configured default model. */
+export async function createNewSession(): Promise<Session> {
+	if (modelStore.options.length === 0) {
+		await settingsStore.load();
+	}
+	modelStore.selectDefault();
+	const model = modelStore.selected;
+	if (!model) {
+		throw new Error('Select a default model in Settings before starting a new chat.');
+	}
+
+	const session = await createSession({
+		workspace_path: shellStore.defaultWorkspacePath,
+		provider_id: model.providerId,
+		model_id: model.modelId
+	});
+	sessionStore.appendSession(session);
+	shellStore.commitActiveWorkspace(session.workspace_path);
+	sessionVisitHistory.recordVisit(session.id);
+	return session;
+}

--- a/cometline/src/lib/actions/new-chat.ts
+++ b/cometline/src/lib/actions/new-chat.ts
@@ -1,10 +1,10 @@
 import { goto } from '$app/navigation';
 import { chatStore } from '$lib/stores/chat.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
-import { shellStore } from '$lib/stores/shell.svelte';
+import { createNewSession } from '$lib/actions/create-new-session';
 
-/** Reset to the hero new-chat screen, same as the sidebar New Chat controls. */
-export function startNewChat() {
+/** Create and open a persisted session, same as the sidebar New Chat controls. */
+export async function startNewChat() {
 	const currentSessionId = sessionStore.current?.id ?? chatStore.sessionID;
 	if (currentSessionId) {
 		const pending = sessionStore.takePendingMessage(currentSessionId);
@@ -23,9 +23,6 @@ export function startNewChat() {
 				.catch(() => {});
 		}
 	}
-	shellStore.resetActiveToDefault();
-	sessionStore.selectSession(null);
-	chatStore.detachActiveSession();
-	shellStore.centerComposer();
-	void goto('/');
+	const session = await createNewSession();
+	await goto(`/session/${session.id}`);
 }

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -25,6 +25,8 @@
 	import { startJobInSession } from '$lib/jobs/start-job-in-chat';
 	import type { JobResource } from '$lib/client/cometmind';
 	import { createChatViewController } from '$lib/conversation/chat-view-controller.svelte';
+	import { PanelLeft } from '@lucide/svelte';
+	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 
 	const THREAD_IN = { duration: 140 };
 
@@ -325,6 +327,15 @@
 		<div class="mini-titlebar" aria-label="Mini window drag area">
 			<span>Mini Chat</span>
 			<button
+				class="mini-sidebar-toggle"
+				type="button"
+				aria-label="Show chats"
+				title="Show chats"
+				onclick={() => miniShellStore.toggleSidebar()}
+			>
+				<PanelLeft size={15} stroke-width={1.8} />
+			</button>
+			<button
 				class="mini-open-main"
 				type="button"
 				disabled={openInMainWindowBlocked}
@@ -485,6 +496,24 @@
 		-webkit-app-region: no-drag;
 	}
 
+	.mini-sidebar-toggle {
+		position: absolute;
+		left: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 28px;
+		height: 28px;
+		display: grid;
+		place-items: center;
+		padding: 0;
+		border: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--panel-bg) 88%, var(--text-main) 6%);
+		color: var(--text-main);
+		cursor: pointer;
+		-webkit-app-region: no-drag;
+	}
+
 	.mini-open-main svg {
 		width: 14px;
 		height: 14px;
@@ -495,7 +524,8 @@
 		stroke-linejoin: round;
 	}
 
-	.mini-open-main:hover {
+	.mini-open-main:hover,
+	.mini-sidebar-toggle:hover {
 		border-color: color-mix(in srgb, var(--hero-composer-glow-color) 54%, var(--border-soft));
 		background: color-mix(in srgb, var(--hero-composer-glow-color) 18%, var(--panel-bg));
 	}

--- a/cometline/src/lib/components/MiniSessionSidebar.svelte
+++ b/cometline/src/lib/components/MiniSessionSidebar.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import { X } from '@lucide/svelte';
+	import type { Session } from '$lib/types';
+	import { sessionStore } from '$lib/stores/session.svelte';
+	import { shellStore } from '$lib/stores/shell.svelte';
+	import {
+		layoutSessionsForSidebar,
+		PINNED_GROUP_KEY,
+		DISCORD_GROUP_KEY,
+		isDiscordSession
+	} from '$lib/sessions/group-by-workspace';
+	import SidebarSearch from '$lib/components/sidebar/SidebarSearch.svelte';
+	import SessionRow from '$lib/components/sidebar/SessionRow.svelte';
+
+	let {
+		onClose,
+		onSelectSession,
+		onNewChat
+	}: {
+		onClose: () => void;
+		onSelectSession: (session: Session) => void;
+		onNewChat: () => void;
+	} = $props();
+
+	let searchQuery = $state('');
+	let searchInput = $state<HTMLInputElement | null>(null);
+	let collapsedGroups = $state<Record<string, boolean>>({});
+	let filteredSessions = $derived.by(() => {
+		const query = searchQuery.trim().toLowerCase();
+		if (!query) return sessionStore.sessions;
+		return sessionStore.sessions.filter((session) =>
+			(session.title || 'Untitled').toLowerCase().includes(query)
+		);
+	});
+	let sidebarLayout = $derived(
+		layoutSessionsForSidebar(
+			filteredSessions,
+			shellStore.sidebarOrderWorkspacePath,
+			shellStore.sidebarOrderDiscordActive
+		)
+	);
+	let totalSessions = $derived(filteredSessions.length);
+
+	function isCollapsed(key: string) {
+		if (searchQuery.trim()) return false;
+		if (key in collapsedGroups) return Boolean(collapsedGroups[key]);
+		return key === DISCORD_GROUP_KEY;
+	}
+
+	function toggleGroup(key: string) {
+		collapsedGroups = { ...collapsedGroups, [key]: !isCollapsed(key) };
+	}
+
+	function selectSession(session: Session) {
+		onSelectSession(session);
+	}
+</script>
+
+<aside class="mini-sidebar" aria-label="Chats">
+	<header class="mini-sidebar-header">
+		<SidebarSearch bind:searchQuery bind:searchInput onNewChat={onNewChat} />
+		<button type="button" class="close-sidebar" onclick={onClose} aria-label="Close chats" title="Close chats">
+			<X size={16} stroke-width={2} />
+		</button>
+	</header>
+
+	<div class="session-list scrollbar-none">
+		{#if sidebarLayout.pinnedSessions.length > 0}
+			<section class="session-section pinned">
+				<button class="section-header" aria-expanded={!isCollapsed(PINNED_GROUP_KEY)} onclick={() => toggleGroup(PINNED_GROUP_KEY)}>
+					<span>Pinned</span><span>{sidebarLayout.pinnedSessions.length}</span>
+				</button>
+				{#if !isCollapsed(PINNED_GROUP_KEY)}
+					{#each sidebarLayout.pinnedSessions as session (session.id)}
+						<SessionRow {session} showWorkspaceLabel selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
+					{/each}
+				{/if}
+			</section>
+		{/if}
+
+		{#each sidebarLayout.workspaceGroups as group (group.workspacePath)}
+			<section class:active={group.workspacePath === shellStore.workspacePath} class="session-section">
+				<button class="section-header" aria-expanded={!isCollapsed(group.workspacePath)} onclick={() => toggleGroup(group.workspacePath)} title={group.workspacePath}>
+					<span>{group.label}</span><span>{group.sessions.length}</span>
+				</button>
+				{#if !isCollapsed(group.workspacePath)}
+					{#each group.sessions as session (session.id)}
+						<SessionRow {session} selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
+					{/each}
+				{/if}
+			</section>
+		{/each}
+
+		{#if sidebarLayout.discordSessions.length > 0}
+			<section class="session-section discord">
+				<button class="section-header" aria-expanded={!isCollapsed(DISCORD_GROUP_KEY)} onclick={() => toggleGroup(DISCORD_GROUP_KEY)}>
+					<span>Discord</span><span>{sidebarLayout.discordSessions.length}</span>
+				</button>
+				{#if !isCollapsed(DISCORD_GROUP_KEY)}
+					{#each sidebarLayout.discordSessions as session (session.id)}
+						<SessionRow {session} showGatewayLabel={isDiscordSession(session)} selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
+					{/each}
+				{/if}
+			</section>
+		{/if}
+
+		{#if totalSessions === 0}
+			<p class="session-empty">{searchQuery.trim() ? 'No chats match your search' : 'No chats yet'}</p>
+		{/if}
+	</div>
+</aside>
+
+<style>
+	.mini-sidebar {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: color-mix(in srgb, var(--panel-bg) 96%, var(--app-bg));
+		border-right: 1px solid var(--border-soft);
+		box-shadow: 18px 0 46px rgba(0, 0, 0, 0.18);
+	}
+
+	.mini-sidebar-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 10px;
+		border-bottom: 1px solid var(--border-soft);
+	}
+
+	.close-sidebar {
+		display: grid;
+		place-items: center;
+		width: 28px;
+		height: 28px;
+		flex: 0 0 auto;
+		border: 1px solid var(--border-soft);
+		border-radius: 8px;
+		background: transparent;
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+
+	.close-sidebar:hover {
+		color: var(--text-main);
+		background: color-mix(in srgb, var(--text-main) 6%, transparent);
+	}
+
+	.session-list {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		gap: 8px;
+		overflow-y: auto;
+		padding: 10px;
+	}
+
+	.session-section {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 2px;
+		border: 1px solid transparent;
+		border-radius: 9px;
+		background: color-mix(in srgb, var(--workspace-inactive-color, #9a9a9f) 8%, transparent);
+	}
+
+	.session-section.active {
+		border-color: color-mix(in srgb, var(--hero-composer-glow-color, var(--accent)) 28%, transparent);
+		background: color-mix(in srgb, var(--hero-composer-glow-color, var(--accent)) 12%, transparent);
+	}
+
+	.session-section.pinned {
+		background: color-mix(in srgb, var(--pinned-group-color, #b45309) 10%, transparent);
+	}
+
+	.session-section.discord {
+		background: color-mix(in srgb, var(--discord-group-color, #5865f2) 10%, transparent);
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		width: 100%;
+		padding: 6px 8px;
+		border: 0;
+		border-radius: 7px;
+		background: transparent;
+		color: var(--text-muted);
+		font-size: 10px;
+		font-weight: 650;
+		letter-spacing: 0.04em;
+		text-align: left;
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+	.section-header span:last-child {
+		padding: 1px 5px;
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--text-main) 7%, transparent);
+		font-size: 9px;
+	}
+
+	.session-empty {
+		margin: 18px 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		text-align: center;
+	}
+</style>

--- a/cometline/src/lib/components/MiniSessionSidebar.svelte
+++ b/cometline/src/lib/components/MiniSessionSidebar.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { X } from '@lucide/svelte';
+	import { flip } from 'svelte/animate';
 	import type { Session } from '$lib/types';
+	import { deleteSession, updateSession } from '$lib/client/cometmind';
+	import { createMiniWindowSession } from '$lib/mini-window-session';
+	import { chatStore } from '$lib/stores/chat.svelte';
 	import { sessionStore } from '$lib/stores/session.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import {
@@ -11,6 +15,8 @@
 	} from '$lib/sessions/group-by-workspace';
 	import SidebarSearch from '$lib/components/sidebar/SidebarSearch.svelte';
 	import SessionRow from '$lib/components/sidebar/SessionRow.svelte';
+
+	const WORKSPACE_GROUP_FLIP = { duration: 240 };
 
 	let {
 		onClose,
@@ -25,6 +31,8 @@
 	let searchQuery = $state('');
 	let searchInput = $state<HTMLInputElement | null>(null);
 	let collapsedGroups = $state<Record<string, boolean>>({});
+	let deletingID = $state<string | null>(null);
+	let pinningID = $state<string | null>(null);
 	let filteredSessions = $derived.by(() => {
 		const query = searchQuery.trim().toLowerCase();
 		if (!query) return sessionStore.sessions;
@@ -54,6 +62,38 @@
 	function selectSession(session: Session) {
 		onSelectSession(session);
 	}
+
+	export function focusSearch() {
+		searchInput?.focus();
+		searchInput?.select();
+	}
+
+	async function togglePinSession(session: Session) {
+		pinningID = session.id;
+		try {
+			const updated = await updateSession(session.id, { pinned: !session.pinned });
+			sessionStore.updateSession(updated);
+		} finally {
+			pinningID = null;
+		}
+	}
+
+	async function removeSession(session: Session) {
+		if (!window.confirm(`Delete ${session.title || 'this chat'}?`)) return;
+		deletingID = session.id;
+		try {
+			await deleteSession(session.id);
+			const wasCurrent = sessionStore.current?.id === session.id;
+			sessionStore.removeSession(session.id);
+			if (wasCurrent) {
+				chatStore.clear();
+				onClose();
+				await createMiniWindowSession();
+			}
+		} finally {
+			deletingID = null;
+		}
+	}
 </script>
 
 <aside class="mini-sidebar" aria-label="Chats">
@@ -72,23 +112,25 @@
 				</button>
 				{#if !isCollapsed(PINNED_GROUP_KEY)}
 					{#each sidebarLayout.pinnedSessions as session (session.id)}
-						<SessionRow {session} showWorkspaceLabel selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
+						<SessionRow {session} showWorkspaceLabel selected={sessionStore.current?.id === session.id} deleting={deletingID === session.id} pinning={pinningID === session.id} onSelect={() => selectSession(session)} onDelete={() => void removeSession(session)} onPin={() => void togglePinSession(session)} onContextMenu={() => {}} />
 					{/each}
 				{/if}
 			</section>
 		{/if}
 
 		{#each sidebarLayout.workspaceGroups as group (group.workspacePath)}
-			<section class:active={group.workspacePath === shellStore.workspacePath} class="session-section">
-				<button class="section-header" aria-expanded={!isCollapsed(group.workspacePath)} onclick={() => toggleGroup(group.workspacePath)} title={group.workspacePath}>
-					<span>{group.label}</span><span>{group.sessions.length}</span>
-				</button>
-				{#if !isCollapsed(group.workspacePath)}
-					{#each group.sessions as session (session.id)}
-						<SessionRow {session} selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
-					{/each}
-				{/if}
-			</section>
+			<div animate:flip={WORKSPACE_GROUP_FLIP}>
+				<section class:active={group.workspacePath === shellStore.workspacePath} class="session-section">
+					<button class="section-header" aria-expanded={!isCollapsed(group.workspacePath)} onclick={() => toggleGroup(group.workspacePath)} title={group.workspacePath}>
+						<span>{group.label}</span><span>{group.sessions.length}</span>
+					</button>
+					{#if !isCollapsed(group.workspacePath)}
+						{#each group.sessions as session (session.id)}
+							<SessionRow {session} selected={sessionStore.current?.id === session.id} deleting={deletingID === session.id} pinning={pinningID === session.id} onSelect={() => selectSession(session)} onDelete={() => void removeSession(session)} onPin={() => void togglePinSession(session)} onContextMenu={() => {}} />
+						{/each}
+					{/if}
+				</section>
+			</div>
 		{/each}
 
 		{#if sidebarLayout.discordSessions.length > 0}
@@ -98,7 +140,7 @@
 				</button>
 				{#if !isCollapsed(DISCORD_GROUP_KEY)}
 					{#each sidebarLayout.discordSessions as session (session.id)}
-						<SessionRow {session} showGatewayLabel={isDiscordSession(session)} selected={sessionStore.current?.id === session.id} showActions={false} onSelect={() => selectSession(session)} onDelete={() => {}} onPin={() => {}} onContextMenu={() => {}} />
+						<SessionRow {session} showGatewayLabel={isDiscordSession(session)} showPin={false} selected={sessionStore.current?.id === session.id} deleting={deletingID === session.id} onSelect={() => selectSession(session)} onDelete={() => void removeSession(session)} onPin={() => {}} onContextMenu={() => {}} />
 					{/each}
 				{/if}
 			</section>

--- a/cometline/src/lib/components/MiniShell.svelte
+++ b/cometline/src/lib/components/MiniShell.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { fly, fade } from 'svelte/transition';
+	import { matchesShortcut } from '$lib/keyboard-shortcuts';
+	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
+	import { settingsStore } from '$lib/stores/settings.svelte';
+	import { createMiniWindowSession, navigateMiniToSession } from '$lib/mini-window-session';
+	import MiniSessionSidebar from '$lib/components/MiniSessionSidebar.svelte';
+	import type { Session } from '$lib/types';
+
+	let { children } = $props();
+	let creatingSession = $state(false);
+
+	async function createSession() {
+		if (creatingSession) return;
+		creatingSession = true;
+		try {
+			await createMiniWindowSession();
+			miniShellStore.closeSidebar();
+		} finally {
+			creatingSession = false;
+		}
+	}
+
+	async function selectSession(session: Session) {
+		await navigateMiniToSession(session);
+		miniShellStore.closeSidebar();
+	}
+
+	function onKeydown(event: KeyboardEvent) {
+		if (matchesShortcut(event, settingsStore.settings.shortcuts.toggleSidebar)) {
+			event.preventDefault();
+			miniShellStore.toggleSidebar();
+			return;
+		}
+		if (matchesShortcut(event, settingsStore.settings.shortcuts.newChat)) {
+			event.preventDefault();
+			void createSession();
+			return;
+		}
+		if (event.key === 'Escape' && miniShellStore.sidebarOpen) {
+			event.preventDefault();
+			miniShellStore.closeSidebar();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<div class="mini-shell">
+	{@render children()}
+	{#if miniShellStore.sidebarOpen}
+		<button class="mini-sidebar-backdrop" type="button" aria-label="Close chats" onclick={() => miniShellStore.closeSidebar()} transition:fade={{ duration: 120 }}></button>
+		<div class="mini-sidebar-drawer" transition:fly={{ x: -220, duration: 180 }}>
+			<MiniSessionSidebar onClose={() => miniShellStore.closeSidebar()} onSelectSession={selectSession} onNewChat={() => void createSession()} />
+		</div>
+	{/if}
+</div>
+
+<style>
+	.mini-shell {
+		position: relative;
+		width: 100vw;
+		height: 100vh;
+		overflow: hidden;
+	}
+
+	.mini-sidebar-backdrop {
+		position: absolute;
+		inset: 0;
+		z-index: 70;
+		border: 0;
+		background: rgba(0, 0, 0, 0.18);
+		cursor: default;
+	}
+
+	.mini-sidebar-drawer {
+		position: absolute;
+		inset: 0 auto 0 0;
+		z-index: 80;
+		width: min(88vw, 330px);
+	}
+</style>

--- a/cometline/src/lib/components/MiniShell.svelte
+++ b/cometline/src/lib/components/MiniShell.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { tick } from 'svelte';
+	import { cubicOut } from 'svelte/easing';
 	import { fly, fade } from 'svelte/transition';
 	import { matchesShortcut } from '$lib/keyboard-shortcuts';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
@@ -9,6 +11,7 @@
 
 	let { children } = $props();
 	let creatingSession = $state(false);
+	let sidebarRef = $state<{ focusSearch: () => void } | null>(null);
 
 	async function createSession() {
 		if (creatingSession) return;
@@ -26,10 +29,21 @@
 		miniShellStore.closeSidebar();
 	}
 
+	async function focusSearch() {
+		miniShellStore.openSidebar();
+		await tick();
+		sidebarRef?.focusSearch();
+	}
+
 	function onKeydown(event: KeyboardEvent) {
 		if (matchesShortcut(event, settingsStore.settings.shortcuts.toggleSidebar)) {
 			event.preventDefault();
 			miniShellStore.toggleSidebar();
+			return;
+		}
+		if (matchesShortcut(event, settingsStore.settings.shortcuts.focusSearch)) {
+			event.preventDefault();
+			void focusSearch();
 			return;
 		}
 		if (matchesShortcut(event, settingsStore.settings.shortcuts.newChat)) {
@@ -49,9 +63,9 @@
 <div class="mini-shell">
 	{@render children()}
 	{#if miniShellStore.sidebarOpen}
-		<button class="mini-sidebar-backdrop" type="button" aria-label="Close chats" onclick={() => miniShellStore.closeSidebar()} transition:fade={{ duration: 120 }}></button>
-		<div class="mini-sidebar-drawer" transition:fly={{ x: -220, duration: 180 }}>
-			<MiniSessionSidebar onClose={() => miniShellStore.closeSidebar()} onSelectSession={selectSession} onNewChat={() => void createSession()} />
+		<button class="mini-sidebar-backdrop" type="button" aria-label="Close chats" onclick={() => miniShellStore.closeSidebar()} transition:fade={{ duration: 180, easing: cubicOut }}></button>
+		<div class="mini-sidebar-drawer" transition:fly={{ x: -260, opacity: 0, duration: 220, easing: cubicOut }}>
+			<MiniSessionSidebar bind:this={sidebarRef} onClose={() => miniShellStore.closeSidebar()} onSelectSession={selectSession} onNewChat={() => void createSession()} />
 		</div>
 	{/if}
 </div>

--- a/cometline/src/lib/components/sidebar/SessionRow.svelte
+++ b/cometline/src/lib/components/sidebar/SessionRow.svelte
@@ -12,6 +12,7 @@
 		showWorkspaceLabel = false,
 		showGatewayLabel = false,
 		showPin = true,
+		showActions = true,
 		onSelect,
 		onDelete,
 		onPin,
@@ -24,6 +25,7 @@
 		showWorkspaceLabel?: boolean;
 		showGatewayLabel?: boolean;
 		showPin?: boolean;
+		showActions?: boolean;
 		onSelect: () => void;
 		onDelete: () => void;
 		onPin: () => void;
@@ -44,6 +46,7 @@
 	class="session-row-wrap group relative flex items-stretch"
 	class:selected
 	class:streaming={streaming && !selected}
+	class:has-actions={showActions}
 	role="group"
 	oncontextmenu={handleContextMenu}
 >
@@ -64,9 +67,10 @@
 			<span class="session-workspace">{workspaceLabel(session.workspace_path)}</span>
 		{/if}
 	</button>
-	<div class="session-actions">
-		{#if showPin}
-			<button
+	{#if showActions}
+		<div class="session-actions">
+			{#if showPin}
+				<button
 				class="pin-session"
 				class:active={session.pinned}
 				disabled={pinning}
@@ -75,24 +79,25 @@
 					? `Unpin ${session.title || 'Untitled'}`
 					: `Pin ${session.title || 'Untitled'}`}
 				title={session.pinned ? 'Unpin session' : 'Pin session'}
-			>
-				{#if session.pinned}
-					<Pin size={13} stroke-width={2} />
-				{:else}
-					<PinOff size={13} stroke-width={1.9} />
-				{/if}
-			</button>
-		{/if}
-		<button
+				>
+					{#if session.pinned}
+						<Pin size={13} stroke-width={2} />
+					{:else}
+						<PinOff size={13} stroke-width={1.9} />
+					{/if}
+				</button>
+			{/if}
+			<button
 			class="delete-session"
 			disabled={deleting}
 			onclick={onDelete}
 			aria-label={`Delete ${session.title || 'Untitled'}`}
 			title="Delete session"
-		>
-			<Trash2 size={13} stroke-width={1.9} />
-		</button>
-	</div>
+			>
+				<Trash2 size={13} stroke-width={1.9} />
+			</button>
+		</div>
+	{/if}
 </div>
 
 <style>
@@ -133,7 +138,7 @@
 		width: 100%;
 		text-align: left;
 		padding: 6px 8px;
-		padding-right: 58px;
+		padding-right: 8px;
 		border: none;
 		background: transparent;
 		color: var(--text-main);
@@ -141,6 +146,10 @@
 		line-height: 1.35;
 		font-weight: 450;
 		cursor: pointer;
+	}
+
+	.session-row-wrap.has-actions .session-row {
+		padding-right: 58px;
 	}
 
 	.session-row-wrap.selected .session-title {

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '$lib/types';
+
+const mocks = vi.hoisted(() => ({
+	goto: vi.fn().mockResolvedValue(undefined),
+	createNewSession: vi.fn(),
+	selectSession: vi.fn(),
+	selectFromSession: vi.fn(),
+	setActiveWorkspacePath: vi.fn(),
+	setSidebarOrderWorkspacePath: vi.fn(),
+	setSidebarOrderDiscordActive: vi.fn(),
+	recordVisit: vi.fn()
+}));
+
+vi.mock('$app/navigation', () => ({ goto: mocks.goto }));
+vi.mock('$lib/actions/create-new-session', () => ({ createNewSession: mocks.createNewSession }));
+vi.mock('$lib/client/cometmind', () => ({ createSession: vi.fn(), listSessions: vi.fn() }));
+vi.mock('$lib/stores/model.svelte', () => ({
+	modelStore: { options: [], selected: null, selectDefault: vi.fn(), selectFromSession: mocks.selectFromSession }
+}));
+vi.mock('$lib/stores/session.svelte', () => ({
+	sessionStore: { selectSession: mocks.selectSession, upsertSession: vi.fn(), appendSession: vi.fn() }
+}));
+vi.mock('$lib/stores/settings.svelte', () => ({ settingsStore: { load: vi.fn() } }));
+vi.mock('$lib/stores/shell.svelte', () => ({
+	shellStore: {
+		workspacePath: '/current-workspace',
+		setActiveWorkspacePath: mocks.setActiveWorkspacePath,
+		setSidebarOrderWorkspacePath: mocks.setSidebarOrderWorkspacePath,
+		setSidebarOrderDiscordActive: mocks.setSidebarOrderDiscordActive
+	}
+}));
+vi.mock('$lib/stores/session-visit-history.svelte', () => ({
+	sessionVisitHistory: { recordVisit: mocks.recordVisit }
+}));
+
+import { createMiniWindowSession, navigateMiniToSession } from './mini-window-session';
+
+const session: Session = {
+	id: 'mini-session',
+	workspace_id: 'workspace-2',
+	workspace_path: '/other-workspace',
+	title: '',
+	model_id: 'model',
+	provider_id: 'provider',
+	status: 'active',
+	origin: 'user',
+	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+	pinned: false,
+	created_at: 0,
+	updated_at: 0
+};
+
+describe('mini window sessions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.createNewSession.mockResolvedValue(session);
+		vi.stubGlobal('window', {
+			electronAPI: { saveMiniWindowState: vi.fn().mockResolvedValue(undefined) }
+		});
+	});
+
+	it('keeps selected session navigation inside the mini route namespace', async () => {
+		await navigateMiniToSession(session);
+
+		expect(mocks.selectSession).toHaveBeenCalledWith(session);
+		expect(mocks.selectFromSession).toHaveBeenCalledWith(session);
+		expect(mocks.setActiveWorkspacePath).toHaveBeenCalledWith('/other-workspace');
+		expect(mocks.setSidebarOrderWorkspacePath).toHaveBeenCalledWith('/other-workspace');
+		expect(mocks.recordVisit).toHaveBeenCalledWith('mini-session');
+		expect(window.electronAPI?.saveMiniWindowState).toHaveBeenCalledWith({
+			sessionId: 'mini-session'
+		});
+		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
+	});
+
+	it('creates a default-model session and opens it in the mini route', async () => {
+		await expect(createMiniWindowSession()).resolves.toEqual(session);
+
+		expect(mocks.createNewSession).toHaveBeenCalledOnce();
+		expect(window.electronAPI?.saveMiniWindowState).toHaveBeenCalledWith({
+			sessionId: 'mini-session'
+		});
+		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
+	});
+});

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -4,6 +4,7 @@ import type { Session } from '$lib/types';
 const mocks = vi.hoisted(() => ({
 	goto: vi.fn().mockResolvedValue(undefined),
 	createNewSession: vi.fn(),
+	listAllSessions: vi.fn(),
 	selectSession: vi.fn(),
 	selectFromSession: vi.fn(),
 	setActiveWorkspacePath: vi.fn(),
@@ -14,7 +15,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('$app/navigation', () => ({ goto: mocks.goto }));
 vi.mock('$lib/actions/create-new-session', () => ({ createNewSession: mocks.createNewSession }));
-vi.mock('$lib/client/cometmind', () => ({ createSession: vi.fn(), listSessions: vi.fn() }));
+vi.mock('$lib/client/cometmind', () => ({
+	createSession: vi.fn(),
+	listAllSessions: mocks.listAllSessions
+}));
 vi.mock('$lib/stores/model.svelte', () => ({
 	modelStore: { options: [], selected: null, selectDefault: vi.fn(), selectFromSession: mocks.selectFromSession }
 }));
@@ -34,7 +38,11 @@ vi.mock('$lib/stores/session-visit-history.svelte', () => ({
 	sessionVisitHistory: { recordVisit: mocks.recordVisit }
 }));
 
-import { createMiniWindowSession, navigateMiniToSession } from './mini-window-session';
+import {
+	createMiniWindowSession,
+	ensureMiniWindowSession,
+	navigateMiniToSession
+} from './mini-window-session';
 
 const session: Session = {
 	id: 'mini-session',
@@ -55,6 +63,7 @@ describe('mini window sessions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.createNewSession.mockResolvedValue(session);
+		mocks.listAllSessions.mockResolvedValue({ sessions: [session] });
 		vi.stubGlobal('window', {
 			electronAPI: { saveMiniWindowState: vi.fn().mockResolvedValue(undefined) }
 		});
@@ -82,5 +91,12 @@ describe('mini window sessions', () => {
 			sessionId: 'mini-session'
 		});
 		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
+	});
+
+	it('reuses a preferred session from another workspace', async () => {
+		await expect(ensureMiniWindowSession('mini-session')).resolves.toBe('mini-session');
+
+		expect(mocks.listAllSessions).toHaveBeenCalledOnce();
+		expect(mocks.createNewSession).not.toHaveBeenCalled();
 	});
 });

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -1,7 +1,13 @@
+import { goto } from '$app/navigation';
 import { createSession, listSessions } from '$lib/client/cometmind';
+import { createNewSession } from '$lib/actions/create-new-session';
 import { modelStore } from '$lib/stores/model.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
+import { shellStore } from '$lib/stores/shell.svelte';
+import { sessionVisitHistory } from '$lib/stores/session-visit-history.svelte';
+import { isDiscordSession } from '$lib/sessions/group-by-workspace';
+import type { Session } from '$lib/types';
 
 async function resolveSelectedModel() {
 	if (modelStore.options.length === 0) {
@@ -56,4 +62,28 @@ export async function ensureMiniWindowSession(preferredSessionId = '') {
 	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
 	sessionStore.appendSession(session);
 	return session.id;
+}
+
+/** Select a session without leaving the mini-window route namespace. */
+export async function navigateMiniToSession(session: Session) {
+	sessionStore.selectSession(session);
+	modelStore.selectFromSession(session);
+	if (session.workspace_path && session.workspace_path !== shellStore.workspacePath) {
+		shellStore.setActiveWorkspacePath(session.workspace_path);
+	}
+	if (session.workspace_path) {
+		shellStore.setSidebarOrderWorkspacePath(session.workspace_path);
+	}
+	shellStore.setSidebarOrderDiscordActive(isDiscordSession(session));
+	sessionVisitHistory.recordVisit(session.id);
+	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
+	await goto(`/mini/session/${session.id}`);
+}
+
+/** Create and open a persisted mini-window session using the configured default model. */
+export async function createMiniWindowSession() {
+	const session = await createNewSession();
+	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
+	await goto(`/mini/session/${session.id}`);
+	return session;
 }

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -1,5 +1,5 @@
 import { goto } from '$app/navigation';
-import { createSession, listSessions } from '$lib/client/cometmind';
+import { createSession, listAllSessions } from '$lib/client/cometmind';
 import { createNewSession } from '$lib/actions/create-new-session';
 import { modelStore } from '$lib/stores/model.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
@@ -42,7 +42,9 @@ export async function ensureMiniWindowSession(preferredSessionId = '') {
 	const workspacePath = (await window.electronAPI?.getWorkspacePath?.()) ?? '/';
 
 	if (sessionId && shouldReuseSession) {
-		const sessions = await listSessions(workspacePath);
+		// Mini sessions may be pinned or belong to another workspace. The route ID
+		// is authoritative, so do not filter it through Electron's default workspace.
+		const sessions = await listAllSessions();
 		const session = sessions.sessions.find((item) => item.id === sessionId);
 		if (session) {
 			sessionStore.upsertSession(session);

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/conversation/thinking-attribution';
 
 const { goto } = vi.hoisted(() => ({ goto: vi.fn() }));
+const { createNewSession } = vi.hoisted(() => ({ createNewSession: vi.fn() }));
 
 vi.mock('$app/environment', () => ({ browser: true }));
 vi.mock('$app/navigation', () => ({ goto }));
@@ -19,6 +20,7 @@ vi.mock('$lib/client/cometmind', () => ({
 	streamMessage: vi.fn(),
 	abortSession: vi.fn()
 }));
+vi.mock('$lib/actions/create-new-session', () => ({ createNewSession }));
 
 import { getSessionMessages, listChildSessions, streamMessage } from '$lib/client/cometmind';
 import { chatStore } from './chat.svelte';
@@ -69,6 +71,7 @@ describe('chatStore session switching', () => {
 		sessionStore.setSessions([]);
 		goto.mockClear();
 		vi.clearAllMocks();
+		createNewSession.mockResolvedValue({ id: 'new-session' });
 		vi.mocked(listChildSessions).mockResolvedValue({ sessions: [] });
 		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
 			cb(0);

--- a/cometline/src/lib/stores/mini-shell.svelte.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.ts
@@ -1,0 +1,20 @@
+function createMiniShellStore() {
+	let sidebarOpen = $state(false);
+
+	return {
+		get sidebarOpen() {
+			return sidebarOpen;
+		},
+		toggleSidebar() {
+			sidebarOpen = !sidebarOpen;
+		},
+		openSidebar() {
+			sidebarOpen = true;
+		},
+		closeSidebar() {
+			sidebarOpen = false;
+		}
+	};
+}
+
+export const miniShellStore = createMiniShellStore();

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import AppShell from '$lib/components/AppShell.svelte';
+	import MiniShell from '$lib/components/MiniShell.svelte';
 	import { connectionState } from '$lib/stores/runtime.svelte';
 	import { settingsStore, readHasDismissedSetupWizardSync } from '$lib/stores/settings.svelte';
 	import { sessionStore } from '$lib/stores/session.svelte';
@@ -205,7 +206,11 @@
 	}
 </script>
 
-{#if isMiniRoute || isSettingsRoute}
+{#if isMiniRoute}
+	<MiniShell>
+		{@render children()}
+	</MiniShell>
+{:else if isSettingsRoute}
 	{@render children()}
 {:else}
 	<AppShell>


### PR DESCRIPTION
## Background

The mini window previously owned a rolling chat but could not browse sessions. Moving to a pinned or cross-workspace session could also create a replacement session because its route resolver restricted lookup to Electron's default workspace.

[761a38c](https://github.com/Cometline/cometline/commit/761a38c4801f0033939e58176ed9dcdd1a7c5f4d): New chats now persist immediately with the configured default model, so main and mini `Cmd+T` open real session records.

[c3e8212](https://github.com/Cometline/cometline/commit/c3e8212f1b9953290ec1a46f002db5d08afd1747): The mini window gains an overlay session drawer with search, workspace grouping, and mini-route navigation.

[7116410](https://github.com/Cometline/cometline/commit/71164101b120d31ae313884137a99754123640c3): Session resolution now checks all sessions, so pinned and cross-workspace chats open without creating a replacement session.

[86c7545](https://github.com/Cometline/cometline/commit/86c7545a9ac029c505bf3b28083267df571ed320): The drawer adds keyboard search, pin and delete controls, and matching group and drawer transitions.