### PR TITLE
[main] fix: refresh queued message visibility

### DIFF
--- a/cometline/src/lib/actions/chat-turn-queue.test.ts
+++ b/cometline/src/lib/actions/chat-turn-queue.test.ts
@@ -139,6 +139,31 @@ describe('createChatTurnQueue', () => {
 		expect(runTurn).toHaveBeenCalledTimes(1);
 	});
 
+	it('updates the queue change handler when its view changes', async () => {
+		const firstView = vi.fn();
+		const currentView = vi.fn();
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const runTurn = vi.fn().mockImplementation(async (payload: ChatTurnPayload) => {
+			if (payload.text === 'first') await firstGate;
+		});
+		const queue = createChatTurnQueue(runTurn, firstView);
+
+		void queue.enqueue('first');
+		await vi.waitFor(() => expect(queue.processing).toBe(true));
+		queue.setOnChange(currentView);
+		firstView.mockClear();
+
+		await queue.enqueue('second');
+
+		expect(firstView).not.toHaveBeenCalled();
+		expect(currentView).toHaveBeenCalled();
+		releaseFirst!();
+		await vi.waitFor(() => expect(queue.processing).toBe(false));
+	});
+
 	it('remove drops a specific queued turn', async () => {
 		let releaseFirst: (() => void) | undefined;
 		const firstGate = new Promise<void>((resolve) => {

--- a/cometline/src/lib/actions/chat-turn-queue.ts
+++ b/cometline/src/lib/actions/chat-turn-queue.ts
@@ -13,6 +13,7 @@ export interface ChatTurnQueue {
 	enqueue(payload: ChatTurnPayload | string): Promise<boolean>;
 	remove(id: string): boolean;
 	clear(): void;
+	setOnChange(onChange?: () => void): void;
 	readonly pendingCount: number;
 	readonly pendingMessages: readonly QueuedMessage[];
 	readonly processing: boolean;
@@ -30,9 +31,10 @@ export function createChatTurnQueue(
 	let processing = false;
 	let activeTurnSignature: string | null = null;
 	let nextID = 0;
+	let currentOnChange = onChange;
 
 	function notifyChange() {
-		onChange?.();
+		currentOnChange?.();
 	}
 
 	function createQueuedMessage(payload: ChatTurnPayload): QueuedMessage {
@@ -133,6 +135,9 @@ export function createChatTurnQueue(
 		clear() {
 			queue = [];
 			notifyChange();
+		},
+		setOnChange(nextOnChange) {
+			currentOnChange = nextOnChange;
 		}
 	};
 }

--- a/cometline/src/lib/actions/new-chat.ts
+++ b/cometline/src/lib/actions/new-chat.ts
@@ -23,6 +23,9 @@ export async function startNewChat() {
 				.catch(() => {});
 		}
 	}
+	// Creating the next persisted session may wait on the sidecar. Unbind now so
+	// the current turn queue can keep draining without the old view staying active.
+	chatStore.detachActiveSession();
 	const session = await createNewSession();
 	await goto(`/session/${session.id}`);
 }

--- a/cometline/src/lib/conversation/conversation-controller.test.ts
+++ b/cometline/src/lib/conversation/conversation-controller.test.ts
@@ -38,6 +38,7 @@ describe('createConversationController', () => {
 		onAwaitingFirstAssistantChange?: Mock<
 			NonNullable<ConversationControllerDeps['onAwaitingFirstAssistantChange']>
 		>;
+		onQueueChange?: Mock<NonNullable<ConversationControllerDeps['onQueueChange']>>;
 	}) {
 		const send = overrides?.send ?? vi.fn().mockResolvedValue(undefined);
 		const refreshSession = overrides?.refreshSession ?? vi.fn().mockResolvedValue(undefined);
@@ -50,6 +51,7 @@ describe('createConversationController', () => {
 			send,
 			refreshSession,
 			flight: overrides?.flight,
+			onQueueChange: overrides?.onQueueChange,
 			onAwaitingFirstAssistantChange: overrides?.onAwaitingFirstAssistantChange
 		});
 
@@ -309,6 +311,34 @@ describe('createConversationController', () => {
 			'start:sess-1:second',
 			'end:sess-1:second'
 		]);
+	});
+
+	it('rebinds queue updates after returning to a session', async () => {
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const send = vi.fn().mockImplementation(async (_sessionId: string, payload: FlightPayload) => {
+			const text = typeof payload === 'string' ? payload : payload.text;
+			if (text === 'first') await firstGate;
+		});
+		const oldViewChange = vi.fn();
+		const currentViewChange = vi.fn();
+		const { controller: oldView } = createDeps({ send, onQueueChange: oldViewChange });
+
+		void oldView.enqueue('first');
+		await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+		const { controller: currentView } = createDeps({ send, onQueueChange: currentViewChange });
+		void currentView.pendingCount;
+		oldViewChange.mockClear();
+		currentViewChange.mockClear();
+
+		await currentView.enqueue('second');
+
+		expect(oldViewChange).not.toHaveBeenCalled();
+		expect(currentViewChange).toHaveBeenCalled();
+		releaseFirst!();
+		await vi.waitFor(() => expect(currentView.processing).toBe(false));
 	});
 
 	it('consumes pending first message on mount', async () => {

--- a/cometline/src/lib/conversation/conversation-controller.ts
+++ b/cometline/src/lib/conversation/conversation-controller.ts
@@ -158,6 +158,10 @@ function ensureQueue(
 			await runTurn(deps, queueForSessionId, payload, getHasVisibleConversation);
 		}, deps.onQueueChange);
 		turnQueues.set(sessionId, queue);
+	} else {
+		// A session queue can outlive its ChatView while it drains in the background.
+		// Point change notifications at the view that is currently showing that session.
+		queue.setOnChange(deps.onQueueChange);
 	}
 	return queue;
 }

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -291,6 +291,23 @@ describe('chatStore session switching', () => {
 		]);
 	});
 
+	it('detaches the active chat while creating a new persisted session', async () => {
+		let resolveSession: ((session: { id: string }) => void) | undefined;
+		createNewSession.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveSession = resolve;
+				})
+		);
+		chatStore.bindSession('sess-a');
+
+		const newChat = startNewChat();
+
+		expect(chatStore.sessionID).toBe(null);
+		resolveSession?.({ id: 'sess-b' });
+		await newChat;
+	});
+
 	it('surfaces an error item when the model fails before any output (e.g. 401)', async () => {
 		vi.mocked(streamMessage).mockImplementation(async function* () {
 			yield { type: 'error', message: 'cometsdk: openai: authentication failed (HTTP 401)' };


### PR DESCRIPTION
## Background

Queued messages can continue draining after the ChatView that created their queue is no longer the active view. The queue retained that stale view's update callback, so the message could be queued correctly but not appear in the current queue panel.

[bca700b](https://github.com/Cometline/cometline/commit/bca700be2e63a9290cc7cbcf48a2b8d4b10cfa44): New Chat now detaches the active chat before waiting for persisted session creation, allowing the previous session's stream and queue to continue in the background.

[5182bd9](https://github.com/Cometline/cometline/commit/5182bd925361612a0640765d041d8fd6729d5201): Session queues now refresh their view callback when a controller returns to that session, keeping queued-message visibility aligned with the active ChatView.