### PR TITLE
[main] fix: reset thread state on session change

### DIFF
--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -392,14 +392,16 @@
 			class:docked={!heroLayout}
 			in:fade={firstTurnActive ? { duration: 0 } : THREAD_IN}
 		>
-			<ChatThread
-				{sessionId}
-				{awaitingFirstAssistant}
-				{firstTurnFlightDone}
-				{firstTurnHandoffPending}
-				onNotifyAgent={submit}
-				onStartJob={startJobFromCard}
-			/>
+			{#key sessionId}
+				<ChatThread
+					{sessionId}
+					{awaitingFirstAssistant}
+					{firstTurnFlightDone}
+					{firstTurnHandoffPending}
+					onNotifyAgent={submit}
+					onStartJob={startJobFromCard}
+				/>
+			{/key}
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Background

Forking a session reuses historical transcript row keys while the chat view remains mounted. Session-local row and scroll transition state can therefore survive into the fork until a full page refresh.

[871ad27](https://github.com/Cometline/cometline/commit/871ad27f9f4ff10aa5f652bc338d68a766583d94): Key `ChatThread` by session ID so fork navigation remounts session-local presentation state without stopping background streams.