### PR TITLE
Fix/terminal text selection

### DIFF
--- a/cometline/docs/postmortem/thread-turn-scroll-pinning.md
+++ b/cometline/docs/postmortem/thread-turn-scroll-pinning.md
@@ -7,7 +7,7 @@
 
 On follow-up turns (from the second user message onward), we wanted ChatGPT / Claude-style behavior:
 
-1. After the user sends a message, the bubble stays pinned near the **upper third** of the viewport.
+1. After the user sends a message, the bubble stays pinned near the **upper fifth** of the viewport.
 2. Enough space remains below so the start of the AI reply is visible **without scrolling down first**.
 3. **No layout shift** when streaming ends.
 4. “Jump to latest” and manual scrolling should not land in an **empty dead zone** with no content.
@@ -97,7 +97,7 @@ thread-messages
 
 ```css
 --thread-user-pin-offset-first: 24px;        /* first turn (flight-driven; pin rarely used) */
---thread-user-pin-ratio-followup: 0.28;      /* follow-up upper third */
+--thread-user-pin-ratio-followup: 0.18;      /* follow-up upper fifth */
 --thread-turn-bottom-clearance: 96px;        /* min-height = viewport - clearance */
 ```
 
@@ -174,7 +174,7 @@ Per [`FRONTEND_PATTERNS.md`](../FRONTEND_PATTERNS.md):
 
 ## Verification checklist
 
-1. **Turn 2+:** After send, user bubble near upper third; thinking / first tokens visible without scrolling down.
+1. **Turn 2+:** After send, user bubble near upper fifth; thinking / first tokens visible without scrolling down.
 2. **Stream end:** No jump; `min-height` remains until the next user message.
 3. **Jump to latest:** Shows the last AI content, not blank space.
 4. **Manual scroll:** Should not rest in a message-free dead zone (blank area is inside the turn, semantically “reply canvas”).

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -196,6 +196,15 @@
 				return;
 			}
 			if (
+				shellStore.focusedPane === 'terminal' &&
+				shellStore.terminalPanelOpen &&
+				!shellStore.settingsOpen &&
+				!inboxStore.drawerOpen
+			) {
+				// Let terminal applications own Escape and keyboard shortcuts.
+				return;
+			}
+			if (
 				shellStore.workspacePanelOpen &&
 				event.key === 'Escape' &&
 				!shellStore.settingsOpen &&

--- a/cometline/src/lib/components/TerminalInstance.svelte
+++ b/cometline/src/lib/components/TerminalInstance.svelte
@@ -98,6 +98,7 @@
 			cursorBlink: true,
 			fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
 			fontSize: 12,
+			macOptionClickForcesSelection: true,
 			scrollback: 10_000,
 			theme: {
 				background: '#171717',
@@ -132,7 +133,14 @@
 	});
 </script>
 
