### PR TITLE
[main] fix: preserve user message flights

### DIFF
--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -46,7 +46,10 @@
 			awaitingFirstAssistant = value;
 		},
 		flight: {
-			onUserMessageFlight: (payloadOrText, { firstTurn, stageUser, revealStagedUser }) => {
+			onUserMessageFlight: (
+				payloadOrText,
+				{ firstTurn, stageUser, revealStagedUser, userItemId }
+			) => {
 				const payload =
 					typeof payloadOrText === 'string' ? { text: payloadOrText } : payloadOrText;
 				if (compact && firstTurn) {
@@ -61,13 +64,17 @@
 						revealStagedUser();
 						return;
 					}
-					stageUser(payload.text, payload.images);
+					const compactUserItemId = stageUser(payload.text, payload.images);
+					const flight = startFlight();
 					return userBubbleFlight
 						.runAsync(payload.text, payload.images, {
 							origin: 'above-composer',
-							skipStage: true
+							skipStage: true,
+							targetUserId: compactUserItemId,
+							signal: flight.signal
 						})
-						.then(() => undefined);
+						.then(() => undefined)
+						.finally(() => finishFlight(flight));
 				}
 				if (firstTurn) {
 					awaitingFirstAssistant = true;
@@ -76,23 +83,35 @@
 					if (!firstTurnFlight) {
 						firstTurnFlightDone = true;
 						firstTurnHandoffPending = false;
+						stageUser(payload.text, payload.images);
+						revealStagedUser();
 						return;
 					}
+					const flight = startFlight();
 					return firstTurnFlight
-						?.runAsync(payload.text, payload.images)
+						?.runAsync(payload.text, payload.images, {
+							stageUser,
+							revealStagedUser,
+							signal: flight.signal
+						})
 						.catch((error) => {
 							firstTurnFlightDone = true;
 							firstTurnHandoffPending = false;
 							throw error;
-						});
+						})
+						.finally(() => finishFlight(flight));
 				}
+				const flight = startFlight();
 				return userBubbleFlight
 					?.runAsync(payload.text, payload.images, {
 						origin: 'above-composer',
 						skipStage: true,
-						skipReveal: true
+						skipReveal: true,
+						targetUserId: userItemId,
+						signal: flight.signal
 					})
-					.then(() => undefined);
+					.then(() => undefined)
+					.finally(() => finishFlight(flight));
 			}
 		}
 	});
@@ -100,6 +119,7 @@
 	let chatHome = $state<HTMLDivElement | null>(null);
 	let userBubbleFlight = $state<UserBubbleFlight>();
 	let firstTurnFlight = $state<FirstTurnFlight>();
+	let flightAbortController = $state<AbortController | null>(null);
 	let awaitingFirstAssistant = $state(false);
 	let firstTurnActive = $state(false);
 	let firstTurnFlightDone = $state(false);
@@ -151,6 +171,16 @@
 	let heroLayout = $derived(chatView.heroLayout);
 	let composerFocusRequestId = $derived(shellStore.composerFocusRequestId);
 
