### PR TITLE
[main] feat: default model roles and shortcut tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ Cometline and CometMind share settings in `~/.cometmind/cometline-settings.json`
       "enabledModels": ["gpt-4o"]
     }
   ],
-  "activeProviderId": "openai",
+  "defaultProviderId": "openai",
+  "defaultModelId": "gpt-4o",
   "cometmind": {
     "maxTokens": 2048,
     "acp": { "command": "opencode", "args": ["acp"], "timeout": "30m" }

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -1746,13 +1746,27 @@ function writeProviderSettings(settings) {
 	const nextProviders = Array.isArray(settings.providers)
 		? normalizeProviders(settings.providers)
 		: current.providers;
-	const requestedActive = nextProviders.find((p) => p.id === settings.activeProviderId);
-	const nextActive =
-		requestedActive?.enabled && requestedActive.enabledModels.length > 0
-			? requestedActive.id
-			: (nextProviders.find((p) => p.enabled && p.enabledModels.length > 0)?.id ??
-				nextProviders[0]?.id ??
-				'');
+	const preferredDefaultProvider =
+		String(settings.defaultProviderId ?? current.defaultProviderId ?? '').trim();
+	const preferredDefaultModel = String(
+		settings.defaultModelId ?? current.defaultModelId ?? ''
+	).trim();
+	const runtimeProviders = nextProviders.filter((p) => p.enabled && p.enabledModels.length > 0);
+	let nextDefaultProvider =
+		runtimeProviders.find((p) => p.id === preferredDefaultProvider) ??
+		runtimeProviders.find((p) => p.id === settings.activeProviderId) ??
+		runtimeProviders.find((p) => p.id === current.activeProviderId) ??
+		runtimeProviders[0] ??
+		nextProviders[0];
+	const nextDefaultProviderId = nextDefaultProvider?.id ?? '';
+	const nextDefaultModelId =
+		nextDefaultProvider &&
+		preferredDefaultModel &&
+		nextDefaultProvider.enabledModels.includes(preferredDefaultModel)
+			? preferredDefaultModel
+			: nextDefaultProvider?.enabledModels?.[0] ||
+				nextDefaultProvider?.selectedModel ||
+				'';
 	const appSettings = { ...(current.app ?? {}), ...(settings.app ?? {}) };
 	const personaId = resolveNextPersonaId(settings, current);
 	appSettings.personaId = personaId;
@@ -1764,9 +1778,10 @@ function writeProviderSettings(settings) {
 		normalizeSettings(
 			{
 				providers: nextProviders,
-				activeProviderId: nextActive,
-				defaultModelId: settings.defaultModelId ?? current.defaultModelId ?? '',
-				defaultProviderId: settings.defaultProviderId ?? current.defaultProviderId ?? '',
+				// Mirror Default into active for legacy readers.
+				activeProviderId: nextDefaultProviderId,
+				defaultModelId: nextDefaultModelId,
+				defaultProviderId: nextDefaultProviderId,
 				appearance: settings.appearance ?? current.appearance,
 				shortcuts: settings.shortcuts ?? current.shortcuts,
 				cometmind: nextCometMind,
@@ -1851,15 +1866,26 @@ function providerEnv() {
 	const runtimeProviders = settings.providers.filter(
 		(p) => p.enabled && p.enabledModels.length > 0
 	);
+	const defaultId = String(settings.defaultProviderId || '').trim();
 	const active =
+		runtimeProviders.find((p) => p.id === defaultId) ??
 		runtimeProviders.find((p) => p.id === settings.activeProviderId) ??
 		runtimeProviders[0] ??
 		settings.providers[0];
+	const model =
+		(settings.defaultModelId &&
+		active.enabledModels?.includes(settings.defaultModelId)
+			? settings.defaultModelId
+			: null) ||
+		active.enabledModels[0] ||
+		active.selectedModel ||
+		active.models[0] ||
+		'';
 	const env = {
 		...process.env,
 		PATH: pathWithCometMindCliBins(process.env.PATH),
 		COMETMIND_PROVIDER: active.id,
-		COMETMIND_MODEL: active.enabledModels[0] || active.selectedModel || active.models[0] || '',
+		COMETMIND_MODEL: model,
 		COMETMIND_MAX_TOKENS: String(settings.cometmind?.maxTokens ?? 2048),
 		COMETMIND_LOG_LEVEL: settings.cometmind?.logLevel ?? 'error'
 		// Persona SOUL path lives in cometline-settings.json (cometmind.systemPromptPath).

--- a/cometline/electron/main.cjs
+++ b/cometline/electron/main.cjs
@@ -1700,7 +1700,7 @@ function attachWebviewPanelShortcuts(webContents) {
 
 function readProviderSettings() {
 	const fromEnv = {
-		activeProviderId: process.env.COMETMIND_PROVIDER,
+		providerId: process.env.COMETMIND_PROVIDER,
 		baseURL: process.env.COMETMIND_BASE_URL,
 		apiKey:
 			process.env.COMETMIND_API_KEY ||
@@ -1711,13 +1711,20 @@ function readProviderSettings() {
 
 	const base = readSavedProviderSettings();
 
-	// Allow env overrides for the active provider only. Apply provider first so
+	// Allow env overrides for the default provider. Apply provider first so
 	// key/baseURL/model attach to the provider selected by COMETMIND_PROVIDER.
-	if (fromEnv.activeProviderId) {
-		const matched = base.providers.find((p) => p.id === fromEnv.activeProviderId.trim());
-		if (matched) base.activeProviderId = matched.id;
+	if (fromEnv.providerId) {
+		const matched = base.providers.find((p) => p.id === fromEnv.providerId.trim());
+		if (matched) {
+			base.defaultProviderId = matched.id;
+			if (!base.defaultModelId || !matched.enabledModels.includes(base.defaultModelId)) {
+				base.defaultModelId =
+					matched.enabledModels[0] || matched.selectedModel || matched.models[0] || '';
+			}
+		}
 	}
-	const active = base.providers.find((p) => p.id === base.activeProviderId) ?? base.providers[0];
+	const active =
+		base.providers.find((p) => p.id === base.defaultProviderId) ?? base.providers[0];
 	if (fromEnv.baseURL) active.baseURL = fromEnv.baseURL.trim();
 	if (fromEnv.apiKey) active.apiKey = fromEnv.apiKey.trim();
 	if (fromEnv.selectedModel) {
@@ -1726,6 +1733,7 @@ function readProviderSettings() {
 		active.enabled = true;
 		if (model && !active.models.includes(model)) active.models = [...active.models, model];
 		if (model && !active.enabledModels.includes(model)) active.enabledModels = [model];
+		base.defaultModelId = model;
 	}
 
 	return base;
@@ -1754,8 +1762,7 @@ function writeProviderSettings(settings) {
 	const runtimeProviders = nextProviders.filter((p) => p.enabled && p.enabledModels.length > 0);
 	let nextDefaultProvider =
 		runtimeProviders.find((p) => p.id === preferredDefaultProvider) ??
-		runtimeProviders.find((p) => p.id === settings.activeProviderId) ??
-		runtimeProviders.find((p) => p.id === current.activeProviderId) ??
+		runtimeProviders.find((p) => p.id === current.defaultProviderId) ??
 		runtimeProviders[0] ??
 		nextProviders[0];
 	const nextDefaultProviderId = nextDefaultProvider?.id ?? '';
@@ -1778,8 +1785,6 @@ function writeProviderSettings(settings) {
 		normalizeSettings(
 			{
 				providers: nextProviders,
-				// Mirror Default into active for legacy readers.
-				activeProviderId: nextDefaultProviderId,
 				defaultModelId: nextDefaultModelId,
 				defaultProviderId: nextDefaultProviderId,
 				appearance: settings.appearance ?? current.appearance,
@@ -1869,7 +1874,6 @@ function providerEnv() {
 	const defaultId = String(settings.defaultProviderId || '').trim();
 	const active =
 		runtimeProviders.find((p) => p.id === defaultId) ??
-		runtimeProviders.find((p) => p.id === settings.activeProviderId) ??
 		runtimeProviders[0] ??
 		settings.providers[0];
 	const model =

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -41,6 +41,7 @@ __export(schema_exports, {
   normalizeSettings: () => normalizeSettings,
   parseAndNormalizeSettings: () => parseAndNormalizeSettings,
   resolveActiveProviderId: () => resolveActiveProviderId,
+  resolveDefaultModelPair: () => resolveDefaultModelPair,
   runtimeProviders: () => runtimeProviders,
   runtimeSlice: () => runtimeSlice,
   validateSettings: () => validateSettings
@@ -5304,7 +5305,12 @@ function defaultSettings() {
 }
 function normalizeSettings(next, options = {}) {
   const providers = normalizeProviders(next.providers);
-  const activeProviderId = resolveActiveProviderId(providers, next.activeProviderId);
+  const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+    providers,
+    next.defaultProviderId,
+    next.defaultModelId,
+    next.activeProviderId
+  );
   const cometmind = normalizeCometMindSettings(
     next.cometmind,
     options.fallbackWorkspacePath ?? ""
@@ -5315,9 +5321,10 @@ function normalizeSettings(next, options = {}) {
   const customPersonas = normalizeCustomPersonas(next.app?.personas?.custom);
   return {
     providers,
+    // Mirror Default into activeProviderId for legacy Electron/env readers.
     activeProviderId,
-    defaultModelId: String(next.defaultModelId ?? "").trim(),
-    defaultProviderId: String(next.defaultProviderId ?? "").trim(),
+    defaultModelId,
+    defaultProviderId,
     appearance: {
       heroComposer: normalizeHeroComposerAppearance(next.appearance?.heroComposer),
       caretTrail: normalizeCaretTrailSettings(next.appearance?.caretTrail)
@@ -5344,6 +5351,29 @@ function normalizeSettings(next, options = {}) {
     cometmind
   };
 }
+function resolveDefaultModelPair(providers, preferredDefaultProviderId, preferredDefaultModelId, legacyActiveProviderId) {
+  const runtime = providers.filter((p) => p.enabled && p.enabledModels.length > 0);
+  const byId = new Map(runtime.map((p) => [p.id, p]));
+  let defaultProviderId = String(preferredDefaultProviderId ?? "").trim();
+  let defaultModelId = String(preferredDefaultModelId ?? "").trim();
+  if (defaultProviderId && byId.has(defaultProviderId)) {
+    const provider = byId.get(defaultProviderId);
+    if (!defaultModelId || !provider.enabledModels.includes(defaultModelId)) {
+      defaultModelId = primaryModel(provider);
+    }
+  } else {
+    const legacyActive = String(legacyActiveProviderId ?? "").trim();
+    const migrated = legacyActive && byId.get(legacyActive) || runtime[0] || providers[0] || null;
+    defaultProviderId = migrated?.id ?? "";
+    defaultModelId = migrated ? primaryModel(migrated) : "";
+  }
+  return {
+    defaultProviderId,
+    defaultModelId,
+    // Keep active mirrored to Default so legacy env/readers stay consistent.
+    activeProviderId: defaultProviderId
+  };
+}
 function primaryModel(provider) {
   return provider.enabledModels[0] || provider.selectedModel || provider.models[0] || "";
 }
@@ -5352,11 +5382,12 @@ function runtimeProviders(settings) {
 }
 function runtimeSlice(settings) {
   const providers = runtimeProviders(settings);
-  const active = providers.find((p) => p.id === settings.activeProviderId) ?? providers[0] ?? null;
+  const active = providers.find((p) => p.id === settings.defaultProviderId) ?? providers.find((p) => p.id === settings.activeProviderId) ?? providers[0] ?? null;
   if (!active) return null;
+  const model = settings.defaultModelId && active.enabledModels.includes(settings.defaultModelId) ? settings.defaultModelId : primaryModel(active);
   return {
     provider: active.id,
-    model: primaryModel(active),
+    model,
     baseURL: active.baseURL,
     maxTokens: settings.cometmind.maxTokens,
     maxSteps: 50,
@@ -5630,6 +5661,7 @@ function parseAndNormalizeSettings(raw, options = {}) {
   normalizeSettings,
   parseAndNormalizeSettings,
   resolveActiveProviderId,
+  resolveDefaultModelPair,
   runtimeProviders,
   runtimeSlice,
   validateSettings

--- a/cometline/electron/settings-schema.cjs
+++ b/cometline/electron/settings-schema.cjs
@@ -40,7 +40,6 @@ __export(schema_exports, {
   normalizeProviders: () => normalizeProviders,
   normalizeSettings: () => normalizeSettings,
   parseAndNormalizeSettings: () => parseAndNormalizeSettings,
-  resolveActiveProviderId: () => resolveActiveProviderId,
   resolveDefaultModelPair: () => resolveDefaultModelPair,
   runtimeProviders: () => runtimeProviders,
   runtimeSlice: () => runtimeSlice,
@@ -5237,17 +5236,6 @@ function normalizeProvider(provider, fallback) {
     enabledModels
   };
 }
-function resolveActiveProviderId(providers, preferredId) {
-  const preferred = preferredId ? providers.find((provider) => provider.id === preferredId) : void 0;
-  if (preferred?.enabled && preferred.enabledModels.length > 0) {
-    return preferred.id;
-  }
-  const enabledWithModels = providers.find(
-    (provider) => provider.enabled && provider.enabledModels.length > 0
-  );
-  if (enabledWithModels) return enabledWithModels.id;
-  return providers[0]?.id ?? "";
-}
 function normalizeProviders(providers) {
   const saved = Array.isArray(providers) ? providers : [];
   const normalizedDefaults = DEFAULT_PROVIDERS.map((provider) => {
@@ -5287,16 +5275,17 @@ function migrateSingleProvider(saved) {
         enabledModels: saved.selectedModel ? [String(saved.selectedModel).trim()] : []
       }
     ],
-    activeProviderId: id
+    defaultProviderId: id,
+    defaultModelId: String(saved.selectedModel || "").trim()
   };
 }
 function defaultSettings() {
   const providers = DEFAULT_PROVIDERS.map(cloneProvider);
+  const { defaultProviderId, defaultModelId } = resolveDefaultModelPair(providers);
   return {
     providers,
-    activeProviderId: resolveActiveProviderId(providers),
-    defaultModelId: "",
-    defaultProviderId: "",
+    defaultModelId,
+    defaultProviderId,
     appearance: defaultAppearance(),
     shortcuts: defaultKeyboardShortcuts(),
     app: defaultAppSettings(),
@@ -5305,7 +5294,7 @@ function defaultSettings() {
 }
 function normalizeSettings(next, options = {}) {
   const providers = normalizeProviders(next.providers);
-  const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+  const { defaultProviderId, defaultModelId } = resolveDefaultModelPair(
     providers,
     next.defaultProviderId,
     next.defaultModelId,
@@ -5321,8 +5310,6 @@ function normalizeSettings(next, options = {}) {
   const customPersonas = normalizeCustomPersonas(next.app?.personas?.custom);
   return {
     providers,
-    // Mirror Default into activeProviderId for legacy Electron/env readers.
-    activeProviderId,
     defaultModelId,
     defaultProviderId,
     appearance: {
@@ -5369,9 +5356,7 @@ function resolveDefaultModelPair(providers, preferredDefaultProviderId, preferre
   }
   return {
     defaultProviderId,
-    defaultModelId,
-    // Keep active mirrored to Default so legacy env/readers stay consistent.
-    activeProviderId: defaultProviderId
+    defaultModelId
   };
 }
 function primaryModel(provider) {
@@ -5382,7 +5367,7 @@ function runtimeProviders(settings) {
 }
 function runtimeSlice(settings) {
   const providers = runtimeProviders(settings);
-  const active = providers.find((p) => p.id === settings.defaultProviderId) ?? providers.find((p) => p.id === settings.activeProviderId) ?? providers[0] ?? null;
+  const active = providers.find((p) => p.id === settings.defaultProviderId) ?? providers[0] ?? null;
   if (!active) return null;
   const model = settings.defaultModelId && active.enabledModels.includes(settings.defaultModelId) ? settings.defaultModelId : primaryModel(active);
   return {
@@ -5439,7 +5424,6 @@ var providerConfigSchema = external_exports.object({
 });
 var providerSettingsSchema = external_exports.object({
   providers: external_exports.array(providerConfigSchema).min(1),
-  activeProviderId: external_exports.string(),
   defaultModelId: external_exports.string(),
   defaultProviderId: external_exports.string(),
   appearance: external_exports.object({
@@ -5660,7 +5644,6 @@ function parseAndNormalizeSettings(raw, options = {}) {
   normalizeProviders,
   normalizeSettings,
   parseAndNormalizeSettings,
-  resolveActiveProviderId,
   resolveDefaultModelPair,
   runtimeProviders,
   runtimeSlice,

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -119,7 +119,6 @@ declare global {
 
 	interface ProviderSettings {
 		providers: ProviderConfig[];
-		activeProviderId: string;
 		defaultModelId: string;
 		defaultProviderId: string;
 		appearance: AppearanceSettings;

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -15,6 +15,7 @@
 	import CloseConfirmModal from './CloseConfirmModal.svelte';
 	import WebPanel from './WebPanel.svelte';
 	import TerminalPanel from './TerminalPanel.svelte';
+	import Tooltip from './Tooltip.svelte';
 	import { getSession } from '$lib/client/cometmind';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import { sessionStore } from '$lib/stores/session.svelte';
@@ -551,15 +552,16 @@
 					aria-label="Window title bar"
 					transition:slide={titlebarSlideParams()}
 				>
-					<button
-						type="button"
-						class="shell-titlebar-btn"
-						aria-label="Show sidebar"
-						title="Show sidebar"
-						onclick={() => shellStore.openSidebar()}
-					>
-						<PanelLeft size={16} stroke-width={1.8} />
-					</button>
+					<Tooltip label="Show sidebar" action="toggleSidebar">
+						<button
+							type="button"
+							class="shell-titlebar-btn"
+							aria-label="Show sidebar"
+							onclick={() => shellStore.openSidebar()}
+						>
+							<PanelLeft size={16} stroke-width={1.8} />
+						</button>
+					</Tooltip>
 					{#if titlebarSessionTitle}
 						<span class="shell-titlebar-title" title={titlebarSessionTitle}>
 							{titlebarSessionTitle}

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -27,6 +27,7 @@
 	import { createChatViewController } from '$lib/conversation/chat-view-controller.svelte';
 	import { PanelLeft } from '@lucide/svelte';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 
 	const THREAD_IN = { duration: 140 };
 
@@ -347,15 +348,16 @@
 	{#if compact}
 		<div class="mini-titlebar" aria-label="Mini window drag area">
 			<span>Mini Chat</span>
-			<button
-				class="mini-sidebar-toggle"
-				type="button"
-				aria-label="Show chats"
-				title="Show chats"
-				onclick={() => miniShellStore.toggleSidebar()}
-			>
-				<PanelLeft size={15} stroke-width={1.8} />
-			</button>
+			<Tooltip label="Show chats" action="toggleSidebar">
+				<button
+					class="mini-sidebar-toggle"
+					type="button"
+					aria-label="Show chats"
+					onclick={() => miniShellStore.toggleSidebar()}
+				>
+					<PanelLeft size={15} stroke-width={1.8} />
+				</button>
+			</Tooltip>
 			<button
 				class="mini-open-main"
 				type="button"
@@ -517,11 +519,15 @@
 		-webkit-app-region: no-drag;
 	}
 
-	.mini-sidebar-toggle {
+	.mini-titlebar :global(.tooltip-wrap) {
 		position: absolute;
 		left: 12px;
 		top: 50%;
 		transform: translateY(-50%);
+		-webkit-app-region: no-drag;
+	}
+
+	.mini-sidebar-toggle {
 		width: 28px;
 		height: 28px;
 		display: grid;
@@ -532,7 +538,6 @@
 		background: color-mix(in srgb, var(--panel-bg) 88%, var(--text-main) 6%);
 		color: var(--text-main);
 		cursor: pointer;
-		-webkit-app-region: no-drag;
 	}
 
 	.mini-open-main svg {

--- a/cometline/src/lib/components/MiniSessionSidebar.svelte
+++ b/cometline/src/lib/components/MiniSessionSidebar.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/sessions/group-by-workspace';
 	import SidebarSearch from '$lib/components/sidebar/SidebarSearch.svelte';
 	import SessionRow from '$lib/components/sidebar/SessionRow.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 
 	const WORKSPACE_GROUP_FLIP = { duration: 240 };
 
@@ -99,9 +100,11 @@
 <aside class="mini-sidebar" aria-label="Chats">
 	<header class="mini-sidebar-header">
 		<SidebarSearch bind:searchQuery bind:searchInput onNewChat={onNewChat} />
-		<button type="button" class="close-sidebar" onclick={onClose} aria-label="Close chats" title="Close chats">
-			<X size={16} stroke-width={2} />
-		</button>
+		<Tooltip label="Close chats">
+			<button type="button" class="close-sidebar" onclick={onClose} aria-label="Close chats">
+				<X size={16} stroke-width={2} />
+			</button>
+		</Tooltip>
 	</header>
 
 	<div class="session-list scrollbar-none">

--- a/cometline/src/lib/components/Sidebar.svelte
+++ b/cometline/src/lib/components/Sidebar.svelte
@@ -28,6 +28,7 @@
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import RenameSessionDialog from '$lib/components/sidebar/RenameSessionDialog.svelte';
 	import SessionContextMenu from '$lib/components/sidebar/SessionContextMenu.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { terminalStore } from '$lib/stores/terminal.svelte';
 	import { settingsStore } from '$lib/stores/settings.svelte';
 
@@ -296,43 +297,46 @@
 		</div>
 
 		<div class="sidebar-footer p-2">
-			<button aria-label="Settings" title="Settings" onclick={openSettings}>
-				<Settings size={16} stroke-width={1.8} />
-			</button>
-			<button
-				aria-label={jobsIndicatorStore.hasOngoing
-					? `Jobs (${jobsIndicatorStore.ongoingCount} ongoing)`
-					: 'Jobs'}
-				title={jobsIndicatorStore.hasOngoing
-					? `Jobs (${jobsIndicatorStore.ongoingCount} ongoing)`
-					: 'Jobs'}
-				class="nav-badge"
-				class:has-badge={jobsIndicatorStore.hasOngoing}
-				class:active={page.url.pathname === '/jobs'}
-				onclick={() => goto('/jobs')}
-			>
-				<Briefcase size={16} stroke-width={1.8} />
-			</button>
-			<button
-				aria-label="Skill Drafts"
-				title="Skill Drafts"
-				class="nav-badge"
-				class:has-badge={skillDraftsStore.hasDrafts}
-				class:active={page.url.pathname === '/skill-drafts'}
-				onclick={() => goto('/skill-drafts')}
-			>
-				<Sparkles size={16} stroke-width={1.8} />
-			</button>
-			<button
-				aria-label="Inbox"
-				title="Inbox"
-				class="nav-badge"
-				class:has-badge={inboxStore.openCount > 0}
-				class:active={inboxStore.drawerOpen}
-				onclick={() => inboxStore.toggleDrawer()}
-			>
-				<Bell size={16} stroke-width={1.8} />
-			</button>
+			<Tooltip label="Settings" action="openSettings">
+				<button aria-label="Settings" onclick={openSettings}>
+					<Settings size={16} stroke-width={1.8} />
+				</button>
+			</Tooltip>
+			<Tooltip label="Jobs" action="openJobs">
+				<button
+					aria-label={jobsIndicatorStore.hasOngoing
+						? `Jobs (${jobsIndicatorStore.ongoingCount} ongoing)`
+						: 'Jobs'}
+					class="nav-badge"
+					class:has-badge={jobsIndicatorStore.hasOngoing}
+					class:active={page.url.pathname === '/jobs'}
+					onclick={() => goto('/jobs')}
+				>
+					<Briefcase size={16} stroke-width={1.8} />
+				</button>
+			</Tooltip>
+			<Tooltip label="Skill Drafts" action="openSkillDrafts">
+				<button
+					aria-label="Skill Drafts"
+					class="nav-badge"
+					class:has-badge={skillDraftsStore.hasDrafts}
+					class:active={page.url.pathname === '/skill-drafts'}
+					onclick={() => goto('/skill-drafts')}
+				>
+					<Sparkles size={16} stroke-width={1.8} />
+				</button>
+			</Tooltip>
+			<Tooltip label="Inbox" action="openInbox">
+				<button
+					aria-label="Inbox"
+					class="nav-badge"
+					class:has-badge={inboxStore.openCount > 0}
+					class:active={inboxStore.drawerOpen}
+					onclick={() => inboxStore.toggleDrawer()}
+				>
+					<Bell size={16} stroke-width={1.8} />
+				</button>
+			</Tooltip>
 		</div>
 	</div>
 

--- a/cometline/src/lib/components/TerminalPanel.svelte
+++ b/cometline/src/lib/components/TerminalPanel.svelte
@@ -2,6 +2,7 @@
 	import { Globe, Play, Power, SquareTerminal, X } from '@lucide/svelte';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import TerminalInstance from '$lib/components/TerminalInstance.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { sessionStore } from '$lib/stores/session.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import { terminalStore } from '$lib/stores/terminal.svelte';
@@ -49,24 +50,26 @@
 	>
 		<header class="terminal-panel-toolbar">
 			<div class="surface-switcher" role="group" aria-label="Workspace panel surface">
-				<button
-					type="button"
-					class="icon-button"
-					onclick={() => shellStore.openWebPanelFromShortcut()}
-					aria-label="Open web panel"
-					title="Web (Cmd+O)"
-				>
-					<Globe size={16} />
-				</button>
-				<button
-					type="button"
-					class="icon-button active"
-					onclick={() => shellStore.requestTerminalFocus()}
-					aria-label="Focus terminal"
-					title="Terminal (Cmd+J)"
-				>
-					<SquareTerminal size={16} />
-				</button>
+				<Tooltip label="Web" action="openWebPanel">
+					<button
+						type="button"
+						class="icon-button"
+						onclick={() => shellStore.openWebPanelFromShortcut()}
+						aria-label="Open web panel"
+					>
+						<Globe size={16} />
+					</button>
+				</Tooltip>
+				<Tooltip label="Terminal" action="openTerminal">
+					<button
+						type="button"
+						class="icon-button active"
+						onclick={() => shellStore.requestTerminalFocus()}
+						aria-label="Focus terminal"
+					>
+						<SquareTerminal size={16} />
+					</button>
+				</Tooltip>
 			</div>
 			<div class="terminal-title">
 				{#if activeTerminal?.status === 'running'}

--- a/cometline/src/lib/components/Tooltip.svelte
+++ b/cometline/src/lib/components/Tooltip.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
+	import { settingsStore } from '$lib/stores/settings.svelte';
+	import type { ShortcutAction } from '$lib/keyboard-shortcuts';
+	import { shortcutTooltipKbd } from './shortcut-tooltip';
+	import { clampTooltipPosition } from './tooltip-position';
+	import { portal } from './portal';
+
+	let {
+		label,
+		action,
+		disabled = false,
+		delay = 350,
+		children
+	}: {
+		label: string;
+		action?: ShortcutAction;
+		disabled?: boolean;
+		delay?: number;
+		children: Snippet;
+	} = $props();
+
+	const tipId = `tooltip-${Math.random().toString(36).slice(2, 10)}`;
+	let wrapEl = $state<HTMLElement | null>(null);
+	let bubbleEl = $state<HTMLElement | null>(null);
+	let open = $state(false);
+	let placed = $state(false);
+	let tipTop = $state(0);
+	let tipLeft = $state(0);
+	let showTimer: ReturnType<typeof setTimeout> | null = null;
+	let describedEl: HTMLElement | null = null;
+
+	const kbd = $derived(shortcutTooltipKbd(action, settingsStore.settings.shortcuts));
+
+	function clearTimer() {
+		if (showTimer) {
+			clearTimeout(showTimer);
+			showTimer = null;
+		}
+	}
+
+	function findTarget(): HTMLElement | null {
+		if (!wrapEl) return null;
+		return (
+			wrapEl.querySelector<HTMLElement>('button, a, [role="button"], input, select, textarea') ??
+			(wrapEl.firstElementChild as HTMLElement | null)
+		);
+	}
+
+	function setDescribedBy(on: boolean) {
+		const target = findTarget();
+		if (describedEl && describedEl !== target) {
+			describedEl.removeAttribute('aria-describedby');
+			describedEl = null;
+		}
+		if (!target) return;
+		if (on) {
+			target.setAttribute('aria-describedby', tipId);
+			describedEl = target;
+		} else {
+			target.removeAttribute('aria-describedby');
+			describedEl = null;
+		}
+	}
+
+	function effectiveDelay() {
+		if (
+			typeof window !== 'undefined' &&
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+		) {
+			return 0;
+		}
+		return delay;
+	}
+
+	function reposition() {
+		if (!wrapEl || !bubbleEl) return;
+		const anchor = wrapEl.getBoundingClientRect();
+		const tip = bubbleEl.getBoundingClientRect();
+		const pos = clampTooltipPosition({
+			anchor,
+			tip: { width: tip.width, height: tip.height },
+			viewport: { width: window.innerWidth, height: window.innerHeight }
+		});
+		tipTop = pos.top;
+		tipLeft = pos.left;
+	}
+
+	async function show() {
+		if (disabled) return;
+		clearTimer();
+		showTimer = setTimeout(async () => {
+			open = true;
+			placed = false;
+			setDescribedBy(true);
+			await tick();
+			reposition();
+			placed = true;
+		}, effectiveDelay());
+	}
+
+	function hide() {
+		clearTimer();
+		open = false;
+		placed = false;
+		setDescribedBy(false);
+	}
+
+	function onKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && open) {
+			hide();
+		}
+	}
+
+	function onViewportChange() {
+		if (open) reposition();
+	}
+
+	onDestroy(() => {
+		clearTimer();
+		setDescribedBy(false);
+	});
+</script>
+
+<svelte:window onresize={onViewportChange} onscroll={onViewportChange} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<span
+	class="tooltip-wrap"
+	bind:this={wrapEl}
+	onmouseenter={show}
+	onmouseleave={hide}
+	onfocusin={show}
+	onfocusout={hide}
+	onkeydown={onKeydown}
+>
+	{@render children()}
+	{#if open}
+		<span
+			class="tooltip-bubble"
+			class:placed
+			id={tipId}
+			role="tooltip"
+			use:portal
+			bind:this={bubbleEl}
+			style:top="{tipTop}px"
+			style:left="{tipLeft}px"
+		>
+			<span class="tooltip-label">{label}</span>
+			{#if kbd}
+				<kbd>{kbd}</kbd>
+			{/if}
+		</span>
+	{/if}
+</span>
+
+<style>
+	.tooltip-wrap {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		vertical-align: middle;
+		max-width: 100%;
+	}
+
+	.tooltip-bubble {
+		position: fixed;
+		z-index: 10000;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 8px;
+		border-radius: 8px;
+		border: 1px solid var(--border-soft);
+		background: var(--panel-bg, rgba(255, 255, 255, 0.96));
+		color: var(--text-main);
+		font-size: 12px;
+		font-weight: 550;
+		font-style: normal;
+		letter-spacing: normal;
+		line-height: 1.2;
+		text-transform: none;
+		white-space: nowrap;
+		pointer-events: none;
+		box-shadow: 0 6px 18px rgba(15, 23, 42, 0.1);
+		opacity: 0;
+		visibility: hidden;
+	}
+
+	.tooltip-bubble.placed {
+		opacity: 1;
+		visibility: visible;
+		animation: tooltip-fade 120ms ease-out;
+	}
+
+	.tooltip-label {
+		color: var(--text-main);
+	}
+
+	kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1px 5px;
+		border: 1px solid var(--border-soft);
+		border-radius: 5px;
+		background: color-mix(in srgb, var(--panel-bg, #fff) 70%, var(--text-soft, #999) 12%);
+		font-family: inherit;
+		font-size: 11px;
+		font-weight: 650;
+		color: var(--text-muted, var(--text-soft));
+		line-height: 1.3;
+	}
+
+	@keyframes tooltip-fade {
+		from {
+			opacity: 0;
+			transform: translateY(2px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.tooltip-bubble.placed {
+			animation: none;
+		}
+	}
+</style>

--- a/cometline/src/lib/components/Tooltip.svelte.test.ts
+++ b/cometline/src/lib/components/Tooltip.svelte.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import source from './Tooltip.svelte?raw';
+
+describe('Tooltip', () => {
+	it('exposes a tooltip role and shortcut kbd slot', () => {
+		expect(source).toContain('role="tooltip"');
+		expect(source).toContain('<kbd>{kbd}</kbd>');
+		expect(source).toContain('aria-describedby');
+		expect(source).toContain('position: fixed');
+		expect(source).toContain('clampTooltipPosition');
+		expect(source).toContain('use:portal');
+		expect(source).toContain('text-transform: none');
+	});
+});

--- a/cometline/src/lib/components/WebPanel.svelte
+++ b/cometline/src/lib/components/WebPanel.svelte
@@ -12,6 +12,7 @@
 	import { tick, untrack } from 'svelte';
 	import FilePreview from '$lib/components/FilePreview.svelte';
 	import FileTreeBrowser from '$lib/components/FileTreeBrowser.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { sessionStore } from '$lib/stores/session.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import { isWebPanelUrl, normalizeUserUrl, openLink } from '$lib/open-link';
@@ -582,34 +583,42 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<header class="web-panel-toolbar" onmousedown={handlePanelMouseDown}>
 			<div class="nav-actions">
-				<button
-					type="button"
-					class="icon-button"
-					disabled={!terminalAvailable}
-					onclick={() => shellStore.requestTerminalFocus()}
-					aria-label={terminalAvailable ? 'Open terminal' : 'Terminal unavailable in draft'}
-					title={terminalAvailable ? 'Terminal (Cmd+J)' : 'Start a chat to use Terminal'}
+				<Tooltip
+					label={terminalAvailable ? 'Open terminal' : 'Start a chat to use Terminal'}
+					action={terminalAvailable ? 'openTerminal' : undefined}
 				>
-					<SquareTerminal size={16} />
-				</button>
-				<button
-					type="button"
-					class="icon-button"
-					disabled={!toolbarCanGoBack}
-					onclick={onBack}
-					aria-label="Back"
-				>
-					<ArrowLeft size={16} />
-				</button>
-				<button
-					type="button"
-					class="icon-button"
-					disabled={!toolbarCanGoForward}
-					onclick={onForward}
-					aria-label="Forward"
-				>
-					<ArrowRight size={16} />
-				</button>
+					<button
+						type="button"
+						class="icon-button"
+						disabled={!terminalAvailable}
+						onclick={() => shellStore.requestTerminalFocus()}
+						aria-label={terminalAvailable ? 'Open terminal' : 'Terminal unavailable in draft'}
+					>
+						<SquareTerminal size={16} />
+					</button>
+				</Tooltip>
+				<Tooltip label="Back" action="navigateBack">
+					<button
+						type="button"
+						class="icon-button"
+						disabled={!toolbarCanGoBack}
+						onclick={onBack}
+						aria-label="Back"
+					>
+						<ArrowLeft size={16} />
+					</button>
+				</Tooltip>
+				<Tooltip label="Forward" action="navigateForward">
+					<button
+						type="button"
+						class="icon-button"
+						disabled={!toolbarCanGoForward}
+						onclick={onForward}
+						aria-label="Forward"
+					>
+						<ArrowRight size={16} />
+					</button>
+				</Tooltip>
 				{#if panelMode === 'url'}
 					<button
 						type="button"

--- a/cometline/src/lib/components/chat/AssistantThinkingWait.svelte
+++ b/cometline/src/lib/components/chat/AssistantThinkingWait.svelte
@@ -28,7 +28,7 @@
 <style>
 	.assistant-thinking-wait {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		gap: 10px;
 		padding: 8px 2px 2px;
 	}
@@ -38,7 +38,6 @@
 		flex-direction: column;
 		gap: 2px;
 		min-width: 0;
-		padding-top: 2px;
 	}
 
 	.assistant-thinking-detail {

--- a/cometline/src/lib/components/composer/ComposerToolbar.svelte
+++ b/cometline/src/lib/components/composer/ComposerToolbar.svelte
@@ -2,6 +2,7 @@
 	import { Folder, Send, Square } from '@lucide/svelte';
 	import ContextWindowRing from '$lib/components/composer/ContextWindowRing.svelte';
 	import ModelPicker from '$lib/components/composer/ModelPicker.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { modelStore, type ModelOption } from '$lib/stores/model.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 
@@ -30,6 +31,8 @@
 		onStop?: () => void;
 		onSubmit: () => void;
 	} = $props();
+
+	const sendLabel = $derived(streaming ? 'Queue follow-up' : 'Send');
 </script>
 
 <div class="composer-footer">
@@ -58,18 +61,22 @@
 			/>
 		{/if}
 		{#if streaming}
-			<button class="stop-button" onclick={() => onStop?.()} aria-label="Stop response">
-				<Square size={14} fill="currentColor" stroke-width={0} />
-			</button>
+			<Tooltip label="Stop response" action="stopResponse">
+				<button class="stop-button" onclick={() => onStop?.()} aria-label="Stop response">
+					<Square size={14} fill="currentColor" stroke-width={0} />
+				</button>
+			</Tooltip>
 		{/if}
-		<button
-			class="send-button"
-			onclick={onSubmit}
-			disabled={!canSubmit || disabled || !modelStore.selected}
-			aria-label={streaming ? 'Queue follow-up' : 'Send'}
-		>
-			<Send size={16} stroke-width={1.8} />
-		</button>
+		<Tooltip label={sendLabel} action="sendMessage">
+			<button
+				class="send-button"
+				onclick={onSubmit}
+				disabled={!canSubmit || disabled || !modelStore.selected}
+				aria-label={sendLabel}
+			>
+				<Send size={16} stroke-width={1.8} />
+			</button>
+		</Tooltip>
 	</div>
 </div>
 

--- a/cometline/src/lib/components/onboarding/SetupWizard.svelte
+++ b/cometline/src/lib/components/onboarding/SetupWizard.svelte
@@ -424,14 +424,13 @@
 
 	async function saveAndConnect() {
 		if (!selectedProvider) return;
-		// Enable the chosen provider and set it as active + default.
+		// Enable the chosen provider and set it as Default.
 		const finalProviders = draft.providers.map((p) =>
 			p.id === selectedProvider.id ? cloneProvider({ ...p, enabled: true }) : p
 		);
 		const finalDraft: ProviderSettings = {
 			...draft,
 			providers: finalProviders,
-			activeProviderId: selectedProvider.id,
 			defaultProviderId: selectedProvider.id,
 			defaultModelId: selectedProvider.enabledModels[0] ?? selectedProvider.selectedModel
 		};

--- a/cometline/src/lib/components/portal.ts
+++ b/cometline/src/lib/components/portal.ts
@@ -1,0 +1,9 @@
+/** Move a node to `document.body` so fixed UI escapes ancestor stacking/overflow. */
+export function portal(node: HTMLElement) {
+	document.body.appendChild(node);
+	return {
+		destroy() {
+			node.remove();
+		}
+	};
+}

--- a/cometline/src/lib/components/settings/SettingsModelRolesPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsModelRolesPanel.svelte
@@ -32,17 +32,15 @@
 
 	function modelsForProvider(provider: ProviderConfig | undefined): string[] {
 		if (!provider) return [];
-		return provider.enabledModels.length ? provider.enabledModels : provider.models;
+		return [...provider.enabledModels];
 	}
 
 	function firstModelForProvider(provider: ProviderConfig | undefined): string {
-		return provider
-			? (provider.enabledModels[0] ?? provider.selectedModel ?? provider.models[0] ?? '')
-			: '';
+		return provider?.enabledModels[0] ?? '';
 	}
 
 	function providerById(providerId: string) {
-		return providers.find((provider) => provider.id === providerId);
+		return runtimeProviders.find((provider) => provider.id === providerId);
 	}
 
 	function firstRuntimeProvider() {
@@ -53,18 +51,8 @@
 		return provider.method === 'ollama' ? `${provider.name} (Local)` : provider.name;
 	}
 
-	function explicitRole(providerId: string, modelId: string) {
-		let provider = providerById(providerId);
-		if (!provider || !modelsForProvider(provider).includes(modelId)) {
-			provider = firstRuntimeProvider();
-		}
-		const model = modelsForProvider(provider).includes(modelId)
-			? modelId
-			: firstModelForProvider(provider);
-		return {
-			providerId: provider?.id ?? '',
-			modelId: model
-		};
+	function isRuntimeProviderId(providerId: string): boolean {
+		return runtimeProviders.some((provider) => provider.id === providerId);
 	}
 
 	// ── Default model picker ────────────────────────────────────────────
@@ -170,11 +158,8 @@
 		modelSearch = '';
 	}
 
-	// ── Title model (provider + model, falls back to session) ───────────
-	const titleProvider = $derived(
-		runtimeProviders.find((provider) => provider.id === cometmind.titleProviderId) ??
-			providers.find((provider) => provider.id === cometmind.titleProviderId)
-	);
+	// ── Title model (provider + model, falls back to Default) ───────────
+	const titleProvider = $derived(providerById(cometmind.titleProviderId));
 
 	const titleModels = $derived(modelsForProvider(titleProvider));
 
@@ -191,12 +176,8 @@
 		cometmind = { ...cometmind, titleModelId: modelId };
 	}
 
-	// ── Memory extraction (provider + model, falls back to session) ─────
-	const extractionProvider = $derived(
-		runtimeProviders.find(
-			(provider) => provider.id === cometmind.memory.extractionProviderId
-		) ?? providers.find((provider) => provider.id === cometmind.memory.extractionProviderId)
-	);
+	// ── Memory extraction (provider + model, falls back to Default) ─────
+	const extractionProvider = $derived(providerById(cometmind.memory.extractionProviderId));
 
 	const extractionModels = $derived(modelsForProvider(extractionProvider));
 
@@ -243,36 +224,44 @@
 		}
 	});
 
+	// Drop role pins that point at disabled / model-less providers.
 	$effect(() => {
-		const autonomy = explicitRole(cometmind.autonomy.providerId, cometmind.autonomy.modelId);
-		const synthesis = explicitRole(
-			cometmind.skills.synthesisProviderId,
-			cometmind.skills.synthesisModel
-		);
-		const autonomyChanged =
-			autonomy.providerId !== cometmind.autonomy.providerId ||
-			autonomy.modelId !== cometmind.autonomy.modelId;
-		const synthesisChanged =
-			synthesis.providerId !== cometmind.skills.synthesisProviderId ||
-			synthesis.modelId !== cometmind.skills.synthesisModel;
-		if (autonomyChanged || synthesisChanged) {
-			cometmind = {
-				...cometmind,
-				autonomy: {
-					...cometmind.autonomy,
-					providerId: autonomy.providerId,
-					modelId: autonomy.modelId
-				},
-				skills: {
-					...cometmind.skills,
-					synthesisProviderId: synthesis.providerId,
-					synthesisModel: synthesis.modelId
-				}
-			};
+		const next = { ...cometmind };
+		let changed = false;
+		if (next.titleProviderId && !isRuntimeProviderId(next.titleProviderId)) {
+			next.titleProviderId = '';
+			next.titleModelId = '';
+			changed = true;
 		}
+		if (
+			next.memory.extractionProviderId &&
+			!isRuntimeProviderId(next.memory.extractionProviderId)
+		) {
+			next.memory = { ...next.memory, extractionProviderId: '', extractionModel: '' };
+			changed = true;
+		}
+		if (next.autonomy.providerId && !isRuntimeProviderId(next.autonomy.providerId)) {
+			next.autonomy = { ...next.autonomy, providerId: '', modelId: '' };
+			changed = true;
+		}
+		if (
+			next.skills.synthesisProviderId &&
+			!isRuntimeProviderId(next.skills.synthesisProviderId)
+		) {
+			next.skills = { ...next.skills, synthesisProviderId: '', synthesisModel: '' };
+			changed = true;
+		}
+		if (changed) cometmind = next;
 	});
 
 	function setAutonomyProvider(providerId: string) {
+		if (!providerId) {
+			cometmind = {
+				...cometmind,
+				autonomy: { ...cometmind.autonomy, providerId: '', modelId: '' }
+			};
+			return;
+		}
 		const provider = providerById(providerId) ?? firstRuntimeProvider();
 		cometmind = {
 			...cometmind,
@@ -289,6 +278,13 @@
 	}
 
 	function setSynthesisProvider(providerId: string) {
+		if (!providerId) {
+			cometmind = {
+				...cometmind,
+				skills: { ...cometmind.skills, synthesisProviderId: '', synthesisModel: '' }
+			};
+			return;
+		}
 		const provider = providerById(providerId) ?? firstRuntimeProvider();
 		cometmind = {
 			...cometmind,
@@ -312,8 +308,9 @@
 				<div>
 					<h3>Default model</h3>
 					<p>
-						Choose which model new chats use by default. You can still switch models per
-						session.
+						Choose which model new chats use by default, and what unpinned roles
+						(titles, extraction, jobs, synthesis) fall back to. You can still switch
+						models per session.
 					</p>
 				</div>
 			</div>
@@ -372,7 +369,10 @@
 		<div class="settings-section">
 			<div class="settings-section-heading">
 				<h3>Autonomous jobs</h3>
-				<p>Choose the exact model used when CometMind claims jobs in the background.</p>
+				<p>
+					Optional override for background job claims. Leave empty to use the Default
+					model.
+				</p>
 			</div>
 			<label>
 				<span>Autonomous jobs provider</span>
@@ -380,12 +380,13 @@
 					value={cometmind.autonomy.providerId}
 					onchange={(e) => setAutonomyProvider(e.currentTarget.value)}
 				>
+					<option value="">Use default model</option>
 					{#each runtimeProviders as provider (provider.id)}
 						<option value={provider.id}>{providerOptionLabel(provider)}</option>
 					{/each}
 				</select>
 			</label>
-			{#if autonomyProvider}
+			{#if cometmind.autonomy.providerId}
 				<label>
 					<span>Autonomous jobs model</span>
 					<select
@@ -408,7 +409,8 @@
 			<div class="settings-section-heading">
 				<h3>Skill synthesis</h3>
 				<p>
-					Choose the exact model that proposes reusable skill drafts after completed jobs.
+					Optional override for skill draft proposals after completed jobs. Leave empty to
+					use the Default model.
 				</p>
 			</div>
 			<label>
@@ -417,12 +419,13 @@
 					value={cometmind.skills.synthesisProviderId}
 					onchange={(e) => setSynthesisProvider(e.currentTarget.value)}
 				>
+					<option value="">Use default model</option>
 					{#each runtimeProviders as provider (provider.id)}
 						<option value={provider.id}>{providerOptionLabel(provider)}</option>
 					{/each}
 				</select>
 			</label>
-			{#if synthesisProvider}
+			{#if cometmind.skills.synthesisProviderId}
 				<label>
 					<span>Synthesis model</span>
 					<select
@@ -446,7 +449,7 @@
 				<h3>Session titles</h3>
 				<p>
 					CometMind names each session from your first message using an LLM. Pin a cheaper
-					/ faster model here, or leave as default to reuse the session's own model.
+					/ faster model here, or leave empty to use the Default model.
 				</p>
 			</div>
 			<label>
@@ -455,8 +458,8 @@
 					value={cometmind.titleProviderId}
 					onchange={(e) => setTitleProvider(e.currentTarget.value)}
 				>
-					<option value="">Use session model (default)</option>
-					{#each providers as provider (provider.id)}
+					<option value="">Use default model</option>
+					{#each runtimeProviders as provider (provider.id)}
 						<option value={provider.id}>{providerOptionLabel(provider)}</option>
 					{/each}
 				</select>
@@ -484,9 +487,9 @@
 			<div class="settings-section-heading">
 				<h3>Memory extraction</h3>
 				<p>
-					After each turn, CometMind extracts durable memories in the background. Pin a
-					cheaper model from any provider for this step, or leave as default to reuse the
-					session's own model.
+					After each turn, CometMind extracts durable memories in the background. The same
+					provider also runs memory compaction merges. Leave empty to use the Default
+					model.
 				</p>
 			</div>
 			<label>
@@ -495,8 +498,8 @@
 					value={cometmind.memory.extractionProviderId}
 					onchange={(e) => setExtractionProvider(e.currentTarget.value)}
 				>
-					<option value="">Use session model (default)</option>
-					{#each providers as provider (provider.id)}
+					<option value="">Use default model</option>
+					{#each runtimeProviders as provider (provider.id)}
 						<option value={provider.id}>{providerOptionLabel(provider)}</option>
 					{/each}
 				</select>
@@ -513,8 +516,7 @@
 						{/each}
 					</select>
 					<p class="settings-field-hint">
-						A small, fast model is ideal — extraction runs after every turn in the
-						background.
+						A small, fast model is ideal — extraction and compaction both use this pin.
 					</p>
 				</label>
 			{/if}

--- a/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
+++ b/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
@@ -381,12 +381,7 @@ export function createSettingsPanelController(deps: {
 		}
 
 		const draft = deps.getDraft();
-		const activeProvider =
-			draft.providers.find(
-				(provider) => provider.enabled && provider.enabledModels.length > 0
-			) ?? draft.providers[0];
 		const payload: ProviderSettings = providerPayloadFromDraft(draft);
-		payload.activeProviderId = activeProvider?.id ?? '';
 		const personaIdChanged = settingsStore.settings.app.personaId !== draft.app.personaId;
 		const runtimeAction = personaIdChanged
 			? 'reload'
@@ -417,12 +412,7 @@ export function createSettingsPanelController(deps: {
 	) {
 		deps.getCometmindPanel()?.syncFields?.();
 		const draft = deps.getDraft();
-		const activeProvider =
-			draft.providers.find(
-				(provider) => provider.enabled && provider.enabledModels.length > 0
-			) ?? draft.providers[0];
 		const payload: ProviderSettings = providerPayloadFromDraft(draft);
-		payload.activeProviderId = activeProvider?.id ?? '';
 		payload.cometmind = { ...payload.cometmind, ...overrides };
 		const runtimeAction = runtimeActionForSettingsSave(settingsStore.settings, payload);
 		const { settings: saved, reload } = await settingsStore.save(payload, { runtimeAction });

--- a/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
+++ b/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
@@ -576,15 +576,21 @@ export function createSettingsPanelController(deps: {
 		if (DEFAULT_PROVIDER_IDS.has(providerId)) return;
 		const draft = deps.getDraft();
 		const nextProviders = draft.providers.filter((p) => p.id !== providerId);
+		let nextDefaultProviderId = draft.defaultProviderId;
+		let nextDefaultModelId = draft.defaultModelId;
+		if (draft.defaultProviderId === providerId) {
+			const fallback =
+				nextProviders.find(
+					(provider) => provider.enabled && provider.enabledModels.length > 0
+				) ?? nextProviders[0];
+			nextDefaultProviderId = fallback?.id ?? '';
+			nextDefaultModelId = fallback?.enabledModels[0] ?? '';
+		}
 		deps.setDraft({
 			...draft,
 			providers: nextProviders,
-			activeProviderId:
-				nextProviders.find(
-					(provider) => provider.enabled && provider.enabledModels.length > 0
-				)?.id ??
-				nextProviders[0]?.id ??
-				''
+			defaultProviderId: nextDefaultProviderId,
+			defaultModelId: nextDefaultModelId
 		});
 		deps.setSelectedProviderId(nextProviders[0]?.id ?? '');
 	}

--- a/cometline/src/lib/components/shortcut-tooltip.test.ts
+++ b/cometline/src/lib/components/shortcut-tooltip.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	shortcutTooltipKbd,
+	shortcutTooltipText,
+	resolveShortcutBinding
+} from './shortcut-tooltip';
+import type { KeyboardShortcuts } from '$lib/keyboard-shortcuts';
+
+const macShortcuts: KeyboardShortcuts = {
+	openTerminal: { command: true, key: 'j' },
+	openWebPanel: { command: true, key: 'o' },
+	sendMessage: { key: 'Enter' }
+};
+
+describe('shortcut-tooltip helpers', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('resolveShortcutBinding returns the live binding', () => {
+		expect(resolveShortcutBinding('openTerminal', macShortcuts)).toEqual({
+			command: true,
+			key: 'j'
+		});
+		expect(resolveShortcutBinding(undefined, macShortcuts)).toBeUndefined();
+		expect(resolveShortcutBinding('openJobs', macShortcuts)).toBeUndefined();
+	});
+
+	it('shortcutTooltipText appends a Mac-formatted chord when bound', () => {
+		vi.stubGlobal('navigator', { platform: 'MacIntel' });
+		expect(shortcutTooltipText('Open terminal', 'openTerminal', macShortcuts)).toBe(
+			'Open terminal (⌘ j)'
+		);
+	});
+
+	it('shortcutTooltipText uses Ctrl wording on non-Mac', () => {
+		vi.stubGlobal('navigator', { platform: 'Win32' });
+		expect(shortcutTooltipText('Open terminal', 'openTerminal', macShortcuts)).toBe(
+			'Open terminal (Ctrl + j)'
+		);
+	});
+
+	it('shortcutTooltipText returns label only when unbound or action omitted', () => {
+		vi.stubGlobal('navigator', { platform: 'MacIntel' });
+		expect(shortcutTooltipText('Jobs', 'openJobs', macShortcuts)).toBe('Jobs');
+		expect(shortcutTooltipText('Copy', undefined, macShortcuts)).toBe('Copy');
+	});
+
+	it('shortcutTooltipText reflects a remapped binding', () => {
+		vi.stubGlobal('navigator', { platform: 'MacIntel' });
+		const remapped: KeyboardShortcuts = {
+			...macShortcuts,
+			openTerminal: { command: true, shift: true, key: 't' }
+		};
+		expect(shortcutTooltipText('Open terminal', 'openTerminal', remapped)).toBe(
+			'Open terminal (⌘ ⇧ t)'
+		);
+	});
+
+	it('shortcutTooltipKbd returns only the chord', () => {
+		vi.stubGlobal('navigator', { platform: 'MacIntel' });
+		expect(shortcutTooltipKbd('openTerminal', macShortcuts)).toBe('⌘ j');
+		expect(shortcutTooltipKbd('openJobs', macShortcuts)).toBeUndefined();
+		expect(shortcutTooltipKbd(undefined, macShortcuts)).toBeUndefined();
+	});
+});

--- a/cometline/src/lib/components/shortcut-tooltip.ts
+++ b/cometline/src/lib/components/shortcut-tooltip.ts
@@ -1,0 +1,43 @@
+import {
+	formatShortcut,
+	type KeyboardShortcuts,
+	type ShortcutAction,
+	type ShortcutBinding
+} from '$lib/keyboard-shortcuts';
+
+/** Resolve the live binding for a shortcut action, if any. */
+export function resolveShortcutBinding(
+	action: ShortcutAction | undefined,
+	shortcuts: KeyboardShortcuts
+): ShortcutBinding | undefined {
+	if (!action) return undefined;
+	return shortcuts[action];
+}
+
+/**
+ * Accessible / visual tip copy: action label plus formatted shortcut when bound.
+ * Returns only the label when there is no action or no binding.
+ */
+export function shortcutTooltipText(
+	label: string,
+	action: ShortcutAction | undefined,
+	shortcuts: KeyboardShortcuts
+): string {
+	const binding = resolveShortcutBinding(action, shortcuts);
+	if (!binding) return label;
+	const formatted = formatShortcut(binding);
+	if (!formatted || formatted === 'None') return label;
+	return `${label} (${formatted})`;
+}
+
+/** Formatted shortcut chord for kbd display, or undefined when unbound. */
+export function shortcutTooltipKbd(
+	action: ShortcutAction | undefined,
+	shortcuts: KeyboardShortcuts
+): string | undefined {
+	const binding = resolveShortcutBinding(action, shortcuts);
+	if (!binding) return undefined;
+	const formatted = formatShortcut(binding);
+	if (!formatted || formatted === 'None') return undefined;
+	return formatted;
+}

--- a/cometline/src/lib/components/sidebar/SidebarSearch.svelte
+++ b/cometline/src/lib/components/sidebar/SidebarSearch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Search, SquarePen } from '@lucide/svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 
 	let {
 		searchQuery = $bindable(''),
@@ -28,9 +29,11 @@
 			/>
 		</label>
 		<div class="search-divider" aria-hidden="true"></div>
-		<button class="new-chat-button" onclick={onNewChat} aria-label="New chat" title="New chat">
-			<SquarePen size={16} stroke-width={1.8} />
-		</button>
+		<Tooltip label="New chat" action="newChat">
+			<button class="new-chat-button" onclick={onNewChat} aria-label="New chat">
+				<SquarePen size={16} stroke-width={1.8} />
+			</button>
+		</Tooltip>
 	</div>
 </div>
 
@@ -98,9 +101,15 @@
 		background: var(--border-soft);
 	}
 
+	.search-composite :global(.tooltip-wrap) {
+		align-self: stretch;
+		height: 100%;
+	}
+
 	.new-chat-button {
 		display: grid;
 		width: 1.625rem;
+		height: 100%;
 		flex-shrink: 0;
 		place-items: center;
 		border: 0;

--- a/cometline/src/lib/components/tooltip-position.test.ts
+++ b/cometline/src/lib/components/tooltip-position.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { clampTooltipPosition } from './tooltip-position';
+
+const tip = { width: 120, height: 28 };
+const viewport = { width: 800, height: 600 };
+
+describe('clampTooltipPosition', () => {
+	it('centers above a mid-screen anchor', () => {
+		const pos = clampTooltipPosition({
+			anchor: { top: 200, left: 340, width: 28, height: 28, bottom: 228 },
+			tip,
+			viewport
+		});
+		expect(pos.placement).toBe('above');
+		expect(pos.top).toBe(200 - 28 - 6);
+		expect(pos.left).toBe(340 + 14 - 60);
+	});
+
+	it('shifts right when the tip would overflow the left edge', () => {
+		const pos = clampTooltipPosition({
+			anchor: { top: 500, left: 8, width: 28, height: 28, bottom: 528 },
+			tip,
+			viewport
+		});
+		expect(pos.left).toBe(8);
+		expect(pos.placement).toBe('above');
+	});
+
+	it('shifts left when the tip would overflow the right edge', () => {
+		const pos = clampTooltipPosition({
+			anchor: { top: 500, left: 780, width: 28, height: 28, bottom: 528 },
+			tip,
+			viewport
+		});
+		expect(pos.left).toBe(800 - 120 - 8);
+	});
+
+	it('flips below when there is not enough room above', () => {
+		const pos = clampTooltipPosition({
+			anchor: { top: 20, left: 200, width: 28, height: 28, bottom: 48 },
+			tip,
+			viewport
+		});
+		expect(pos.placement).toBe('below');
+		expect(pos.top).toBe(48 + 6);
+	});
+});

--- a/cometline/src/lib/components/tooltip-position.ts
+++ b/cometline/src/lib/components/tooltip-position.ts
@@ -1,0 +1,50 @@
+export type TooltipPlacement = 'above' | 'below';
+
+export type TooltipBox = {
+	width: number;
+	height: number;
+};
+
+export type TooltipViewport = {
+	width: number;
+	height: number;
+};
+
+export type TooltipPosition = {
+	top: number;
+	left: number;
+	placement: TooltipPlacement;
+};
+
+/**
+ * Prefer above the anchor; flip below if needed. Horizontally center on the
+ * anchor, then clamp so the tip stays inside the viewport with a margin.
+ */
+export function clampTooltipPosition(input: {
+	anchor: { top: number; left: number; width: number; height: number; bottom: number };
+	tip: TooltipBox;
+	viewport: TooltipViewport;
+	gap?: number;
+	margin?: number;
+}): TooltipPosition {
+	const gap = input.gap ?? 6;
+	const margin = input.margin ?? 8;
+	const { anchor, tip, viewport } = input;
+
+	let placement: TooltipPlacement = 'above';
+	let top = anchor.top - tip.height - gap;
+	if (top < margin) {
+		placement = 'below';
+		top = anchor.bottom + gap;
+		if (top + tip.height > viewport.height - margin) {
+			top = Math.max(margin, viewport.height - tip.height - margin);
+		}
+	}
+
+	let left = anchor.left + anchor.width / 2 - tip.width / 2;
+	const minLeft = margin;
+	const maxLeft = Math.max(margin, viewport.width - tip.width - margin);
+	left = Math.min(Math.max(left, minLeft), maxLeft);
+
+	return { top, left, placement };
+}

--- a/cometline/src/lib/settings/pending-settings.ts
+++ b/cometline/src/lib/settings/pending-settings.ts
@@ -18,7 +18,6 @@ export function pendingSettingsSnapshot(settings: ProviderSettings): string {
 
 	return JSON.stringify({
 		providers: settings.providers.map(cloneProvider),
-		activeProviderId: settings.activeProviderId,
 		defaultModelId: settings.defaultModelId ?? '',
 		defaultProviderId: settings.defaultProviderId ?? '',
 		appearance: {
@@ -49,7 +48,6 @@ function modelsSectionSnapshot(settings: ProviderSettings): string {
 	const cometmind = cloneCometMindSettings(normalizeCometMindSettings(settings.cometmind));
 	return JSON.stringify({
 		providers: settings.providers.map(cloneProvider),
-		activeProviderId: settings.activeProviderId,
 		defaultModelId: settings.defaultModelId ?? '',
 		defaultProviderId: settings.defaultProviderId ?? '',
 		titleProviderId: cometmind.titleProviderId,

--- a/cometline/src/lib/settings/schema.test.ts
+++ b/cometline/src/lib/settings/schema.test.ts
@@ -252,7 +252,7 @@ describe('settings schema', () => {
 		expect(settings.cometmind.systemPromptPath).toBe('/tmp/SOUL.md');
 	});
 
-	it('runtimeSlice projects active provider', () => {
+	it('runtimeSlice projects default provider', () => {
 		const settings = normalizeSettings({
 			...defaultSettings(),
 			providers: defaultSettings().providers.map((p) =>
@@ -265,7 +265,8 @@ describe('settings schema', () => {
 						}
 					: { ...p, enabled: false, enabledModels: [] }
 			),
-			activeProviderId: 'openai',
+			defaultProviderId: 'openai',
+			defaultModelId: 'gpt-4o',
 			cometmind: {
 				...defaultSettings().cometmind,
 				systemPromptPath: '/tmp/SOUL.md'
@@ -277,6 +278,59 @@ describe('settings schema', () => {
 		expect(slice?.maxTokens).toBe(2048);
 		expect(slice?.systemPromptPath).toBe('/tmp/SOUL.md');
 		expect(slice?.providers).toHaveLength(1);
+	});
+
+	it('normalizeSettings migrates active into default and mirrors active', () => {
+		const settings = normalizeSettings({
+			...defaultSettings(),
+			providers: defaultSettings().providers.map((p) =>
+				p.id === 'codex'
+					? {
+							...p,
+							enabled: true,
+							enabledModels: ['gpt-5.4'],
+							models: ['gpt-5.4']
+						}
+					: { ...p, enabled: false, enabledModels: [] }
+			),
+			activeProviderId: 'codex',
+			defaultProviderId: '',
+			defaultModelId: ''
+		});
+		expect(settings.defaultProviderId).toBe('codex');
+		expect(settings.defaultModelId).toBe('gpt-5.4');
+		expect(settings.activeProviderId).toBe('codex');
+	});
+
+	it('normalizeSettings prefers explicit default over active', () => {
+		const settings = normalizeSettings({
+			...defaultSettings(),
+			providers: defaultSettings().providers.map((p) => {
+				if (p.id === 'codex') {
+					return {
+						...p,
+						enabled: true,
+						enabledModels: ['gpt-5.4'],
+						models: ['gpt-5.4']
+					};
+				}
+				if (p.id === 'opencode-go') {
+					return {
+						...p,
+						enabled: true,
+						enabledModels: ['deepseek-v4-flash'],
+						models: ['deepseek-v4-flash']
+					};
+				}
+				return { ...p, enabled: false, enabledModels: [] };
+			}),
+			activeProviderId: 'codex',
+			defaultProviderId: 'opencode-go',
+			defaultModelId: 'deepseek-v4-flash'
+		});
+		expect(settings.defaultProviderId).toBe('opencode-go');
+		expect(settings.defaultModelId).toBe('deepseek-v4-flash');
+		expect(settings.activeProviderId).toBe('opencode-go');
 	});
 
 	it('validateSettings rejects empty providers list', () => {

--- a/cometline/src/lib/settings/schema.test.ts
+++ b/cometline/src/lib/settings/schema.test.ts
@@ -26,7 +26,9 @@ describe('settings schema', () => {
 		) as Partial<ProviderSettings>;
 		const settings = normalizeSettings(fixture);
 
-		expect(settings.activeProviderId).toBe('local-llm');
+		expect(settings.defaultProviderId).toBe('local-llm');
+		expect(settings.defaultModelId).toBe('qwen2.5');
+		expect(settings).not.toHaveProperty('activeProviderId');
 		expect(settings.cometmind.systemPromptPath).toBe('/tmp/SOUL.md');
 		expect(settings.cometmind.storage).toMatchObject({
 			retentionDays: 90,
@@ -70,7 +72,8 @@ describe('settings schema', () => {
 			'Advanced / Custom endpoint'
 		);
 		expect(settings.providers.find((p) => p.id === 'codex')?.apiKey).toBe('');
-		expect(settings.activeProviderId).toBe('codex');
+		expect(settings.defaultProviderId).toBe('codex');
+		expect(settings).not.toHaveProperty('activeProviderId');
 		expect(settings.app.personaId).toBe('minako');
 		expect(settings.app.hasCompletedSetup).toBe(false);
 		expect(settings.app.hasDismissedSetupWizard).toBe(false);
@@ -213,7 +216,9 @@ describe('settings schema', () => {
 			selectedModel: 'gpt-4'
 		});
 		expect(migrated?.providers).toHaveLength(1);
-		expect(migrated?.activeProviderId).toBe('openai');
+		expect(migrated?.defaultProviderId).toBe('openai');
+		expect(migrated?.defaultModelId).toBe('gpt-4');
+		expect(migrated).not.toHaveProperty('activeProviderId');
 	});
 
 	it('preserves renamed built-in provider names', () => {
@@ -280,7 +285,7 @@ describe('settings schema', () => {
 		expect(slice?.providers).toHaveLength(1);
 	});
 
-	it('normalizeSettings migrates active into default and mirrors active', () => {
+	it('normalizeSettings migrates active into default and drops active', () => {
 		const settings = normalizeSettings({
 			...defaultSettings(),
 			providers: defaultSettings().providers.map((p) =>
@@ -299,7 +304,7 @@ describe('settings schema', () => {
 		});
 		expect(settings.defaultProviderId).toBe('codex');
 		expect(settings.defaultModelId).toBe('gpt-5.4');
-		expect(settings.activeProviderId).toBe('codex');
+		expect(settings).not.toHaveProperty('activeProviderId');
 	});
 
 	it('normalizeSettings prefers explicit default over active', () => {
@@ -330,7 +335,7 @@ describe('settings schema', () => {
 		});
 		expect(settings.defaultProviderId).toBe('opencode-go');
 		expect(settings.defaultModelId).toBe('deepseek-v4-flash');
-		expect(settings.activeProviderId).toBe('opencode-go');
+		expect(settings).not.toHaveProperty('activeProviderId');
 	});
 
 	it('validateSettings rejects empty providers list', () => {
@@ -352,7 +357,8 @@ describe('settings schema', () => {
 						}
 					: { ...p, enabled: false, enabledModels: [] }
 			),
-			activeProviderId: 'openai',
+			defaultProviderId: 'openai',
+			defaultModelId: 'gpt-4o',
 			cometmind: {
 				...defaultSettings().cometmind,
 				maxTokens: 3072

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -1095,21 +1095,6 @@ export function normalizeProvider(
 	};
 }
 
-/** Runtime active provider: first enabled with models, else preferred id, else sidebar order. */
-export function resolveActiveProviderId(providers: ProviderConfig[], preferredId?: string): string {
-	const preferred = preferredId
-		? providers.find((provider) => provider.id === preferredId)
-		: undefined;
-	if (preferred?.enabled && preferred.enabledModels.length > 0) {
-		return preferred.id;
-	}
-	const enabledWithModels = providers.find(
-		(provider) => provider.enabled && provider.enabledModels.length > 0
-	);
-	if (enabledWithModels) return enabledWithModels.id;
-	return providers[0]?.id ?? '';
-}
-
 export function normalizeProviders(
 	providers: Partial<ProviderConfig>[] | undefined
 ): ProviderConfig[] {
@@ -1165,17 +1150,23 @@ export function migrateSingleProvider(
 				enabledModels: saved.selectedModel ? [String(saved.selectedModel).trim()] : []
 			}
 		],
-		activeProviderId: id
+		defaultProviderId: id,
+		defaultModelId: String(saved.selectedModel || '').trim()
 	};
 }
 
+/** Legacy settings files may still carry activeProviderId; read-only for migration. */
+export type SettingsNormalizeInput = Partial<ProviderSettings> & {
+	activeProviderId?: string;
+};
+
 export function defaultSettings(): ProviderSettings {
 	const providers = DEFAULT_PROVIDERS.map(cloneProvider);
+	const { defaultProviderId, defaultModelId } = resolveDefaultModelPair(providers);
 	return {
 		providers,
-		activeProviderId: resolveActiveProviderId(providers),
-		defaultModelId: '',
-		defaultProviderId: '',
+		defaultModelId,
+		defaultProviderId,
 		appearance: defaultAppearance(),
 		shortcuts: defaultKeyboardShortcuts(),
 		app: defaultAppSettings(),
@@ -1189,11 +1180,11 @@ export interface NormalizeSettingsOptions {
 }
 
 export function normalizeSettings(
-	next: Partial<ProviderSettings>,
+	next: SettingsNormalizeInput,
 	options: NormalizeSettingsOptions = {}
 ): ProviderSettings {
 	const providers = normalizeProviders(next.providers);
-	const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+	const { defaultProviderId, defaultModelId } = resolveDefaultModelPair(
 		providers,
 		next.defaultProviderId,
 		next.defaultModelId,
@@ -1209,8 +1200,6 @@ export function normalizeSettings(
 	const customPersonas = normalizeCustomPersonaList(next.app?.personas?.custom);
 	return {
 		providers,
-		// Mirror Default into activeProviderId for legacy Electron/env readers.
-		activeProviderId,
 		defaultModelId,
 		defaultProviderId,
 		appearance: {
@@ -1264,7 +1253,7 @@ export function resolveDefaultModelPair(
 	preferredDefaultProviderId?: string,
 	preferredDefaultModelId?: string,
 	legacyActiveProviderId?: string
-): { defaultProviderId: string; defaultModelId: string; activeProviderId: string } {
+): { defaultProviderId: string; defaultModelId: string } {
 	const runtime = providers.filter((p) => p.enabled && p.enabledModels.length > 0);
 	const byId = new Map(runtime.map((p) => [p.id, p]));
 
@@ -1286,9 +1275,7 @@ export function resolveDefaultModelPair(
 
 	return {
 		defaultProviderId,
-		defaultModelId,
-		// Keep active mirrored to Default so legacy env/readers stay consistent.
-		activeProviderId: defaultProviderId
+		defaultModelId
 	};
 }
 
@@ -1303,10 +1290,7 @@ export function runtimeProviders(settings: ProviderSettings): ProviderConfig[] {
 export function runtimeSlice(settings: ProviderSettings): RuntimeSettingsSlice | null {
 	const providers = runtimeProviders(settings);
 	const active =
-		providers.find((p) => p.id === settings.defaultProviderId) ??
-		providers.find((p) => p.id === settings.activeProviderId) ??
-		providers[0] ??
-		null;
+		providers.find((p) => p.id === settings.defaultProviderId) ?? providers[0] ?? null;
 	if (!active) return null;
 
 	const model =
@@ -1371,7 +1355,6 @@ const providerConfigSchema = z.object({
 
 const providerSettingsSchema = z.object({
 	providers: z.array(providerConfigSchema).min(1),
-	activeProviderId: z.string(),
 	defaultModelId: z.string(),
 	defaultProviderId: z.string(),
 	appearance: z.object({

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -1193,7 +1193,12 @@ export function normalizeSettings(
 	options: NormalizeSettingsOptions = {}
 ): ProviderSettings {
 	const providers = normalizeProviders(next.providers);
-	const activeProviderId = resolveActiveProviderId(providers, next.activeProviderId);
+	const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+		providers,
+		next.defaultProviderId,
+		next.defaultModelId,
+		next.activeProviderId
+	);
 	const cometmind = normalizeCometMindSettings(
 		next.cometmind,
 		options.fallbackWorkspacePath ?? ''
@@ -1204,9 +1209,10 @@ export function normalizeSettings(
 	const customPersonas = normalizeCustomPersonaList(next.app?.personas?.custom);
 	return {
 		providers,
+		// Mirror Default into activeProviderId for legacy Electron/env readers.
 		activeProviderId,
-		defaultModelId: String(next.defaultModelId ?? '').trim(),
-		defaultProviderId: String(next.defaultProviderId ?? '').trim(),
+		defaultModelId,
+		defaultProviderId,
 		appearance: {
 			heroComposer: normalizeHeroComposerAppearance(next.appearance?.heroComposer),
 			caretTrail: normalizeCaretTrailSettings(next.appearance?.caretTrail)
@@ -1252,6 +1258,40 @@ export function normalizeSettings(
 	};
 }
 
+/** Resolve Default model pair; migrate from legacy activeProviderId when Default is empty. */
+export function resolveDefaultModelPair(
+	providers: ProviderConfig[],
+	preferredDefaultProviderId?: string,
+	preferredDefaultModelId?: string,
+	legacyActiveProviderId?: string
+): { defaultProviderId: string; defaultModelId: string; activeProviderId: string } {
+	const runtime = providers.filter((p) => p.enabled && p.enabledModels.length > 0);
+	const byId = new Map(runtime.map((p) => [p.id, p]));
+
+	let defaultProviderId = String(preferredDefaultProviderId ?? '').trim();
+	let defaultModelId = String(preferredDefaultModelId ?? '').trim();
+
+	if (defaultProviderId && byId.has(defaultProviderId)) {
+		const provider = byId.get(defaultProviderId)!;
+		if (!defaultModelId || !provider.enabledModels.includes(defaultModelId)) {
+			defaultModelId = primaryModel(provider);
+		}
+	} else {
+		const legacyActive = String(legacyActiveProviderId ?? '').trim();
+		const migrated =
+			(legacyActive && byId.get(legacyActive)) || runtime[0] || providers[0] || null;
+		defaultProviderId = migrated?.id ?? '';
+		defaultModelId = migrated ? primaryModel(migrated) : '';
+	}
+
+	return {
+		defaultProviderId,
+		defaultModelId,
+		// Keep active mirrored to Default so legacy env/readers stay consistent.
+		activeProviderId: defaultProviderId
+	};
+}
+
 function primaryModel(provider: ProviderConfig): string {
 	return provider.enabledModels[0] || provider.selectedModel || provider.models[0] || '';
 }
@@ -1263,12 +1303,21 @@ export function runtimeProviders(settings: ProviderSettings): ProviderConfig[] {
 export function runtimeSlice(settings: ProviderSettings): RuntimeSettingsSlice | null {
 	const providers = runtimeProviders(settings);
 	const active =
-		providers.find((p) => p.id === settings.activeProviderId) ?? providers[0] ?? null;
+		providers.find((p) => p.id === settings.defaultProviderId) ??
+		providers.find((p) => p.id === settings.activeProviderId) ??
+		providers[0] ??
+		null;
 	if (!active) return null;
+
+	const model =
+		(settings.defaultModelId &&
+		active.enabledModels.includes(settings.defaultModelId)
+			? settings.defaultModelId
+			: primaryModel(active));
 
 	return {
 		provider: active.id,
-		model: primaryModel(active),
+		model,
 		baseURL: active.baseURL,
 		maxTokens: settings.cometmind.maxTokens,
 		maxSteps: 50,

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -1,6 +1,7 @@
 import { cloneCometMindSettings, normalizeCometMindSettings } from '$lib/cometmind-settings';
 import type { MemorySettings } from '$lib/client/cometmind';
 import { findProviderForSaved } from '$lib/embedding-models';
+import { resolveDefaultModelPair } from '$lib/settings/schema';
 import type { ProviderConfig, ProviderSettings } from '$lib/types';
 
 export function cloneProvider(provider: ProviderConfig): ProviderConfig {
@@ -56,15 +57,17 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 }
 
 export function providerPayloadFromDraft(draft: ProviderSettings): ProviderSettings {
-	const activeProvider =
-		draft.providers.find((provider) => provider.enabled && provider.enabledModels.length > 0) ??
-		draft.providers.find((provider) => provider.enabled) ??
-		draft.providers[0];
+	const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+		draft.providers,
+		draft.defaultProviderId,
+		draft.defaultModelId,
+		draft.activeProviderId
+	);
 	return {
 		providers: draft.providers.map(cloneProvider),
-		activeProviderId: activeProvider?.id ?? '',
-		defaultModelId: draft.defaultModelId ?? '',
-		defaultProviderId: draft.defaultProviderId ?? '',
+		activeProviderId,
+		defaultModelId,
+		defaultProviderId,
 		appearance: {
 			heroComposer: {
 				...draft.appearance.heroComposer,

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -24,7 +24,6 @@ export function cloneShortcuts(settings: ProviderSettings): ProviderSettings['sh
 export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 	return {
 		providers: settings.providers.map(cloneProvider),
-		activeProviderId: settings.activeProviderId,
 		defaultModelId: settings.defaultModelId ?? '',
 		defaultProviderId: settings.defaultProviderId ?? '',
 		appearance: {
@@ -57,15 +56,13 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 }
 
 export function providerPayloadFromDraft(draft: ProviderSettings): ProviderSettings {
-	const { defaultProviderId, defaultModelId, activeProviderId } = resolveDefaultModelPair(
+	const { defaultProviderId, defaultModelId } = resolveDefaultModelPair(
 		draft.providers,
 		draft.defaultProviderId,
-		draft.defaultModelId,
-		draft.activeProviderId
+		draft.defaultModelId
 	);
 	return {
 		providers: draft.providers.map(cloneProvider),
-		activeProviderId,
 		defaultModelId,
 		defaultProviderId,
 		appearance: {

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -277,12 +277,11 @@ function createSettingsStore() {
 		}
 	}
 
-	function setActiveProvider(providerId: string) {
+	function setDefaultProvider(providerId: string) {
 		const provider = settings.providers.find((p) => p.id === providerId);
 		const modelId = provider?.enabledModels[0] ?? provider?.selectedModel ?? '';
 		settings = {
 			...settings,
-			activeProviderId: providerId,
 			defaultProviderId: providerId,
 			defaultModelId: modelId || settings.defaultModelId
 		};
@@ -319,14 +318,21 @@ function createSettingsStore() {
 
 	function removeProvider(providerId: string) {
 		const nextProviders = settings.providers.filter((p) => p.id !== providerId);
-		let nextActive = settings.activeProviderId;
-		if (nextActive === providerId) {
-			nextActive = nextProviders[0]?.id ?? '';
+		let nextDefaultProviderId = settings.defaultProviderId;
+		let nextDefaultModelId = settings.defaultModelId;
+		if (nextDefaultProviderId === providerId) {
+			const fallback =
+				nextProviders.find((p) => p.enabled && p.enabledModels.length > 0) ??
+				nextProviders[0];
+			nextDefaultProviderId = fallback?.id ?? '';
+			nextDefaultModelId =
+				fallback?.enabledModels[0] ?? fallback?.selectedModel ?? '';
 		}
 		settings = {
 			...settings,
 			providers: nextProviders,
-			activeProviderId: nextActive
+			defaultProviderId: nextDefaultProviderId,
+			defaultModelId: nextDefaultModelId
 		};
 		modelStore.setProviders(
 			settings.providers,
@@ -335,9 +341,9 @@ function createSettingsStore() {
 		);
 	}
 
-	function getActiveProvider() {
+	function getDefaultProvider() {
 		return (
-			settings.providers.find((p) => p.id === settings.activeProviderId) ??
+			settings.providers.find((p) => p.id === settings.defaultProviderId) ??
 			settings.providers[0]
 		);
 	}
@@ -369,11 +375,11 @@ function createSettingsStore() {
 		saveConfirmCloseOnCmdW,
 		saveConfirmBeforeDeletingChats,
 		saveWebPanelWidth,
-		setActiveProvider,
+		setDefaultProvider,
 		updateProvider,
 		addProvider,
 		removeProvider,
-		getActiveProvider
+		getDefaultProvider
 	};
 }
 

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -278,13 +278,16 @@ function createSettingsStore() {
 	}
 
 	function setActiveProvider(providerId: string) {
-		settings = { ...settings, activeProviderId: providerId };
 		const provider = settings.providers.find((p) => p.id === providerId);
+		const modelId = provider?.enabledModels[0] ?? provider?.selectedModel ?? '';
+		settings = {
+			...settings,
+			activeProviderId: providerId,
+			defaultProviderId: providerId,
+			defaultModelId: modelId || settings.defaultModelId
+		};
 		if (provider) {
-			modelStore.selectByProviderModel(
-				provider.id,
-				provider.enabledModels[0] ?? provider.selectedModel
-			);
+			modelStore.selectByProviderModel(provider.id, modelId);
 		}
 	}
 

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -138,7 +138,6 @@ export interface AppSettings {
 
 export interface ProviderSettings {
 	providers: ProviderConfig[];
-	activeProviderId: string;
 	defaultModelId: string;
 	defaultProviderId: string;
 	appearance: AppearanceSettings;

--- a/cometmind/README.md
+++ b/cometmind/README.md
@@ -373,7 +373,8 @@ Example JSON shape (Cometline writes the full file from Settings):
       "selectedModel": "gpt-4o"
     }
   ],
-  "activeProviderId": "my-gateway",
+  "defaultProviderId": "my-gateway",
+  "defaultModelId": "gpt-4o",
   "cometmind": {
     "systemPromptPath": "/path/to/SOUL.md",
     "memory": { "embedding": { "providerId": "", "model": "" } },

--- a/cometmind/internal/agent/runner.go
+++ b/cometmind/internal/agent/runner.go
@@ -611,13 +611,16 @@ func (r *Runner) extractMemoryAfterTurn(ctx context.Context, turn session.AgentT
 	providerID, model := turn.ProviderID, turn.ModelID
 	llmProvider := r.Provider
 	if r.Config != nil {
-		providerID, model = r.Config.ExtractionLLMForSession(turn.ProviderID, turn.ModelID)
-		if providerID != turn.ProviderID {
-			if p, err := provider.NewFor(r.Config, providerID); err == nil {
-				llmProvider = p
-			} else {
-				logging.L().Warn("memory.extract.provider_failed", "session", turn.ID, "provider", providerID, "error", err)
-			}
+		providerID, model = r.Config.ExtractionLLM()
+		if providerID == "" || model == "" {
+			logging.L().Warn("memory.extract.skipped_no_model", "session", turn.ID)
+			return
+		}
+		if p, err := provider.NewFor(r.Config, providerID); err == nil {
+			llmProvider = p
+		} else {
+			logging.L().Warn("memory.extract.provider_failed", "session", turn.ID, "provider", providerID, "error", err)
+			return
 		}
 	}
 	changes, err := r.Memory.ExtractAfterTurn(ctx, turn.ID, model, llmProvider)

--- a/cometmind/internal/config/adapt_default_test.go
+++ b/cometmind/internal/config/adapt_default_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+func TestAdaptCometlineSettingsPrefersDefaultOverActive(t *testing.T) {
+	cfg, err := adaptCometlineSettings(cometlineSettingsJSON{
+		Providers: []cometlineProviderJSON{
+			{
+				ID: "codex", Name: "Codex", Method: ProviderCodex, Enabled: true,
+				EnabledModels: []string{"gpt-5.4-mini", "gpt-5.4"},
+			},
+			{
+				ID: "opencode-go", Name: "OpenCode Go", Method: ProviderOpencodeGo, Enabled: true,
+				EnabledModels: []string{"deepseek-v4-flash", "qwen3.7-plus"},
+				BaseURL:       "https://opencode.ai/zen/go/v1",
+				APIKey:        "k",
+			},
+		},
+		ActiveProviderID:  "codex",
+		DefaultProviderID: "opencode-go",
+		DefaultModelID:    "deepseek-v4-flash",
+	})
+	if err != nil {
+		t.Fatalf("adaptCometlineSettings() error = %v", err)
+	}
+	if cfg.Provider != "opencode-go" || cfg.DefaultProviderID != "opencode-go" {
+		t.Fatalf("provider = %q/%q, want opencode-go", cfg.Provider, cfg.DefaultProviderID)
+	}
+	if cfg.Model != "deepseek-v4-flash" || cfg.DefaultModelID != "deepseek-v4-flash" {
+		t.Fatalf("model = %q/%q, want deepseek-v4-flash", cfg.Model, cfg.DefaultModelID)
+	}
+}

--- a/cometmind/internal/config/cometline_settings.go
+++ b/cometmind/internal/config/cometline_settings.go
@@ -181,7 +181,7 @@ type cometlineCometmindJSON struct {
 
 type cometlineSettingsJSON struct {
 	Providers         []cometlineProviderJSON `json:"providers"`
-	ActiveProviderID  string                  `json:"activeProviderId"`
+	ActiveProviderID  string                  `json:"activeProviderId,omitempty"` // legacy read-only; stripped on write
 	DefaultProviderID string                  `json:"defaultProviderId"`
 	DefaultModelID    string                  `json:"defaultModelId"`
 	Cometmind         cometlineCometmindJSON  `json:"cometmind"`
@@ -539,7 +539,8 @@ func writeMinimalCometlineSettingsJSON(path string, def *Config) error {
 				SelectedModel: def.Model,
 			},
 		},
-		ActiveProviderID: def.Provider,
+		DefaultProviderID: def.Provider,
+		DefaultModelID:    def.Model,
 		Cometmind: cometlineCometmindJSON{
 			SystemPromptPath:   def.SystemPromptPath,
 			MaxTokens:          def.MaxTokens,

--- a/cometmind/internal/config/cometline_settings.go
+++ b/cometmind/internal/config/cometline_settings.go
@@ -180,9 +180,11 @@ type cometlineCometmindJSON struct {
 }
 
 type cometlineSettingsJSON struct {
-	Providers        []cometlineProviderJSON `json:"providers"`
-	ActiveProviderID string                  `json:"activeProviderId"`
-	Cometmind        cometlineCometmindJSON  `json:"cometmind"`
+	Providers         []cometlineProviderJSON `json:"providers"`
+	ActiveProviderID  string                  `json:"activeProviderId"`
+	DefaultProviderID string                  `json:"defaultProviderId"`
+	DefaultModelID    string                  `json:"defaultModelId"`
+	Cometmind         cometlineCometmindJSON  `json:"cometmind"`
 }
 
 func primaryModel(provider cometlineProviderJSON) string {
@@ -225,18 +227,8 @@ func adaptCometlineSettings(raw cometlineSettingsJSON) (*Config, error) {
 		logging.L().Info("config.no_providers_configured")
 	}
 
-	var active cometlineProviderJSON
 	var providers []ProviderEntry
 	if !noProviders {
-		activeID := strings.TrimSpace(raw.ActiveProviderID)
-		activeIdx := 0
-		for i := range runtimeProviders {
-			if runtimeProviders[i].ID == activeID {
-				activeIdx = i
-				break
-			}
-		}
-		active = runtimeProviders[activeIdx]
 		providers = make([]ProviderEntry, 0, len(runtimeProviders))
 		for _, provider := range runtimeProviders {
 			providers = append(providers, ProviderEntry{
@@ -250,12 +242,16 @@ func adaptCometlineSettings(raw cometlineSettingsJSON) (*Config, error) {
 		}
 	}
 
+	defaultProviderID, defaultModelID, defaultBaseURL := resolveDefaultLLM(raw, runtimeProviders)
+
 	cm := raw.Cometmind
 	memDef := defaultMemoryConfig()
 	cfg := &Config{
-		Provider:           strings.TrimSpace(active.ID),
-		Model:              primaryModel(active),
-		BaseURL:            strings.TrimSpace(active.BaseURL),
+		Provider:           defaultProviderID,
+		Model:              defaultModelID,
+		DefaultProviderID:  defaultProviderID,
+		DefaultModelID:     defaultModelID,
+		BaseURL:            defaultBaseURL,
 		TitleProvider:      strings.TrimSpace(cm.TitleProviderID),
 		TitleModel:         strings.TrimSpace(cm.TitleModelID),
 		MaxTokens:          cm.MaxTokens,
@@ -359,9 +355,17 @@ func adaptCometlineSettings(raw cometlineSettingsJSON) (*Config, error) {
 	}
 	if cfg.Provider == "" && !noProviders {
 		cfg.Provider = def.Provider
+		cfg.DefaultProviderID = def.Provider
 	}
 	if cfg.Model == "" && !noProviders {
 		cfg.Model = def.Model
+		cfg.DefaultModelID = def.Model
+	}
+	if cfg.DefaultProviderID == "" {
+		cfg.DefaultProviderID = cfg.Provider
+	}
+	if cfg.DefaultModelID == "" {
+		cfg.DefaultModelID = cfg.Model
 	}
 	if cfg.MaxTokens == 0 {
 		cfg.MaxTokens = def.MaxTokens
@@ -371,6 +375,40 @@ func adaptCometlineSettings(raw cometlineSettingsJSON) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// resolveDefaultLLM picks the Default model pair. Prefer defaultProviderId +
+// defaultModelId; if Default is empty, migrate from legacy activeProviderId.
+func resolveDefaultLLM(raw cometlineSettingsJSON, runtimeProviders []cometlineProviderJSON) (providerID, modelID, baseURL string) {
+	if len(runtimeProviders) == 0 {
+		return "", "", ""
+	}
+	byID := make(map[string]cometlineProviderJSON, len(runtimeProviders))
+	for _, p := range runtimeProviders {
+		byID[strings.TrimSpace(p.ID)] = p
+	}
+
+	defID := strings.TrimSpace(raw.DefaultProviderID)
+	defModel := strings.TrimSpace(raw.DefaultModelID)
+	if defID != "" {
+		if p, ok := byID[defID]; ok {
+			if defModel == "" {
+				defModel = primaryModel(p)
+			}
+			return defID, defModel, strings.TrimSpace(p.BaseURL)
+		}
+	}
+
+	// Migrate: seed Default from legacy Active when Default is unset/invalid.
+	activeID := strings.TrimSpace(raw.ActiveProviderID)
+	if activeID != "" {
+		if p, ok := byID[activeID]; ok {
+			return activeID, primaryModel(p), strings.TrimSpace(p.BaseURL)
+		}
+	}
+
+	p := runtimeProviders[0]
+	return strings.TrimSpace(p.ID), primaryModel(p), strings.TrimSpace(p.BaseURL)
 }
 
 func normalizeContextWindowLimit(value int) int {

--- a/cometmind/internal/config/config.go
+++ b/cometmind/internal/config/config.go
@@ -75,6 +75,10 @@ type GatewayConfig struct {
 type Config struct {
 	Provider           string               `mapstructure:"provider"`
 	Model              string               `mapstructure:"model"`
+	// DefaultProviderID / DefaultModelID are the global Default model pair.
+	// Provider/Model mirror them for legacy callers after settings adapt.
+	DefaultProviderID  string               `mapstructure:"default_provider_id"`
+	DefaultModelID     string               `mapstructure:"default_model_id"`
 	BaseURL            string               `mapstructure:"base_url"`
 	TitleProvider      string               `mapstructure:"title_provider"`
 	TitleModel         string               `mapstructure:"title_model"`

--- a/cometmind/internal/config/config_test.go
+++ b/cometmind/internal/config/config_test.go
@@ -378,7 +378,7 @@ func TestLoadBootsWithNoEnabledProviders(t *testing.T) {
 	empty := `{"providers":[
 		{"id":"anthropic","name":"Anthropic","method":"anthropic","enabled":false,"baseURL":"https://api.anthropic.com","apiKey":"","selectedModel":"","models":[],"enabledModels":[]},
 		{"id":"openai","name":"OpenAI","method":"openai","enabled":false,"baseURL":"https://api.openai.com/v1","apiKey":"","selectedModel":"","models":[],"enabledModels":[]}
-	],"activeProviderId":"","defaultProviderId":"","defaultModelId":""}`
+	],"defaultProviderId":"","defaultModelId":""}`
 	if err := os.WriteFile(filepath.Join(configDir, "cometline-settings.json"), []byte(empty), 0o600); err != nil {
 		t.Fatalf("write settings: %v", err)
 	}

--- a/cometmind/internal/config/config_test.go
+++ b/cometmind/internal/config/config_test.go
@@ -275,10 +275,13 @@ func TestAdaptCometlineSettingsAutonomyModelOverride(t *testing.T) {
 		t.Fatalf("adaptCometlineSettings() error = %v", err)
 	}
 	if cfg.Provider != "anthropic" {
-		t.Fatalf("Provider = %q, want active provider anthropic", cfg.Provider)
+		t.Fatalf("Provider = %q, want default-from-active anthropic", cfg.Provider)
 	}
 	if cfg.Model != "claude-sonnet-4-20250514" {
-		t.Fatalf("Model = %q, want active model claude-sonnet-4-20250514", cfg.Model)
+		t.Fatalf("Model = %q, want default-from-active model claude-sonnet-4-20250514", cfg.Model)
+	}
+	if cfg.DefaultProviderID != "anthropic" {
+		t.Fatalf("DefaultProviderID = %q, want anthropic", cfg.DefaultProviderID)
 	}
 	if cfg.Autonomy.ProviderID != "codex" {
 		t.Fatalf("Autonomy.ProviderID = %q, want codex", cfg.Autonomy.ProviderID)

--- a/cometmind/internal/config/memory.go
+++ b/cometmind/internal/config/memory.go
@@ -84,6 +84,7 @@ func (c *Config) MemorySettings() memory.Settings {
 		SimilarityThreshold: mc.SimilarityThreshold,
 		ExtractionProvider:  mc.ExtractionProvider,
 		ExtractionModel:     mc.ExtractionModel,
+		DefaultModel: firstNonEmpty(strings.TrimSpace(c.DefaultModelID), strings.TrimSpace(c.Model)),
 		Lifecycle: memory.LifecycleSettings{
 			DecayHalfLifeDays:     mc.Lifecycle.DecayHalfLifeDays,
 			ForgetThreshold:       mc.Lifecycle.ForgetThreshold,
@@ -295,20 +296,24 @@ func (c *Config) memoryConfigured() bool {
 	return c.memoryBehaviorConfigured() || c.memoryEmbeddingConfigured()
 }
 
-// ExtractionLLMForSession returns the provider id and model id to use for memory
-// extraction. Configured extraction provider/model override the session values
-// when set; otherwise the session's own provider/model are used.
-func (c *Config) ExtractionLLMForSession(providerID, modelID string) (string, string) {
-	outProvider := strings.TrimSpace(providerID)
-	outModel := strings.TrimSpace(modelID)
+// ExtractionLLM returns the provider/model pair for memory extraction and
+// compaction. Pinned extraction overrides Default; session is never used.
+func (c *Config) ExtractionLLM() (string, string) {
 	if c == nil {
-		return outProvider, outModel
+		return "", ""
 	}
-	if pid := strings.TrimSpace(c.Memory.ExtractionProvider); pid != "" {
-		outProvider = pid
-	}
-	if model := strings.TrimSpace(c.Memory.ExtractionModel); model != "" {
-		outModel = model
-	}
-	return outProvider, outModel
+	return c.ResolveRoleLLM(c.Memory.ExtractionProvider, c.Memory.ExtractionModel)
+}
+
+// ExtractionLLMForSession is kept for callers that historically passed the
+// session pair. Session values are ignored; resolution is pin else Default.
+func (c *Config) ExtractionLLMForSession(_, _ string) (string, string) {
+	return c.ExtractionLLM()
+}
+
+// MemoryLLMProviderID returns the provider used for memory compaction and the
+// memory service's default LLM (extraction pin else Default).
+func (c *Config) MemoryLLMProviderID() string {
+	providerID, _ := c.ExtractionLLM()
+	return providerID
 }

--- a/cometmind/internal/config/memory_extraction_test.go
+++ b/cometmind/internal/config/memory_extraction_test.go
@@ -4,6 +4,8 @@ import "testing"
 
 func TestExtractionLLMForSessionUsesConfiguredProviderAndModel(t *testing.T) {
 	cfg := &Config{
+		DefaultProviderID: "codex",
+		DefaultModelID:    "gpt-5.4",
 		Memory: MemoryConfig{
 			ExtractionProvider: "opencode-go",
 			ExtractionModel:    "deepseek-v4-flash",
@@ -18,11 +20,40 @@ func TestExtractionLLMForSessionUsesConfiguredProviderAndModel(t *testing.T) {
 	}
 }
 
-func TestExtractionLLMForSessionFallsBackToSession(t *testing.T) {
-	cfg := &Config{Memory: MemoryConfig{}}
+func TestExtractionLLMForSessionFallsBackToDefault(t *testing.T) {
+	cfg := &Config{
+		Provider:          "codex",
+		Model:             "gpt-5.4",
+		DefaultProviderID: "opencode-go",
+		DefaultModelID:    "deepseek-v4-flash",
+		Memory:            MemoryConfig{},
+	}
 	providerID, model := cfg.ExtractionLLMForSession("codex", "gpt-5.4")
-	if providerID != "codex" || model != "gpt-5.4" {
-		t.Fatalf("got provider=%q model=%q, want codex/gpt-5.4", providerID, model)
+	if providerID != "opencode-go" || model != "deepseek-v4-flash" {
+		t.Fatalf("got provider=%q model=%q, want default opencode-go/deepseek-v4-flash", providerID, model)
+	}
+}
+
+func TestMemoryLLMProviderIDPrefersExtractionProvider(t *testing.T) {
+	cfg := &Config{
+		Provider:          "codex",
+		DefaultProviderID: "codex",
+		DefaultModelID:    "gpt-5.4",
+		Memory:            MemoryConfig{ExtractionProvider: "opencode-go", ExtractionModel: "qwen3.7-plus"},
+	}
+	if got := cfg.MemoryLLMProviderID(); got != "opencode-go" {
+		t.Fatalf("MemoryLLMProviderID() = %q, want opencode-go", got)
+	}
+}
+
+func TestMemoryLLMProviderIDFallsBackToDefaultProvider(t *testing.T) {
+	cfg := &Config{
+		Provider:          "codex",
+		DefaultProviderID: "opencode-go",
+		DefaultModelID:    "deepseek-v4-flash",
+	}
+	if got := cfg.MemoryLLMProviderID(); got != "opencode-go" {
+		t.Fatalf("MemoryLLMProviderID() = %q, want opencode-go", got)
 	}
 }
 

--- a/cometmind/internal/config/roles.go
+++ b/cometmind/internal/config/roles.go
@@ -1,0 +1,33 @@
+package config
+
+import "strings"
+
+// ResolveRoleLLM returns the provider/model pair for a helper role (titles,
+// memory extraction/compaction, autonomy, skill synthesis).
+//
+// Pins are atomic: both provider and model must be set, otherwise the Default
+// model pair is used. Never mixes a pinned model with a different provider.
+func (c *Config) ResolveRoleLLM(pinProvider, pinModel string) (providerID, modelID string) {
+	pinProvider = strings.TrimSpace(pinProvider)
+	pinModel = strings.TrimSpace(pinModel)
+	if pinProvider != "" && pinModel != "" {
+		return pinProvider, pinModel
+	}
+	if c == nil {
+		return "", ""
+	}
+	defProvider := strings.TrimSpace(c.DefaultProviderID)
+	defModel := strings.TrimSpace(c.DefaultModelID)
+	if defProvider == "" {
+		defProvider = strings.TrimSpace(c.Provider)
+	}
+	if defModel == "" {
+		defModel = strings.TrimSpace(c.Model)
+	}
+	return defProvider, defModel
+}
+
+// DefaultLLM returns the Default model pair used for new sessions and unpinned roles.
+func (c *Config) DefaultLLM() (providerID, modelID string) {
+	return c.ResolveRoleLLM("", "")
+}

--- a/cometmind/internal/config/roles_test.go
+++ b/cometmind/internal/config/roles_test.go
@@ -1,0 +1,46 @@
+package config
+
+import "testing"
+
+func TestResolveRoleLLMPrefersAtomicPin(t *testing.T) {
+	cfg := &Config{
+		DefaultProviderID: "codex",
+		DefaultModelID:    "gpt-5.4",
+	}
+	providerID, modelID := cfg.ResolveRoleLLM("opencode-go", "qwen3.7-plus")
+	if providerID != "opencode-go" || modelID != "qwen3.7-plus" {
+		t.Fatalf("got %s/%s, want pin", providerID, modelID)
+	}
+}
+
+func TestResolveRoleLLMIgnoresPartialPin(t *testing.T) {
+	cfg := &Config{
+		DefaultProviderID: "codex",
+		DefaultModelID:    "gpt-5.4",
+	}
+	providerID, modelID := cfg.ResolveRoleLLM("opencode-go", "")
+	if providerID != "codex" || modelID != "gpt-5.4" {
+		t.Fatalf("got %s/%s, want default (partial pin ignored)", providerID, modelID)
+	}
+}
+
+func TestResolveRoleLLMFallsBackToDefault(t *testing.T) {
+	cfg := &Config{
+		Provider:          "legacy-active",
+		Model:             "legacy-model",
+		DefaultProviderID: "opencode-go",
+		DefaultModelID:    "deepseek-v4-flash",
+	}
+	providerID, modelID := cfg.ResolveRoleLLM("", "")
+	if providerID != "opencode-go" || modelID != "deepseek-v4-flash" {
+		t.Fatalf("got %s/%s, want default", providerID, modelID)
+	}
+}
+
+func TestResolveRoleLLMMirrorsProviderModelWhenDefaultEmpty(t *testing.T) {
+	cfg := &Config{Provider: "codex", Model: "gpt-5.4"}
+	providerID, modelID := cfg.ResolveRoleLLM("", "")
+	if providerID != "codex" || modelID != "gpt-5.4" {
+		t.Fatalf("got %s/%s, want mirrored Provider/Model", providerID, modelID)
+	}
+}

--- a/cometmind/internal/config/testdata/cometline-settings.json
+++ b/cometmind/internal/config/testdata/cometline-settings.json
@@ -23,7 +23,8 @@
       "enabledModels": ["claude-sonnet-4-5"]
     }
   ],
-  "activeProviderId": "local-llm",
+  "defaultProviderId": "local-llm",
+  "defaultModelId": "qwen2.5",
   "appearance": {
     "heroComposer": {
       "glowColor": "#72c0ff",

--- a/cometmind/internal/memory/compactor.go
+++ b/cometmind/internal/memory/compactor.go
@@ -239,6 +239,10 @@ func (c *compactor) mergeCluster(ctx context.Context, cluster []Record) error {
 			maxWeight = m.BaseWeight
 		}
 	}
+	model := extractionModel(c.settings)
+	if model == "" {
+		return fmt.Errorf("memory compaction requires a model: set Memory extraction model, or configure an active chat model")
+	}
 	prompt := fmt.Sprintf(`Merge these related memories into one concise factual memory. Preserve specific details.
 Return JSON: {"content":"..."}
 
@@ -249,7 +253,7 @@ Memories:
 		Content string `json:"content"`
 	}
 	req := &cometsdk.Request{
-		Model:  extractionModel(c.settings),
+		Model:  model,
 		System: "You consolidate memories. Output JSON only.",
 		Messages: []cometsdk.Message{{
 			Role:    cometsdk.RoleUser,
@@ -302,5 +306,5 @@ func extractionModel(s Settings) string {
 	if strings.TrimSpace(s.ExtractionModel) != "" {
 		return s.ExtractionModel
 	}
-	return "claude-sonnet-4-5"
+	return strings.TrimSpace(s.DefaultModel)
 }

--- a/cometmind/internal/memory/compactor_test.go
+++ b/cometmind/internal/memory/compactor_test.go
@@ -85,3 +85,15 @@ func TestRunLifecycleNotifiesAutomaticCompaction(t *testing.T) {
 		t.Fatalf("unexpected notification: %+v", notified)
 	}
 }
+
+func TestExtractionModelPrefersPinnedThenFallback(t *testing.T) {
+	if got := extractionModel(Settings{ExtractionModel: "qwen3.7-plus", DefaultModel: "gpt-5.4"}); got != "qwen3.7-plus" {
+		t.Fatalf("got %q, want pinned extraction model", got)
+	}
+	if got := extractionModel(Settings{DefaultModel: "gpt-5.4"}); got != "gpt-5.4" {
+		t.Fatalf("got %q, want default chat model", got)
+	}
+	if got := extractionModel(Settings{}); got != "" {
+		t.Fatalf("got %q, want empty when no model is configured", got)
+	}
+}

--- a/cometmind/internal/memory/config.go
+++ b/cometmind/internal/memory/config.go
@@ -10,8 +10,11 @@ type Settings struct {
 	SimilarityThreshold float64
 	ExtractionProvider  string
 	ExtractionModel     string
-	Lifecycle           LifecycleSettings
-	Embedding           EmbeddingSettings
+	// DefaultModel is the Default chat model, used by compaction when
+	// ExtractionModel is unset (compaction has no session model to inherit).
+	DefaultModel string
+	Lifecycle    LifecycleSettings
+	Embedding    EmbeddingSettings
 }
 
 // LifecycleSettings controls decay, forget, and compaction.

--- a/cometmind/internal/provider/factory.go
+++ b/cometmind/internal/provider/factory.go
@@ -77,6 +77,13 @@ func New(cfg *config.Config) (cometsdk.Provider, error) {
 	return NewFor(cfg, cfg.Provider)
 }
 
+// NewMemoryLLM returns the provider used for memory compaction and default
+// extraction/update LLM calls. It respects Memory.ExtractionProvider when set
+// so compaction does not send a pinned extraction model to the wrong backend.
+func NewMemoryLLM(cfg *config.Config) (cometsdk.Provider, error) {
+	return NewFor(cfg, cfg.MemoryLLMProviderID())
+}
+
 // NewFor returns a concrete SDK provider for a specific provider id.
 func NewFor(cfg *config.Config, id string) (cometsdk.Provider, error) {
 	entry, method, baseURL := providerConfigFor(cfg, id)

--- a/cometmind/internal/provider/factory_test.go
+++ b/cometmind/internal/provider/factory_test.go
@@ -38,6 +38,36 @@ func TestNewForFallsBackToLegacyMethod(t *testing.T) {
 	}
 }
 
+func TestNewMemoryLLMUsesExtractionProvider(t *testing.T) {
+	cfg := &config.Config{
+		Provider: config.ProviderCodex,
+		Providers: []config.ProviderEntry{
+			{ID: "codex", Method: config.ProviderCodex},
+			{
+				ID:      "opencode-go",
+				Method:  config.ProviderOpencodeGo,
+				APIKey:  "opencode-key",
+				BaseURL: "http://example.com/v1",
+				Model:   "qwen3.7-plus",
+			},
+		},
+		Memory: config.MemoryConfig{
+			ExtractionProvider: "opencode-go",
+			ExtractionModel:    "qwen3.7-plus",
+		},
+	}
+	p, err := NewMemoryLLM(cfg)
+	if err != nil {
+		t.Fatalf("NewMemoryLLM() error = %v", err)
+	}
+	if p == nil {
+		t.Fatal("NewMemoryLLM() returned nil")
+	}
+	if family := SDKFamily(cfg, cfg.MemoryLLMProviderID()); family != config.ProviderOpenAI {
+		t.Fatalf("memory LLM family = %q, want openai (opencode-go), not active codex", family)
+	}
+}
+
 func TestNewForUsesMultiProviderEntry(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "entry-key")
 

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -107,7 +107,7 @@ func New(ctx context.Context) (*Runtime, error) {
 	r.Inbox = inbox.NewService(sqlDB)
 	r.Scheduler = scheduler.NewService(sqlDB)
 	if cfg.MemoryRuntimeEnabled() {
-		p, err := provider.New(cfg)
+		p, err := provider.NewMemoryLLM(cfg)
 		if err != nil {
 			logging.L().Warn("memory.provider.init_failed",
 				"error", err,
@@ -124,14 +124,7 @@ func New(ctx context.Context) (*Runtime, error) {
 		}
 	}
 	if cfg.Skills.SynthesisEnabled {
-		providerID := strings.TrimSpace(cfg.Skills.SynthesisProviderID)
-		if providerID == "" {
-			providerID = cfg.Provider
-		}
-		model := strings.TrimSpace(cfg.Skills.SynthesisModel)
-		if model == "" {
-			model = cfg.Model
-		}
+		providerID, model := cfg.ResolveRoleLLM(cfg.Skills.SynthesisProviderID, cfg.Skills.SynthesisModel)
 		p, err := provider.NewFor(cfg, providerID)
 		if err != nil {
 			logging.L().Warn("skills.synthesis.provider.init_failed", "error", err)
@@ -469,20 +462,16 @@ func (r *Runtime) autonomyProviderID() string {
 	if r == nil || r.Config == nil {
 		return ""
 	}
-	if providerID := strings.TrimSpace(r.Config.Autonomy.ProviderID); providerID != "" {
-		return providerID
-	}
-	return r.Config.Provider
+	providerID, _ := r.Config.ResolveRoleLLM(r.Config.Autonomy.ProviderID, r.Config.Autonomy.ModelID)
+	return providerID
 }
 
 func (r *Runtime) autonomyModelID() string {
 	if r == nil || r.Config == nil {
 		return ""
 	}
-	if modelID := strings.TrimSpace(r.Config.Autonomy.ModelID); modelID != "" {
-		return modelID
-	}
-	return r.Config.Model
+	_, modelID := r.Config.ResolveRoleLLM(r.Config.Autonomy.ProviderID, r.Config.Autonomy.ModelID)
+	return modelID
 }
 
 func (r *Runtime) jobSettingsSnapshot() jobs.Settings {
@@ -570,7 +559,7 @@ func (r *Runtime) reloadMemory(cfg *config.Config) error {
 		}
 		return nil
 	}
-	p, err := provider.New(cfg)
+	p, err := provider.NewMemoryLLM(cfg)
 	if err != nil {
 		return fmt.Errorf("reload memory provider: %w", err)
 	}
@@ -596,20 +585,16 @@ func (r *Runtime) autonomyProviderIDFrom(cfg *config.Config) string {
 	if cfg == nil {
 		return ""
 	}
-	if providerID := strings.TrimSpace(cfg.Autonomy.ProviderID); providerID != "" {
-		return providerID
-	}
-	return cfg.Provider
+	providerID, _ := cfg.ResolveRoleLLM(cfg.Autonomy.ProviderID, cfg.Autonomy.ModelID)
+	return providerID
 }
 
 func (r *Runtime) autonomyModelIDFrom(cfg *config.Config) string {
 	if cfg == nil {
 		return ""
 	}
-	if modelID := strings.TrimSpace(cfg.Autonomy.ModelID); modelID != "" {
-		return modelID
-	}
-	return cfg.Model
+	_, modelID := cfg.ResolveRoleLLM(cfg.Autonomy.ProviderID, cfg.Autonomy.ModelID)
+	return modelID
 }
 
 // WorkspaceForCommand resolves the current directory (or the explicit workspace

--- a/cometmind/internal/runtime/runtime_test.go
+++ b/cometmind/internal/runtime/runtime_test.go
@@ -92,7 +92,7 @@ func TestRuntimeReloadUpdatesSystemPromptFromSettings(t *testing.T) {
 	}
 	writeSettings := func(promptPath string) {
 		t.Helper()
-		body := []byte(`{"providers":[{"id":"anthropic","name":"Anthropic","method":"anthropic","enabled":true,"apiKey":"test-key","selectedModel":"claude-sonnet-4-5","models":["claude-sonnet-4-5"],"enabledModels":["claude-sonnet-4-5"]}],"activeProviderId":"anthropic","cometmind":{"systemPromptPath":"` + promptPath + `"}}`)
+		body := []byte(`{"providers":[{"id":"anthropic","name":"Anthropic","method":"anthropic","enabled":true,"apiKey":"test-key","selectedModel":"claude-sonnet-4-5","models":["claude-sonnet-4-5"],"enabledModels":["claude-sonnet-4-5"]}],"defaultProviderId":"anthropic","defaultModelId":"claude-sonnet-4-5","cometmind":{"systemPromptPath":"` + promptPath + `"}}`)
 		if err := os.WriteFile(settingsPath, body, 0o600); err != nil {
 			t.Fatalf("write settings: %v", err)
 		}

--- a/cometmind/internal/settingsapply/classify.go
+++ b/cometmind/internal/settingsapply/classify.go
@@ -35,7 +35,6 @@ func Catalog() []FieldMeta {
 	return []FieldMeta{
 		{Path: "providers", Secret: false, ApplyClass: ApplyReload, Description: "LLM provider configs (API keys are secret leaf fields)"},
 		{Path: "providers[].apiKey", Secret: true, ApplyClass: ApplyReload, Description: "Provider API key"},
-		{Path: "activeProviderId", Secret: false, ApplyClass: ApplyReload, Description: "Active provider id"},
 		{Path: "defaultModelId", Secret: false, ApplyClass: ApplyReload, Description: "Default model id for new sessions"},
 		{Path: "defaultProviderId", Secret: false, ApplyClass: ApplyReload, Description: "Default provider id for new sessions"},
 		{Path: "cometmind.acp", Secret: false, ApplyClass: ApplyReload, Description: "Coding-harness delegation"},
@@ -121,7 +120,7 @@ func Classify(before, after map[string]any) (ClassifyResult, error) {
 	cometmindSansGatewayEqual := equalSans(before["cometmind"], after["cometmind"], "gateway")
 	providersEqual := canonicalizeEqual(before["providers"], after["providers"])
 	otherTopEqual := true
-	for _, key := range []string{"activeProviderId", "defaultModelId", "defaultProviderId"} {
+	for _, key := range []string{"defaultModelId", "defaultProviderId"} {
 		if changedAt(before, after, key) {
 			otherTopEqual = false
 			break
@@ -131,7 +130,7 @@ func Classify(before, after map[string]any) (ClassifyResult, error) {
 	// as reload-worthy when they change.
 	for k := range after {
 		switch k {
-		case "providers", "activeProviderId", "defaultModelId", "defaultProviderId", "cometmind", "appearance", "shortcuts", "app":
+		case "providers", "defaultModelId", "defaultProviderId", "cometmind", "appearance", "shortcuts", "app":
 			continue
 		default:
 			if changedAt(before, after, k) {

--- a/cometmind/internal/settingsapply/legacy.go
+++ b/cometmind/internal/settingsapply/legacy.go
@@ -1,0 +1,39 @@
+package settingsapply
+
+import "strings"
+
+// RewriteLegacyActiveProviderPatch remaps deprecated activeProviderId in a
+// patch onto defaultProviderId when the patch does not set Default explicitly.
+func RewriteLegacyActiveProviderPatch(patch map[string]any) {
+	if patch == nil {
+		return
+	}
+	active, ok := patch["activeProviderId"]
+	if !ok {
+		return
+	}
+	if _, hasDefault := patch["defaultProviderId"]; !hasDefault {
+		if s, ok := active.(string); ok && strings.TrimSpace(s) != "" {
+			patch["defaultProviderId"] = strings.TrimSpace(s)
+		}
+	}
+	delete(patch, "activeProviderId")
+}
+
+// NormalizeLegacyActiveProvider migrates deprecated activeProviderId into
+// defaultProviderId when Default is empty, then strips activeProviderId so
+// writes no longer persist the legacy field.
+func NormalizeLegacyActiveProvider(doc map[string]any) map[string]any {
+	if doc == nil {
+		return map[string]any{}
+	}
+	active, _ := doc["activeProviderId"].(string)
+	active = strings.TrimSpace(active)
+	def, _ := doc["defaultProviderId"].(string)
+	def = strings.TrimSpace(def)
+	if def == "" && active != "" {
+		doc["defaultProviderId"] = active
+	}
+	delete(doc, "activeProviderId")
+	return doc
+}

--- a/cometmind/internal/settingsapply/legacy_test.go
+++ b/cometmind/internal/settingsapply/legacy_test.go
@@ -1,0 +1,56 @@
+package settingsapply
+
+import "testing"
+
+func TestNormalizeLegacyActiveProviderMigratesAndStrips(t *testing.T) {
+	doc := map[string]any{
+		"activeProviderId":  "codex",
+		"defaultProviderId": "",
+	}
+	got := NormalizeLegacyActiveProvider(doc)
+	if got["defaultProviderId"] != "codex" {
+		t.Fatalf("defaultProviderId = %v, want codex", got["defaultProviderId"])
+	}
+	if _, ok := got["activeProviderId"]; ok {
+		t.Fatal("activeProviderId should be stripped")
+	}
+}
+
+func TestNormalizeLegacyActiveProviderKeepsExplicitDefault(t *testing.T) {
+	doc := map[string]any{
+		"activeProviderId":  "codex",
+		"defaultProviderId": "opencode-go",
+	}
+	got := NormalizeLegacyActiveProvider(doc)
+	if got["defaultProviderId"] != "opencode-go" {
+		t.Fatalf("defaultProviderId = %v, want opencode-go", got["defaultProviderId"])
+	}
+	if _, ok := got["activeProviderId"]; ok {
+		t.Fatal("activeProviderId should be stripped")
+	}
+}
+
+func TestRewriteLegacyActiveProviderPatch(t *testing.T) {
+	patch := map[string]any{"activeProviderId": "anthropic"}
+	RewriteLegacyActiveProviderPatch(patch)
+	if patch["defaultProviderId"] != "anthropic" {
+		t.Fatalf("defaultProviderId = %v, want anthropic", patch["defaultProviderId"])
+	}
+	if _, ok := patch["activeProviderId"]; ok {
+		t.Fatal("activeProviderId should be removed from patch")
+	}
+}
+
+func TestRewriteLegacyActiveProviderPatchKeepsExplicitDefault(t *testing.T) {
+	patch := map[string]any{
+		"activeProviderId":  "codex",
+		"defaultProviderId": "opencode-go",
+	}
+	RewriteLegacyActiveProviderPatch(patch)
+	if patch["defaultProviderId"] != "opencode-go" {
+		t.Fatalf("defaultProviderId = %v, want opencode-go", patch["defaultProviderId"])
+	}
+	if _, ok := patch["activeProviderId"]; ok {
+		t.Fatal("activeProviderId should be removed from patch")
+	}
+}

--- a/cometmind/internal/tools/settings_tools.go
+++ b/cometmind/internal/tools/settings_tools.go
@@ -117,6 +117,7 @@ func (t patchSettingsTool) Execute(ctx context.Context, input json.RawMessage) (
 	if in.Patch == nil {
 		return Result{OK: false, Output: "patch is required"}, nil
 	}
+	settingsapply.RewriteLegacyActiveProviderPatch(in.Patch)
 	if desktopKeys := settingsapply.DesktopKeysInPatch(in.Patch); len(desktopKeys) > 0 {
 		return Result{OK: false, Output: settingsapply.FormatUnsupported(desktopKeys)}, nil
 	}
@@ -129,8 +130,10 @@ func (t patchSettingsTool) Execute(ctx context.Context, input json.RawMessage) (
 	merged := settingsapply.MergePatch(before, in.Patch)
 	settingsapply.RestoreSecretsInProviders(merged, before)
 	merged = settingsapply.StripDesktopKeys(merged)
+	beforeNorm := settingsapply.NormalizeLegacyActiveProvider(cloneSettingsDoc(before))
+	merged = settingsapply.NormalizeLegacyActiveProvider(merged)
 
-	plan, err := settingsapply.Classify(before, merged)
+	plan, err := settingsapply.Classify(beforeNorm, merged)
 	if err != nil {
 		return Result{OK: false, Output: err.Error()}, nil
 	}
@@ -233,6 +236,25 @@ func encodeSettingsJSON(doc map[string]any) ([]byte, error) {
 	}
 	b = append(b, '\n')
 	return b, nil
+}
+
+func cloneSettingsDoc(doc map[string]any) map[string]any {
+	if doc == nil {
+		return map[string]any{}
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		out := make(map[string]any, len(doc))
+		for k, v := range doc {
+			out[k] = v
+		}
+		return out
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return map[string]any{}
+	}
+	return out
 }
 
 func valueAtPath(doc map[string]any, path string) (any, error) {

--- a/cometmind/internal/tools/settings_tools_test.go
+++ b/cometmind/internal/tools/settings_tools_test.go
@@ -38,7 +38,8 @@ func TestSettingsToolsParentOnlyAndRedactionRoundTrip(t *testing.T) {
 				"enabledModels": []any{"gpt-4o"},
 			},
 		},
-		"activeProviderId": "openai",
+		"defaultProviderId": "openai",
+		"defaultModelId": "gpt-4o",
 		"cometmind": map[string]any{
 			"systemPromptPath":   "",
 			"maxTokens":          4096,

--- a/cometmind/server/memory_handlers.go
+++ b/cometmind/server/memory_handlers.go
@@ -5,7 +5,9 @@ import (
 	"strconv"
 
 	"github.com/cometline/cometmind/internal/config"
+	"github.com/cometline/cometmind/internal/logging"
 	"github.com/cometline/cometmind/internal/memory"
+	"github.com/cometline/cometmind/internal/provider"
 	"github.com/gin-gonic/gin"
 )
 
@@ -207,6 +209,11 @@ func (a *App) handlePutMemorySettings(c *gin.Context) {
 		if err := a.memory.UpdateSettings(a.config.MemorySettings()); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
+		}
+		if p, err := provider.NewMemoryLLM(a.config); err != nil {
+			logging.L().Warn("memory.settings.provider_refresh_failed", "error", err)
+		} else {
+			a.memory.SetProvider(p)
 		}
 		c.JSON(http.StatusOK, a.config.EffectiveMemoryConfig())
 		return

--- a/cometmind/server/title.go
+++ b/cometmind/server/title.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -70,15 +71,11 @@ func (a *App) generateTitleAsync(ctx context.Context, sess session.Session, mess
 
 // generateTitleLLM asks an LLM for a concise title for the message. It uses the
 // configured title provider/model when set (typically a cheaper, faster model),
-// falling back to the session's own provider/model otherwise.
+// falling back to the Default model pair otherwise.
 func (a *App) generateTitleLLM(ctx context.Context, sess session.Session, message string) (string, error) {
-	providerID := strings.TrimSpace(a.config.TitleProvider)
-	if providerID == "" {
-		providerID = sess.ProviderID
-	}
-	model := strings.TrimSpace(a.config.TitleModel)
-	if model == "" {
-		model = sess.ModelID
+	providerID, model := a.config.ResolveRoleLLM(a.config.TitleProvider, a.config.TitleModel)
+	if providerID == "" || model == "" {
+		return "", fmt.Errorf("title generation requires a Default model or a pinned title model")
 	}
 
 	p, err := provider.NewFor(a.config, providerID)

--- a/docs/learning/07-cometline-desktop.md
+++ b/docs/learning/07-cometline-desktop.md
@@ -137,7 +137,7 @@ Key sections:
 
 | File | Section | Contents |
 |------|---------|----------|
-| settings | `providers[]`, `activeProviderId`, `defaultModelId` / `defaultProviderId` | Provider configs and default model roles |
+| settings | `providers[]`, `defaultModelId` / `defaultProviderId` | Provider configs and default model roles |
 | settings | `cometmind` | maxTokens, ACP/harness, MCP, memory, jobs, autonomy, scheduler, storage, gateway |
 | desktop | `appearance` | Hero glow, caret trail, … |
 | desktop | `shortcuts` | Keyboard bindings |


### PR DESCRIPTION
## Background

Role-based LLMs still drifted toward an Active provider after Default became the only model role source of truth, and chrome icon buttons still used hardcoded `title` shortcut hints. This branch pins unpinned roles to Default, drops legacy `activeProviderId` from settings, and adds live viewport-clamped shortcut tooltips.

[fc13480](https://github.com/Cometline/cometline/commit/fc1348096ddb0bcbeb6f3cf0e858e3bdf37edeb2): Extraction, compaction, and other unpinned roles now resolve from the Default model instead of Active, so provider and model stay paired.

[87de51d](https://github.com/Cometline/cometline/commit/87de51d601ab2dfb2022f9cd02845d8532a72e5e): Settings migrate leftover `activeProviderId` into Default on read and stop writing it, keeping the desktop schema aligned with Default-only roles.

[80322d0](https://github.com/Cometline/cometline/commit/80322d091effbfc55126a068e3225b7466044ef0): Chrome and mini-window icon buttons use a portaled Tooltip with live `formatShortcut` bindings, and the thinking wait indicator is vertically aligned with its detail text.


Made with [Cursor](https://cursor.com)