-<div class="terminal-instance" class:active onmouseup={onMouseUp} aria-hidden={!active}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="terminal-instance"
+	class:active
+	onfocusin={() => shellStore.setFocusedPane('terminal')}
+	onmouseup={onMouseUp}
+	aria-hidden={!active}
+>
 	<div class="terminal-host" bind:this={host}></div>
 	{#if selection}
 		<button

--- a/cometline/src/lib/components/TerminalInstance.svelte.test.ts
+++ b/cometline/src/lib/components/TerminalInstance.svelte.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+const { fitAddonConstructor, terminalConstructor, shellStore, terminalStore } = vi.hoisted(() => ({
+	fitAddonConstructor: vi.fn(),
+	terminalConstructor: vi.fn(),
+	shellStore: {
+		setFocusedPane: vi.fn(),
+		addWebContextForActive: vi.fn(),
+		requestComposerFocus: vi.fn()
+	},
+	terminalStore: {
+		getSnapshot: vi.fn(() => null),
+		subscribe: vi.fn(() => () => {}),
+		resize: vi.fn(),
+		write: vi.fn()
+	}
+}));
+
+vi.mock('@xterm/xterm', () => ({
+	Terminal: class {
+		constructor(options: unknown) {
+			return terminalConstructor(options);
+		}
+	}
+}));
+vi.mock('@xterm/addon-fit', () => ({
+	FitAddon: class {
+		constructor() {
+			return fitAddonConstructor();
+		}
+	}
+}));
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+vi.mock('$lib/stores/shell.svelte', () => ({ shellStore }));
+vi.mock('$lib/stores/terminal.svelte', () => ({ terminalStore }));
+
+import TerminalInstance from './TerminalInstance.svelte';
+
+describe('TerminalInstance', () => {
+	beforeEach(() => {
+		fitAddonConstructor.mockReset();
+		fitAddonConstructor.mockReturnValue({ fit: vi.fn() });
+		terminalConstructor.mockReset();
+		terminalConstructor.mockImplementation(() => ({
+			cols: 80,
+			rows: 24,
+			loadAddon: vi.fn(),
+			open: vi.fn(),
+			write: vi.fn(),
+			onData: vi.fn(() => ({ dispose: vi.fn() })),
+			focus: vi.fn(),
+			getSelection: vi.fn(() => ''),
+			clearSelection: vi.fn(),
+			dispose: vi.fn()
+		}));
+		shellStore.setFocusedPane.mockReset();
+		terminalStore.getSnapshot.mockReset();
+		terminalStore.getSnapshot.mockReturnValue(null);
+		terminalStore.subscribe.mockReset();
+		terminalStore.subscribe.mockReturnValue(() => {});
+		terminalStore.resize.mockReset();
+		terminalStore.write.mockReset();
+		vi.stubGlobal(
+			'ResizeObserver',
+			class {
+				observe() {}
+				disconnect() {}
+			}
+		);
+		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+			callback(0);
+			return 1;
+		});
+		vi.stubGlobal('cancelAnimationFrame', () => {});
+	});
+
+	it('enables Option-drag selection for mouse-reporting TUIs', async () => {
+		render(TerminalInstance, { props: { sessionId: 'session-1', active: true } });
+		await tick();
+
+		expect(terminalConstructor).toHaveBeenCalledWith(
+			expect.objectContaining({ macOptionClickForcesSelection: true })
+		);
+	});
+
+	it('tracks native terminal focus without issuing a resize request', async () => {
+		const { container } = render(TerminalInstance, {
+			props: { sessionId: 'session-1', active: true }
+		});
+		await tick();
+		terminalStore.resize.mockClear();
+
+		await fireEvent.focusIn(container.querySelector('.terminal-instance')!);
+
+		expect(shellStore.setFocusedPane).toHaveBeenCalledWith('terminal');
+		expect(terminalStore.resize).not.toHaveBeenCalled();
+	});
+});