+	function startFlight() {
+		flightAbortController?.abort();
+		flightAbortController = new AbortController();
+		return flightAbortController;
+	}
+
+	function finishFlight(controller: AbortController) {
+		if (flightAbortController === controller) flightAbortController = null;
+	}
+
 	function syncQueueState() {
 		queuedCount = conversation.pendingCount;
 		queuedMessages = [...conversation.pendingMessages];
@@ -178,6 +208,10 @@
 	$effect(() => {
 		void sessionId;
 		untrack(() => {
+			flightAbortController?.abort();
+			flightAbortController = null;
+			firstTurnFlight?.cancel();
+			userBubbleFlight?.dismissParticle();
 			firstTurnActive = false;
 			firstTurnHandoffPending = false;
 			snapshotSynced = false;

--- a/cometline/src/lib/components/FirstTurnFlight.svelte
+++ b/cometline/src/lib/components/FirstTurnFlight.svelte
@@ -17,11 +17,17 @@
 	interface Props {
 		root: HTMLElement | null;
 		userBubbleFlight: UserBubbleFlight;
-		stageUser: (text: string, images?: ImageAttachment[]) => void;
+		stageUser: (text: string, images?: ImageAttachment[]) => string;
 		revealStagedUser: () => void;
 		onActiveChange?: (active: boolean) => void;
 		onFlightDoneChange?: (done: boolean) => void;
 		onPrepareFlight?: () => void;
+	}
+
+	interface RunOptions {
+		stageUser?: (text: string, images?: ImageAttachment[]) => string;
+		revealStagedUser?: () => void;
+		signal?: AbortSignal;
 	}
 
 	let {
@@ -49,9 +55,19 @@
 	);
 	let showAvatarFlight = $state(false);
 
-	export async function runAsync(text: string, images?: ImageAttachment[]): Promise<void> {
+	export async function runAsync(
+		text: string,
+		images?: ImageAttachment[],
+		opts: RunOptions = {}
+	): Promise<void> {
 		if (active) return;
-		await animate(text, images);
+		await animate(text, images, opts);
+	}
+
+	export function cancel() {
+		hideAvatarParticle();
+		userBubbleFlight.dismissParticle();
+		setActive(false);
 	}
 
 	function setActive(value: boolean) {
@@ -69,10 +85,17 @@
 		avatarFlightStyle = '';
 	}
 
-	async function animate(text: string, images?: ImageAttachment[]): Promise<void> {
+	async function animate(
+		text: string,
+		images?: ImageAttachment[],
+		opts: RunOptions = {}
+	): Promise<void> {
+		const runStageUser = opts.stageUser ?? stageUser;
+		const runRevealStagedUser = opts.revealStagedUser ?? revealStagedUser;
+		const { signal } = opts;
 		if (!root) {
-			stageUser(text, images);
-			revealStagedUser();
+			runStageUser(text, images);
+			runRevealStagedUser();
 			setFlightDone(true);
 			setActive(false);
 			return;
@@ -91,7 +114,7 @@
 		onPrepareFlight?.();
 		setActive(true);
 		setFlightDone(false);
-		stageUser(text, images);
+		const userItemId = runStageUser(text, images);
 		await tick();
 		const composerFlight =
 			composerElement instanceof HTMLElement
@@ -99,7 +122,17 @@
 				: Promise.resolve();
 
 		let avatarFlightEnd: Promise<void> | undefined;
-		const avatarTarget = await waitForSelector(root, '[data-flight-target="avatar"]');
+		const avatarTarget = await waitForSelector(
+			root,
+			'[data-flight-target="avatar"]',
+			4000,
+			undefined,
+			signal
+		);
+		if (signal?.aborted) {
+			runRevealStagedUser();
+			return;
+		}
 		if (avatarFrom && avatarTarget instanceof HTMLElement) {
 			const avatarTo = await measureStableRect(avatarTarget);
 			avatarFlightStyle = rectStyle(avatarFrom, avatarTo);
@@ -112,13 +145,19 @@
 			skipStage: true,
 			textareaFrom,
 			deferReveal: true,
-			deferHideParticle: true
+			deferHideParticle: true,
+			targetUserId: userItemId,
+			signal
 		});
+		if (signal?.aborted) {
+			runRevealStagedUser();
+			return;
+		}
 
 		if (!userFlew) {
 			await avatarFlightEnd;
 			await composerFlight;
-			revealStagedUser();
+			runRevealStagedUser();
 			setFlightDone(true);
 			await afterPaint();
 			hideAvatarParticle();
@@ -129,7 +168,7 @@
 
 		await avatarFlightEnd;
 		await composerFlight;
-		revealStagedUser();
+		runRevealStagedUser();
 		// Unhide the real thread avatar slot BEFORE tearing down flight particles,
 		// so the avatar never blinks out between overlay end and the thread slot.
 		setFlightDone(true);

--- a/cometline/src/lib/components/UserBubbleFlight.svelte
+++ b/cometline/src/lib/components/UserBubbleFlight.svelte
@@ -17,6 +17,8 @@
 		skipStage?: boolean;
 		skipReveal?: boolean;
 		origin?: UserBubbleFlightOrigin;
+		targetUserId?: string;
+		signal?: AbortSignal;
 	}
 
 	interface Props {
@@ -60,6 +62,8 @@
 			root,
 			text,
 			images,
+			targetUserId: opts.targetUserId,
+			signal: opts.signal,
 			stageUser,
 			revealStagedUser,
 			onPrepare: opts.onPrepare,

--- a/cometline/src/lib/components/chat/UserMessageRow.svelte
+++ b/cometline/src/lib/components/chat/UserMessageRow.svelte
@@ -30,6 +30,7 @@
 			class="bubble user-bubble"
 			class:flight-hidden={item.reveal === false}
 			data-flight-target={item.reveal === false ? 'user' : undefined}
+			data-flight-user-id={item.reveal === false ? item.id : undefined}
 		>
 			{#if item.images?.length}
 				<div class="user-images" class:text-following={Boolean(item.text)}>

--- a/cometline/src/lib/conversation/conversation-controller.test.ts
+++ b/cometline/src/lib/conversation/conversation-controller.test.ts
@@ -67,7 +67,9 @@ describe('createConversationController', () => {
 
 	it('lets active first-turn flight own staging before sending with skipUser', async () => {
 		chatStore.bindSession('sess-1');
-		const onUserMessageFlight = vi.fn().mockResolvedValue(undefined);
+		const onUserMessageFlight = vi.fn().mockImplementation((_, ctx: FlightContext) => {
+			ctx.stageUser('hello', undefined);
+		});
 		const stageSpy = vi.spyOn(chatStore, 'stageUserForSession');
 		const revealSpy = vi.spyOn(chatStore, 'revealStagedUserForSession');
 		const { controller, send, refreshSession } = createDeps({
@@ -76,14 +78,35 @@ describe('createConversationController', () => {
 
 		await controller.enqueue('hello');
 
-		expect(stageSpy).not.toHaveBeenCalled();
+		expect(stageSpy).toHaveBeenCalledWith('sess-1', 'hello', undefined);
 		expect(onUserMessageFlight).toHaveBeenCalledWith(
 			'hello',
 			expect.objectContaining({ firstTurn: true, sessionId: 'sess-1' })
 		);
-		expect(revealSpy).not.toHaveBeenCalled();
+		expect(revealSpy).toHaveBeenCalledWith('sess-1');
 		expect(send).toHaveBeenCalledWith('sess-1', { text: 'hello' }, { skipUser: true });
 		expect(refreshSession).toHaveBeenCalledWith('sess-1');
+		stageSpy.mockRestore();
+		revealSpy.mockRestore();
+	});
+
+	it('reveals and sends a first turn when its flight fails', async () => {
+		chatStore.bindSession('sess-1');
+		const onUserMessageFlight = vi.fn().mockImplementation((_, ctx: FlightContext) => {
+			ctx.stageUser('hello', undefined);
+			throw new Error('flight interrupted');
+		});
+		const stageSpy = vi.spyOn(chatStore, 'stageUserForSession');
+		const revealSpy = vi.spyOn(chatStore, 'revealStagedUserForSession');
+		const { controller, send } = createDeps({
+			flight: { onUserMessageFlight }
+		});
+
+		await controller.enqueue('hello');
+
+		expect(stageSpy).toHaveBeenCalledWith('sess-1', 'hello', undefined);
+		expect(revealSpy).toHaveBeenCalledWith('sess-1');
+		expect(send).toHaveBeenCalledWith('sess-1', { text: 'hello' }, { skipUser: true });
 		stageSpy.mockRestore();
 		revealSpy.mockRestore();
 	});
@@ -318,10 +341,12 @@ describe('createConversationController', () => {
 		const firstGate = new Promise<void>((resolve) => {
 			releaseFirst = resolve;
 		});
-		const send = vi.fn().mockImplementation(async (_sessionId: string, payload: FlightPayload) => {
-			const text = typeof payload === 'string' ? payload : payload.text;
-			if (text === 'first') await firstGate;
-		});
+		const send = vi
+			.fn()
+			.mockImplementation(async (_sessionId: string, payload: FlightPayload) => {
+				const text = typeof payload === 'string' ? payload : payload.text;
+				if (text === 'first') await firstGate;
+			});
 		const oldViewChange = vi.fn();
 		const currentViewChange = vi.fn();
 		const { controller: oldView } = createDeps({ send, onQueueChange: oldViewChange });

--- a/cometline/src/lib/conversation/conversation-controller.ts
+++ b/cometline/src/lib/conversation/conversation-controller.ts
@@ -28,8 +28,9 @@ export interface ConversationFlightAdapter {
 		ctx: {
 			firstTurn: boolean;
 			sessionId: string;
-			stageUser: (text: string, images?: ImageAttachment[]) => void;
+			stageUser: (text: string, images?: ImageAttachment[]) => string;
 			revealStagedUser: () => void;
+			userItemId?: string;
 		}
 	): void | Promise<void>;
 	onFirstTurnComplete?(): void;
@@ -85,12 +86,7 @@ async function runTurn(
 			? chatStore.getCachedItemCount(turnSessionId) === 0
 			: !getHasVisibleConversation();
 	const flightPayload = payload.images?.length ? payload : userDisplay;
-	const stageUser = (text: string, images?: ImageAttachment[]) => {
-		chatStore.stageUserForSession(turnSessionId, text, images);
-	};
-	const revealStagedUser = () => {
-		chatStore.revealStagedUserForSession(turnSessionId);
-	};
+	let stagedUserId: string | undefined;
 	let flightPromise: Promise<void> | undefined;
 	let sendPromise: Promise<void> | undefined;
 	const startSend = () => {
@@ -102,6 +98,14 @@ async function runTurn(
 		}
 		return sendPromise;
 	};
+	const stageUser = (text: string, images?: ImageAttachment[]) => {
+		stagedUserId ??= chatStore.stageUserForSession(turnSessionId, text, images);
+		void startSend();
+		return stagedUserId;
+	};
+	const revealStagedUser = () => {
+		chatStore.revealStagedUserForSession(turnSessionId);
+	};
 
 	commitSidebarWorkspaceForSession(
 		sessionStore.sessions.find((session) => session.id === turnSessionId) ??
@@ -109,23 +113,28 @@ async function runTurn(
 	);
 
 	if (usesFlight && isViewing && firstTurn) {
-		await deps.flight!.onUserMessageFlight!(flightPayload, {
-			firstTurn,
-			sessionId: turnSessionId,
-			stageUser: (text, images) => {
-				stageUser(text, images);
-				void startSend();
-			},
-			revealStagedUser
-		});
+		try {
+			await deps.flight!.onUserMessageFlight!(flightPayload, {
+				firstTurn,
+				sessionId: turnSessionId,
+				stageUser,
+				revealStagedUser
+			});
+		} catch {
+			// A flight failure must not lose or strand the user turn.
+			if (!stagedUserId) stageUser(userDisplay, payload.images);
+		} finally {
+			revealStagedUser();
+		}
 	} else if (usesFlight && isViewing) {
-		stageUser(userDisplay, payload.images);
+		const userItemId = stageUser(userDisplay, payload.images);
 		flightPromise = Promise.resolve(
 			deps.flight!.onUserMessageFlight!(flightPayload, {
 				firstTurn,
 				sessionId: turnSessionId,
 				stageUser,
-				revealStagedUser
+				revealStagedUser,
+				userItemId
 			})
 		)
 			.catch(() => undefined)

--- a/cometline/src/lib/first-turn-flight.test.ts
+++ b/cometline/src/lib/first-turn-flight.test.ts
@@ -7,7 +7,8 @@ import {
 	measureStableUserBubble,
 	rectTransform,
 	textareaUserOrigin,
-	translateStyle
+	translateStyle,
+	waitForSelector
 } from './first-turn-flight';
 
 describe('rectTransform', () => {
@@ -70,6 +71,39 @@ describe('blendFlightOrigin', () => {
 		expect(blended.left).toBeCloseTo(294, 5);
 		expect(blended.top).toBeCloseTo(293.6, 5);
 		expect(blended.width).toBe(280);
+	});
+});
+
+describe('waitForSelector', () => {
+	it('selects the staged user target by its item ID', async () => {
+		const root = document.createElement('div');
+		root.innerHTML = `
+			<div data-flight-target="user" data-flight-user-id="stale"></div>
+			<div data-flight-target="user" data-flight-user-id="current"></div>
+		`;
+
+		const target = await waitForSelector(
+			root,
+			'[data-flight-target="user"]',
+			0,
+			(element) => element.getAttribute('data-flight-user-id') === 'current'
+		);
+
+		expect(target?.getAttribute('data-flight-user-id')).toBe('current');
+	});
+
+	it('stops waiting when the active session flight is aborted', async () => {
+		const controller = new AbortController();
+		const waiting = waitForSelector(
+			document.createElement('div'),
+			'[data-flight-target="user"]',
+			4000,
+			undefined,
+			controller.signal
+		);
+		controller.abort();
+
+		expect(await waiting).toBeNull();
 	});
 });
 

--- a/cometline/src/lib/first-turn-flight.ts
+++ b/cometline/src/lib/first-turn-flight.ts
@@ -222,8 +222,17 @@ export function dockUserOrigin(composerWrapper: DOMRect, target: DOMRect, gap = 
 	return new DOMRect(left, top, width, height);
 }
 
-export function wait(ms: number): Promise<void> {
-	return new Promise((resolve) => window.setTimeout(resolve, ms));
+export function wait(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.resolve();
+	return new Promise((resolve) => {
+		const timeout = window.setTimeout(finish, ms);
+		function finish() {
+			window.clearTimeout(timeout);
+			signal?.removeEventListener('abort', finish);
+			resolve();
+		}
+		signal?.addEventListener('abort', finish, { once: true });
+	});
 }
 
 /** Wait until the browser has painted pending DOM updates. */
@@ -238,26 +247,46 @@ export function afterPaint(): Promise<void> {
 export async function waitForSelector(
 	root: ParentNode,
 	selector: string,
-	timeoutMs = 4000
+	timeoutMs = 4000,
+	predicate?: (element: Element) => boolean,
+	signal?: AbortSignal
 ): Promise<Element | null> {
-	const existing = root.querySelector(selector);
+	if (signal?.aborted) return null;
+	const findMatch = () => {
+		const elements = root.querySelectorAll(selector);
+		return predicate ? ([...elements].find(predicate) ?? null) : (elements[0] ?? null);
+	};
+
+	const existing = findMatch();
 	if (existing) return existing;
 
 	return new Promise((resolve) => {
 		const started = performance.now();
+		let frame = 0;
+		const finish = (result: Element | null) => {
+			if (frame) cancelAnimationFrame(frame);
+			signal?.removeEventListener('abort', onAbort);
+			resolve(result);
+		};
+		const onAbort = () => finish(null);
 		const tick = () => {
-			const found = root.querySelector(selector);
+			if (signal?.aborted) {
+				finish(null);
+				return;
+			}
+			const found = findMatch();
 			if (found) {
-				resolve(found);
+				finish(found);
 				return;
 			}
 			if (performance.now() - started >= timeoutMs) {
-				resolve(null);
+				finish(null);
 				return;
 			}
-			requestAnimationFrame(tick);
+			frame = requestAnimationFrame(tick);
 		};
-		requestAnimationFrame(tick);
+		signal?.addEventListener('abort', onAbort, { once: true });
+		frame = requestAnimationFrame(tick);
 	});
 }
 
@@ -265,6 +294,8 @@ export interface FlyUserBubbleParams {
 	root: HTMLElement;
 	text: string;
 	images?: ImageAttachment[];
+	targetUserId?: string;
+	signal?: AbortSignal;
 	stageUser: (text: string, images?: ImageAttachment[]) => void;
 	revealStagedUser: () => void;
 	onPrepare?: () => void;
@@ -292,6 +323,8 @@ export async function flyUserBubble(params: FlyUserBubbleParams): Promise<boolea
 		root,
 		text,
 		images,
+		targetUserId,
+		signal,
 		stageUser,
 		revealStagedUser,
 		onPrepare,
@@ -324,10 +357,19 @@ export async function flyUserBubble(params: FlyUserBubbleParams): Promise<boolea
 	if (!skipOnPrepare) onPrepare?.();
 	if (!skipStage) stageUser(text, images);
 	await tick();
+	if (signal?.aborted) return false;
 	if (!isFollowUpTurn) scrollThreadToBottom(root);
 	await afterPaint();
 
-	const userTarget = await waitForSelector(root, '[data-flight-target="user"]');
+	const userTarget = await waitForSelector(
+		root,
+		'[data-flight-target="user"]',
+		4000,
+		targetUserId
+			? (element) => element.getAttribute('data-flight-user-id') === targetUserId
+			: undefined,
+		signal
+	);
 	if (!(userTarget instanceof HTMLElement)) {
 		reveal();
 		return false;
@@ -361,7 +403,8 @@ export async function flyUserBubble(params: FlyUserBubbleParams): Promise<boolea
 	const style = translateStyle(fromRect, userTo);
 
 	onShowParticle(text, images, style);
-	await wait(FLIGHT_MS);
+	await wait(FLIGHT_MS, signal);
+	if (signal?.aborted) return false;
 	if (!deferHideParticle) onHideParticle();
 	reveal();
 	return true;

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -23,7 +23,7 @@ vi.mock('$lib/client/cometmind', () => ({
 vi.mock('$lib/actions/create-new-session', () => ({ createNewSession }));
 
 import { getSessionMessages, listChildSessions, streamMessage } from '$lib/client/cometmind';
-import { chatStore } from './chat.svelte';
+import { chatStore, revealRemoteUserItems } from './chat.svelte';
 import { sessionStore } from './session.svelte';
 import { startNewChat } from '$lib/actions/new-chat';
 
@@ -555,6 +555,18 @@ describe('chatStore session switching', () => {
 		// `each_key_duplicate`.
 		const ids = chatStore.items.map((item) => item.id);
 		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe('revealRemoteUserItems', () => {
+	it('does not copy a source window flight-hidden user row', () => {
+		const items = revealRemoteUserItems([
+			{ id: 'u1', type: 'user', text: 'in flight', reveal: false },
+			{ id: 'a1', type: 'assistant', text: '', pending: true }
+		]);
+
+		expect(items[0]).toMatchObject({ id: 'u1', reveal: true });
+		expect(items[1]).toMatchObject({ id: 'a1', pending: true });
 	});
 });
 

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -28,6 +28,12 @@ export type { ChatItem } from '$lib/types';
 
 type AssistantItem = Extract<ChatItem, { type: 'assistant' }>;
 
+export function revealRemoteUserItems(items: ChatItem[]): ChatItem[] {
+	return items.map((item) =>
+		item.type === 'user' && item.reveal === false ? { ...item, reveal: true } : item
+	);
+}
+
 function createChatStore() {
 	let sessionID = $state<string | null>(null);
 	let items = $state.raw<ChatItem[]>([]);
@@ -364,8 +370,10 @@ function createChatStore() {
 		reveal = true
 	) {
 		const next = getCachedItems(targetSessionID).slice();
-		next.push({ id: localID('user'), type: 'user', text, images, reveal });
+		const id = localID('user');
+		next.push({ id, type: 'user', text, images, reveal });
 		writeSessionItems(targetSessionID, next);
+		return id;
 	}
 
 	function stageUserForSession(
@@ -373,7 +381,7 @@ function createChatStore() {
 		text: string,
 		images?: ImageAttachment[]
 	) {
-		addUserToSession(targetSessionID, text, images, false);
+		return addUserToSession(targetSessionID, text, images, false);
 	}
 
 	function revealStagedUserForSession(targetSessionID: string) {
@@ -746,7 +754,11 @@ function createChatStore() {
 	if (browser) {
 		subscribeWindowSync((message) => {
 			if (message.type === 'chat-items') {
-				writeSessionItems(message.sessionId, message.items, { broadcast: false });
+				// Flight visibility belongs to the sending renderer. Other windows have
+				// no matching particle, so render their copy immediately.
+				writeSessionItems(message.sessionId, revealRemoteUserItems(message.items), {
+					broadcast: false
+				});
 				return;
 			}
 			if (message.type === 'chat-streaming') {


### PR DESCRIPTION
## Background

User-message flight state followed the live ChatView session and was copied to other renderer windows. Switching sessions during a flight could strand a hidden user bubble, while main and mini windows could show an empty gap.

[100c40d](https://github.com/Cometline/cometline/commit/100c40d47e8c4c0cb7721a1123882b9bc1024ca2): Capture per-turn staging callbacks and user IDs, abort stale flights on session changes, and render remote staged users without source-window visibility state.