### PR TITLE
[main] feat: gate skill drafts on managed overlap

### DIFF
--- a/cometmind/internal/skills/drafts.go
+++ b/cometmind/internal/skills/drafts.go
@@ -148,6 +148,15 @@ func WriteDraft(name, content string, overwrite bool) error {
 	return os.WriteFile(skillPath, []byte(content), 0o644)
 }
 
+// SkillMarkdownDescription returns the YAML description field from SKILL.md content.
+func SkillMarkdownDescription(content string) string {
+	fm, _, err := parseFrontmatter(content)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(fm.Description)
+}
+
 // PromoteDraft validates and copies a draft into ~/.cometmind/skills, then removes it.
 func PromoteDraft(name string) error {
 	_, content, err := DraftMarkdown(name)

--- a/cometmind/internal/skills/overlap.go
+++ b/cometmind/internal/skills/overlap.go
@@ -1,0 +1,313 @@
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Overlap thresholds (strict first; raise to loosen false positives).
+const (
+	overlapNameJaccardThreshold = 0.5
+	overlapDescJaccardThreshold = 0.4
+	overlapBlockThreshold       = 0.4
+	overlapMaxResults           = 5
+)
+
+const (
+	OverlapLocationLive  = "live"
+	OverlapLocationDraft = "draft"
+
+	OverlapKindExactName          = "exact_name"
+	OverlapKindSimilarName        = "similar_name"
+	OverlapKindSimilarDescription = "similar_description"
+)
+
+// RelatedSkill is one managed live skill or pending draft that may overlap a proposal.
+type RelatedSkill struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Location    string  `json:"location"` // live | draft
+	Kind        string  `json:"kind"`
+	Score       float64 `json:"score"`
+}
+
+type managedSkillEntry struct {
+	Name        string
+	Description string
+	Location    string
+}
+
+// FindRelatedManagedSkills compares name+description against ~/.cometmind/skills
+// and ~/.cometmind/skill-drafts only (not workspace or builtin discovery roots).
+func FindRelatedManagedSkills(name, description string) ([]RelatedSkill, error) {
+	name = strings.TrimSpace(name)
+	description = strings.TrimSpace(description)
+	if name == "" && description == "" {
+		return nil, nil
+	}
+
+	entries, err := listManagedSkillEntries()
+	if err != nil {
+		return nil, err
+	}
+
+	var related []RelatedSkill
+	for _, entry := range entries {
+		if hit, ok := scoreRelated(name, description, entry); ok {
+			related = append(related, hit)
+		}
+	}
+	sort.SliceStable(related, func(i, j int) bool {
+		if related[i].Score == related[j].Score {
+			return related[i].Name < related[j].Name
+		}
+		return related[i].Score > related[j].Score
+	})
+	if len(related) > overlapMaxResults {
+		related = related[:overlapMaxResults]
+	}
+	return related, nil
+}
+
+// ShouldBlockOverlap reports whether related entries are strong enough to gate a new draft.
+func ShouldBlockOverlap(related []RelatedSkill) bool {
+	for _, r := range related {
+		if r.Score >= overlapBlockThreshold {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterSelfDraftOverwrite drops the exact-name draft match for name when overwrite
+// is updating that same pending draft.
+func FilterSelfDraftOverwrite(related []RelatedSkill, name string, overwrite bool) []RelatedSkill {
+	if !overwrite {
+		return related
+	}
+	name = strings.TrimSpace(name)
+	out := make([]RelatedSkill, 0, len(related))
+	for _, r := range related {
+		if r.Location == OverlapLocationDraft && r.Kind == OverlapKindExactName && r.Name == name {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func listManagedSkillEntries() ([]managedSkillEntry, error) {
+	var entries []managedSkillEntry
+
+	mirror, err := MirrorRoot()
+	if err != nil {
+		return nil, err
+	}
+	live, err := readSkillEntriesFromRoot(mirror, OverlapLocationLive)
+	if err != nil {
+		return nil, err
+	}
+	entries = append(entries, live...)
+
+	drafts, err := ListDrafts()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range drafts {
+		entries = append(entries, managedSkillEntry{
+			Name:        d.Name,
+			Description: d.Description,
+			Location:    OverlapLocationDraft,
+		})
+	}
+	return entries, nil
+}
+
+func readSkillEntriesFromRoot(root, location string) ([]managedSkillEntry, error) {
+	dirEntries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]managedSkillEntry, 0, len(dirEntries))
+	for _, entry := range dirEntries {
+		name := entry.Name()
+		if !ValidSkillName(name) {
+			continue
+		}
+		raw, readErr := os.ReadFile(filepath.Join(root, name, "SKILL.md"))
+		if readErr != nil {
+			continue
+		}
+		fm, _, parseErr := parseFrontmatter(string(raw))
+		if parseErr != nil {
+			continue
+		}
+		skillName := strings.TrimSpace(fm.Name)
+		if skillName == "" {
+			skillName = name
+		}
+		out = append(out, managedSkillEntry{
+			Name:        skillName,
+			Description: strings.TrimSpace(fm.Description),
+			Location:    location,
+		})
+	}
+	return out, nil
+}
+
+func scoreRelated(name, description string, entry managedSkillEntry) (RelatedSkill, bool) {
+	best := RelatedSkill{}
+	found := false
+
+	if name != "" && strings.EqualFold(name, entry.Name) {
+		best = RelatedSkill{
+			Name:        entry.Name,
+			Description: entry.Description,
+			Location:    entry.Location,
+			Kind:        OverlapKindExactName,
+			Score:       1.0,
+		}
+		return best, true
+	}
+
+	if name != "" && entry.Name != "" {
+		if score, ok := nameSimilarity(name, entry.Name); ok && score >= overlapNameJaccardThreshold {
+			best = RelatedSkill{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Location:    entry.Location,
+				Kind:        OverlapKindSimilarName,
+				Score:       score,
+			}
+			found = true
+		}
+	}
+
+	if description != "" && entry.Description != "" {
+		descScore := jaccard(tokenizeWords(description), tokenizeWords(entry.Description))
+		if descScore >= overlapDescJaccardThreshold && descScore > best.Score {
+			best = RelatedSkill{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Location:    entry.Location,
+				Kind:        OverlapKindSimilarDescription,
+				Score:       descScore,
+			}
+			found = true
+		}
+	}
+
+	return best, found
+}
+
+func nameSimilarity(a, b string) (float64, bool) {
+	ta := tokenizeName(a)
+	tb := tokenizeName(b)
+	if len(ta) == 0 || len(tb) == 0 {
+		return 0, false
+	}
+	jac := jaccard(ta, tb)
+	cont := nameContainmentScore(ta, tb)
+	score := jac
+	if cont > score {
+		score = cont
+	}
+	if score < overlapNameJaccardThreshold {
+		return score, false
+	}
+	return score, true
+}
+
+// nameContainmentScore is 1.0 when the smaller token set is fully contained in the larger
+// (specialization like pr-review ⊂ go-pr-review), otherwise 0.
+func nameContainmentScore(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	smaller, larger := a, b
+	if len(b) < len(a) {
+		smaller, larger = b, a
+	}
+	for tok := range smaller {
+		if _, ok := larger[tok]; !ok {
+			return 0
+		}
+	}
+	return 1.0
+}
+
+func jaccard(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for tok := range a {
+		if _, ok := b[tok]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+func tokenizeName(name string) map[string]struct{} {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "_", "-")
+	parts := strings.Split(name, "-")
+	out := make(map[string]struct{}, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+func tokenizeWords(text string) map[string]struct{} {
+	text = strings.ToLower(strings.TrimSpace(text))
+	out := make(map[string]struct{})
+	var b strings.Builder
+	flush := func() {
+		w := b.String()
+		b.Reset()
+		if len(w) < 2 {
+			return
+		}
+		out[w] = struct{}{}
+	}
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
+}
+
+// FormatOverlapBlock formats related skills for tool / log messages.
+func FormatOverlapBlock(related []RelatedSkill) string {
+	if len(related) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Possible overlapping managed skills/drafts:\n")
+	for _, r := range related {
+		fmt.Fprintf(&b, "- %s (%s, %s, score=%.2f): %s\n", r.Name, r.Location, r.Kind, r.Score, r.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cometmind/internal/skills/overlap_test.go
+++ b/cometmind/internal/skills/overlap_test.go
@@ -1,0 +1,127 @@
+package skills
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNameContainmentGoPRReview(t *testing.T) {
+	score, ok := nameSimilarity("go-pr-review", "pr-review")
+	if !ok || score < overlapBlockThreshold {
+		t.Fatalf("nameSimilarity(go-pr-review, pr-review) = %v, %v; want block-level containment", score, ok)
+	}
+}
+
+func TestFindRelatedManagedSkillsExactAndDescription(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	live := `---
+name: terraform-apply-guardrails
+description: plan validate apply terraform and handle provider auth failures
+---
+
+Body.
+`
+	if err := WriteSkill("terraform-apply-guardrails", live, false); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+
+	related, err := FindRelatedManagedSkills(
+		"tf-provider-auth-recovery",
+		"plan validate apply terraform and handle provider auth failures on recovery",
+	)
+	if err != nil {
+		t.Fatalf("FindRelatedManagedSkills: %v", err)
+	}
+	if !ShouldBlockOverlap(related) {
+		t.Fatalf("expected description overlap to block, got %+v", related)
+	}
+	found := false
+	for _, r := range related {
+		if r.Name == "terraform-apply-guardrails" && r.Location == OverlapLocationLive {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected live terraform skill in related: %+v", related)
+	}
+}
+
+func TestFindRelatedManagedSkillsIgnoresWorkspaceOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ws := t.TempDir()
+	writeSkill(t, filepath.Join(ws, ".agents", "skills"), "workspace-only", "only in workspace review pull requests")
+
+	related, err := FindRelatedManagedSkills("repo-pr-review", "only in workspace review pull requests carefully")
+	if err != nil {
+		t.Fatalf("FindRelatedManagedSkills: %v", err)
+	}
+	for _, r := range related {
+		if r.Name == "workspace-only" {
+			t.Fatalf("workspace skill must not be in managed overlap: %+v", related)
+		}
+	}
+}
+
+func TestFindRelatedManagedSkillsUnrelated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	content := `---
+name: commit-conventions
+description: Write conventional commit messages for this monorepo
+---
+
+Body.
+`
+	if err := WriteSkill("commit-conventions", content, false); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+	related, err := FindRelatedManagedSkills("docker-build-cache", "Tune Docker layer caching for CI builds")
+	if err != nil {
+		t.Fatalf("FindRelatedManagedSkills: %v", err)
+	}
+	if ShouldBlockOverlap(related) {
+		t.Fatalf("unrelated skills should not block: %+v", related)
+	}
+}
+
+func TestFilterSelfDraftOverwrite(t *testing.T) {
+	related := []RelatedSkill{
+		{Name: "retry-policy", Location: OverlapLocationDraft, Kind: OverlapKindExactName, Score: 1},
+		{Name: "other", Location: OverlapLocationLive, Kind: OverlapKindSimilarDescription, Score: 0.5},
+	}
+	filtered := FilterSelfDraftOverwrite(related, "retry-policy", true)
+	if len(filtered) != 1 || filtered[0].Name != "other" {
+		t.Fatalf("FilterSelfDraftOverwrite = %+v", filtered)
+	}
+	if got := FilterSelfDraftOverwrite(related, "retry-policy", false); len(got) != 2 {
+		t.Fatalf("overwrite=false should keep all, got %+v", got)
+	}
+}
+
+func TestFindRelatedManagedSkillsNameContainmentViaLive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	content := `---
+name: pr-review
+description: Review pull requests for this repository
+---
+
+Body.
+`
+	if err := WriteSkill("pr-review", content, false); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+	related, err := FindRelatedManagedSkills("go-pr-review", "Specialized Go pull request checklist")
+	if err != nil {
+		t.Fatalf("FindRelatedManagedSkills: %v", err)
+	}
+	if !ShouldBlockOverlap(related) {
+		t.Fatalf("expected name containment to block, got %+v", related)
+	}
+	if related[0].Kind != OverlapKindSimilarName && related[0].Kind != OverlapKindExactName {
+		t.Fatalf("expected similar_name, got %+v", related[0])
+	}
+}

--- a/cometmind/internal/skills/skills.go
+++ b/cometmind/internal/skills/skills.go
@@ -202,7 +202,11 @@ func (r Registry) PromptIndex() string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString("\n\n## Available Skills\nUse `load_skill` when the user's task matches one of these skills. Load the full skill before following it; do not assume details from the summary alone.\nIf a request is vague or ambiguous but plausibly falls within a skill's domain, proactively mention the relevant skill and offer to use it before asking for more detail or guessing — for example: \"I have a skill called `setup-cometline` that handles this; want me to use it?\"\n")
+	b.WriteString("\n\n## Available Skills\n")
+	b.WriteString("Use `load_skill` when the user's task matches one of these skills. Load the full skill before following it; do not assume details from the summary alone.\n")
+	b.WriteString("If a request is vague or ambiguous but plausibly falls within a skill's domain, proactively mention the relevant skill and offer to use it before asking for more detail or guessing — for example: \"I have a skill called `setup-cometline` that handles this; want me to use it?\"\n")
+	b.WriteString("When a conversation produces a clear, reusable, already-validated multi-step workflow, offer to save it as an Agent Skill draft. If the user agrees or asks to remember a workflow as a skill, use `write_skill_draft` (never `write_skill`) so it stays pending human review. Skip one-off fixes and unverified advice.\n")
+	b.WriteString("Before creating a draft, the runtime compares against managed skills and pending drafts; near-duplicates are blocked. When blocked, tell the user about the overlaps and ask before re-calling with `force=true`, or update an existing same-name draft with `overwrite=true`.\n")
 	for _, skill := range r.Skills {
 		if skill.Internal {
 			continue

--- a/cometmind/internal/skills/skills_test.go
+++ b/cometmind/internal/skills/skills_test.go
@@ -60,8 +60,21 @@ func TestDiscoverIncludesBundledSetupSkill(t *testing.T) {
 	if skill.Internal {
 		t.Fatal("setup-cometline should be visible to users")
 	}
-	if !strings.Contains(reg.PromptIndex(), "setup-cometline") {
+	idx := reg.PromptIndex()
+	if !strings.Contains(idx, "setup-cometline") {
 		t.Fatal("prompt index should include setup-cometline")
+	}
+	if !strings.Contains(idx, "write_skill_draft") || !strings.Contains(idx, "never `write_skill`") {
+		t.Fatalf("prompt index should nudge draft authoring: %q", idx)
+	}
+	if !strings.Contains(idx, "force=true") {
+		t.Fatalf("prompt index should mention overlap force gate: %q", idx)
+	}
+}
+
+func TestPromptIndexEmptyWhenNoSkills(t *testing.T) {
+	if got := (Registry{}).PromptIndex(); got != "" {
+		t.Fatalf("PromptIndex() = %q, want empty", got)
 	}
 }
 

--- a/cometmind/internal/skills/synthesis.go
+++ b/cometmind/internal/skills/synthesis.go
@@ -54,6 +54,17 @@ func ProposeSkillFromJob(ctx context.Context, p cometsdk.Provider, model string,
 	if name == "" || content == "" {
 		return fmt.Errorf("synthesis proposal missing name or content")
 	}
+	description := SkillMarkdownDescription(content)
+	related, err := FindRelatedManagedSkills(name, description)
+	if err != nil {
+		return err
+	}
+	// Same-name draft may be refreshed; any other blocking overlap skips (no force on auto path).
+	related = FilterSelfDraftOverwrite(related, name, true)
+	if ShouldBlockOverlap(related) {
+		logging.L().Info("skills.synthesis.skipped", "job_id", job.ID, "reason", "overlap:"+FormatOverlapBlock(related))
+		return nil
+	}
 	if err := WriteDraft(name, content, true); err != nil {
 		return err
 	}

--- a/cometmind/internal/skills/synthesis_test.go
+++ b/cometmind/internal/skills/synthesis_test.go
@@ -106,3 +106,30 @@ func TestProposeSkillFromJobRetriesAfterInvalidJSON(t *testing.T) {
 		t.Fatalf("expected exactly 2 synthesis attempts, got %d", p.i)
 	}
 }
+
+func TestProposeSkillFromJobSkipsOnManagedOverlap(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	live := `---
+name: pr-review
+description: Review pull requests for this repository
+---
+
+Body.
+`
+	if err := WriteSkill("pr-review", live, false); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+	json := `{"should_propose":true,"name":"go-pr-review","content":"---\nname: go-pr-review\ndescription: Specialized Go pull request checklist\n---\n\n## Trigger\nUse for Go PRs.","reason":"reusable"}`
+	job := SynthesisJob{ID: "job-1", Description: "Codify Go PR review"}
+	if err := ProposeSkillFromJob(context.Background(), synthesisProvider{text: json}, "test-model", job, nil); err != nil {
+		t.Fatalf("ProposeSkillFromJob() error = %v", err)
+	}
+	drafts, err := ListDrafts()
+	if err != nil {
+		t.Fatalf("ListDrafts: %v", err)
+	}
+	if len(drafts) != 0 {
+		t.Fatalf("expected overlap skip with no draft, got %+v", drafts)
+	}
+}
+

--- a/cometmind/internal/tools/write_skill_draft.go
+++ b/cometmind/internal/tools/write_skill_draft.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/cometline/cometmind/internal/skills"
 )
@@ -12,14 +13,21 @@ type WriteSkillDraft struct{}
 
 func (WriteSkillDraft) Spec() ToolSpec {
 	return ToolSpec{
-		Name:        "write_skill_draft",
-		Description: "Create or update a pending Agent Skill draft in ~/.cometmind/skill-drafts. Provide the full SKILL.md contents with YAML frontmatter (name, description) and markdown body.",
+		Name: "write_skill_draft",
+		Description: "Create or update a pending Agent Skill draft in ~/.cometmind/skill-drafts. " +
+			"Provide the full SKILL.md contents with YAML frontmatter (name, description) and markdown body. " +
+			"Before writing, the runtime compares name/description against managed skills (~/.cometmind/skills) and pending drafts. " +
+			"If a likely overlap is found, the write is blocked unless force=true. " +
+			"When blocked: tell the user about the overlaps and ask whether to proceed; only re-call with force=true after they agree. " +
+			"To update an existing draft with the same name, set overwrite=true (force not required for that same-name draft). " +
+			"Prefer updating or extending an overlapping live skill over creating a parallel near-duplicate.",
 		Parameters: json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"name": {"type": "string", "description": "Skill draft directory name, e.g. commit-conventions"},
 				"content": {"type": "string", "description": "Full SKILL.md file contents"},
-				"overwrite": {"type": "boolean", "description": "Replace an existing draft (default false)"}
+				"overwrite": {"type": "boolean", "description": "Replace an existing draft with the same name (default false)"},
+				"force": {"type": "boolean", "description": "Create anyway after the user agreed despite overlap warnings (default false)"}
 			},
 			"required": ["name", "content"]
 		}`),
@@ -31,6 +39,7 @@ func (WriteSkillDraft) Execute(_ context.Context, input json.RawMessage) (Result
 		Name      *string `json:"name"`
 		Content   *string `json:"content"`
 		Overwrite bool    `json:"overwrite"`
+		Force     bool    `json:"force"`
 	}
 	if err := json.Unmarshal(input, &in); err != nil {
 		return Result{}, err
@@ -43,8 +52,27 @@ func (WriteSkillDraft) Execute(_ context.Context, input json.RawMessage) (Result
 	if !ok {
 		return bad, nil
 	}
+
+	description := skills.SkillMarkdownDescription(content)
+	related, err := skills.FindRelatedManagedSkills(name, description)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	related = skills.FilterSelfDraftOverwrite(related, name, in.Overwrite)
+	if !in.Force && skills.ShouldBlockOverlap(related) {
+		msg := skills.FormatOverlapBlock(related) +
+			"\n\nWrite blocked. Tell the user about these overlaps and ask whether to create a new draft anyway, " +
+			"update an existing same-name draft (overwrite=true), or extend the existing live skill instead. " +
+			"Only re-call write_skill_draft with force=true after the user explicitly agrees to create a near-duplicate."
+		return Result{OK: false, Output: msg}, nil
+	}
+
 	if err := skills.WriteDraft(name, content, in.Overwrite); err != nil {
 		return Result{OK: false, Output: err.Error()}, nil
 	}
-	return Result{OK: true, Output: "skill draft " + name + " written to ~/.cometmind/skill-drafts/" + name + "/SKILL.md"}, nil
+	out := fmt.Sprintf("skill draft %s written to ~/.cometmind/skill-drafts/%s/SKILL.md", name, name)
+	if in.Force && len(related) > 0 {
+		out += "\n(force=true; overlaps were acknowledged)\n" + skills.FormatOverlapBlock(related)
+	}
+	return Result{OK: true, Output: out}, nil
 }

--- a/cometmind/internal/tools/write_skill_draft_test.go
+++ b/cometmind/internal/tools/write_skill_draft_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/skills"
+)
+
+func TestWriteSkillDraftBlocksOverlapUntilForce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	live := "---\nname: pr-review\ndescription: Review pull requests for this repository\n---\n\n# Live\n"
+	if err := skills.WriteSkill("pr-review", live, false); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+
+	content := "---\nname: go-pr-review\ndescription: Specialized Go pull request checklist\n---\n\n# Draft\n"
+	payload, err := json.Marshal(map[string]any{"name": "go-pr-review", "content": content})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	blocked, err := (WriteSkillDraft{}).Execute(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if blocked.OK {
+		t.Fatalf("expected overlap block, got %+v", blocked)
+	}
+	if !strings.Contains(blocked.Output, "pr-review") || !strings.Contains(blocked.Output, "force=true") {
+		t.Fatalf("blocked output missing guidance: %s", blocked.Output)
+	}
+	if _, _, err := skills.DraftMarkdown("go-pr-review"); err == nil {
+		t.Fatal("draft should not exist after blocked write")
+	}
+
+	forcePayload, err := json.Marshal(map[string]any{"name": "go-pr-review", "content": content, "force": true})
+	if err != nil {
+		t.Fatalf("marshal force: %v", err)
+	}
+	forced, err := (WriteSkillDraft{}).Execute(context.Background(), forcePayload)
+	if err != nil {
+		t.Fatalf("force Execute error = %v", err)
+	}
+	if !forced.OK {
+		t.Fatalf("force write failed: %+v", forced)
+	}
+	if _, _, err := skills.DraftMarkdown("go-pr-review"); err != nil {
+		t.Fatalf("draft missing after force: %v", err)
+	}
+}
+
+func TestWriteSkillDraftOverwriteSameNameWithoutForce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	content := "---\nname: retry-policy\ndescription: Handle retry policy work\n---\n\n# v1\n"
+	if err := skills.WriteDraft("retry-policy", content, false); err != nil {
+		t.Fatalf("WriteDraft: %v", err)
+	}
+	updated := "---\nname: retry-policy\ndescription: Handle retry policy work\n---\n\n# v2\n"
+	payload, err := json.Marshal(map[string]any{"name": "retry-policy", "content": updated, "overwrite": true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	res, err := (WriteSkillDraft{}).Execute(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("overwrite same-name draft should succeed without force: %+v", res)
+	}
+	_, body, err := skills.DraftMarkdown("retry-policy")
+	if err != nil {
+		t.Fatalf("DraftMarkdown: %v", err)
+	}
+	if !strings.Contains(body, "# v2") {
+		t.Fatalf("draft not updated: %s", body)
+	}
+}


### PR DESCRIPTION
## Background

Automatic job synthesis and casual `write_skill_draft` calls could stack near-duplicate skills under different names, which clutters the draft inbox and fragments live skill triggers. This change adds a deterministic overlap check against managed skills and pending drafts before a new draft is written.

[490a7f1](https://github.com/Cometline/cometline/commit/490a7f18018b4557ddec743a4ffcf9f982553e64): Adds `FindRelatedManagedSkills` (name containment, Jaccard on names/descriptions) over `~/.cometmind/skills` and skill-drafts only. Chat `write_skill_draft` blocks overlaps unless the user agrees and the agent retries with `force=true` (same-name draft updates still use `overwrite`). Job synthesis uses the same gate but never force-writes. PromptIndex tells the model about the gate.