--- a/cometline/src/lib/components/TerminalPanel.svelte
+++ b/cometline/src/lib/components/TerminalPanel.svelte
@@ -111,11 +111,7 @@
 				</button>
 			</div>
 		</header>
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			class="terminal-panel-content"
-			onmousedown={() => shellStore.requestTerminalFocus()}
-		>
+		<div class="terminal-panel-content">
 			{#if !activeSession}
 				<div class="terminal-empty">Open a chat to start a terminal.</div>
 			{:else if !activeTerminal}

--- a/cometline/src/lib/conversation/thread-scroll.svelte.test.ts
+++ b/cometline/src/lib/conversation/thread-scroll.svelte.test.ts
@@ -50,7 +50,7 @@ describe('createThreadScroll', () => {
 		Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
 	});
 
-	it('releases follow-up pinning when the response stops streaming', async () => {
+	it('keeps follow-up pinning after the response stops streaming', async () => {
 		const view = render(ThreadScrollHarness, {
 			props: {
 				items: initialItems,
@@ -69,14 +69,14 @@ describe('createThreadScroll', () => {
 		await view.rerender({ items: followUpItems, streaming: false, cached: true });
 		await settleEffects();
 		await waitFor(() =>
-			expect(screen.getByTestId('thread-scroll').dataset.activeMinHeight).toBe('0')
+			expect(screen.getByTestId('thread-scroll').dataset.activeMinHeight).toBe('504')
 		);
 
 		scrollIntoView.mockClear();
 		await view.rerender({ items: refreshedFollowUpItems, streaming: false, cached: true });
 		await settleEffects();
 		await waitFor(() =>
-			expect(screen.getByTestId('thread-scroll').dataset.activeMinHeight).toBe('0')
+			expect(screen.getByTestId('thread-scroll').dataset.activeMinHeight).toBe('504')
 		);
 		expect(scrollIntoView).not.toHaveBeenCalled();
 	});

--- a/cometline/src/lib/conversation/thread-scroll.svelte.ts
+++ b/cometline/src/lib/conversation/thread-scroll.svelte.ts
@@ -117,14 +117,6 @@ export function createThreadScroll(deps: ThreadScrollDeps) {
 		});
 	});
 
-	$effect.pre(() => {
-		const streaming = deps.getSessionStreaming();
-		if (streaming) return;
-		untrack(() => {
-			activePinnedUserId = null;
-		});
-	});
-
 	$effect(() => {
 		const isSessionSynced = deps.getIsSessionSynced();
 		const threadItems = deps.getThreadItems();

--- a/cometline/src/lib/conversation/thread-scroll.test.ts
+++ b/cometline/src/lib/conversation/thread-scroll.test.ts
@@ -74,8 +74,8 @@ describe('shouldShowJumpToBottom', () => {
 });
 
 describe('followUpPinScrollMargin', () => {
-	it('uses the upper-third ratio when viewport height is known', () => {
-		expect(followUpPinScrollMargin(800)).toBe(224);
+	it('uses the upper-fifth ratio when viewport height is known', () => {
+		expect(followUpPinScrollMargin(800)).toBe(144);
 	});
 
 	it('falls back when viewport height is zero', () => {

--- a/cometline/src/lib/conversation/thread-scroll.ts
+++ b/cometline/src/lib/conversation/thread-scroll.ts
@@ -3,8 +3,8 @@ import { anyReasoningPending, reasoningTextLength } from './reasoning';
 
 export const SCROLL_PIN_THRESHOLD = 96;
 export const USER_SEND_TOP_OFFSET = 24;
-/** Upper-third pin for follow-up turns (turn 2+), applied via scroll-margin-top. */
-export const USER_PIN_RATIO_FOLLOWUP = 0.28;
+/** Upper-fifth pin for follow-up turns (turn 2+), applied via scroll-margin-top. */
+export const USER_PIN_RATIO_FOLLOWUP = 0.18;
 export const USER_PIN_OFFSET_FALLBACK = 100;
 export const TURN_BOTTOM_CLEARANCE = 96;
 


### PR DESCRIPTION
## Background

Interactive terminal applications claim mouse input, while the terminal panel also resized the PTY on every mouse-down. That made text selection unreliable and prevented terminal applications from receiving Escape. Follow-up reply canvases were also removed as soon as streaming stopped, causing the conversation layout to shift after a response completed.

[fb0dfed](https://github.com/Cometline/cometline/commit/fb0dfedc8ba80b6f7cdeb42deb33ee5b448a0752): Preserve xterm selection by using Option-drag for mouse-reporting TUIs, removing mouse-down resize requests, and passing terminal keyboard input through to the active TUI.

[3f491fd](https://github.com/Cometline/cometline/commit/3f491fd04fa01228b92eebee24d8f698c2aeb426): Keep the active follow-up turn canvas after streaming completes so reply completion does not collapse the layout or move the conversation.