### PR TITLE
[main] fix: improve attachment and window UX

### DIFF
--- a/cometline/electron/src/domains/shortcuts.ts
+++ b/cometline/electron/src/domains/shortcuts.ts
@@ -87,6 +87,7 @@ function matchesInputShortcut(input: Input, binding: ShortcutBinding | undefined
 	const expectsCommand = binding.command ?? false;
 	if (expectsCommand) {
 		if (!(input.control || input.meta)) return false;
+		if (binding.ctrl !== true && input.control && input.meta) return false;
 		if (binding.alt !== undefined ? binding.alt !== input.alt : input.alt) return false;
 		if (binding.shift !== undefined ? binding.shift !== input.shift : input.shift) return false;
 		return true;

--- a/cometline/electron/src/domains/window-bounds.test.ts
+++ b/cometline/electron/src/domains/window-bounds.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+	mainWindowMinWidthForWorkArea,
+	miniWindowOriginForWorkArea,
+	miniWindowSizeForWorkArea
+} from './window-bounds.js';
+
+describe('mainWindowMinWidthForWorkArea', () => {
+	it('uses one third of the work area width', () => {
+		expect(mainWindowMinWidthForWorkArea(1440)).toBe(480);
+		expect(mainWindowMinWidthForWorkArea(1920)).toBe(640);
+		expect(mainWindowMinWidthForWorkArea(1680)).toBe(560);
+	});
+
+	it('falls back when work area width is invalid', () => {
+		expect(mainWindowMinWidthForWorkArea(0)).toBe(560);
+		expect(mainWindowMinWidthForWorkArea(Number.NaN)).toBe(560);
+	});
+});
+
+describe('miniWindowSizeForWorkArea', () => {
+	it('scales width to one third and height by legacy aspect ratio', () => {
+		expect(miniWindowSizeForWorkArea(1440, 900, 18)).toEqual({ width: 480, height: 668 });
+	});
+
+	it('caps height to fit within the work area margins', () => {
+		expect(miniWindowSizeForWorkArea(1440, 500, 18)).toEqual({ width: 480, height: 464 });
+	});
+});
+
+describe('miniWindowOriginForWorkArea', () => {
+	it('places the window in the bottom-right of the work area', () => {
+		expect(
+			miniWindowOriginForWorkArea(
+				{ x: 0, y: 25, width: 1440, height: 875 },
+				{ width: 480, height: 668 },
+				18
+			)
+		).toEqual({ x: 942, y: 214 });
+	});
+});

--- a/cometline/electron/src/domains/window-bounds.ts
+++ b/cometline/electron/src/domains/window-bounds.ts
@@ -1,0 +1,42 @@
+const MAIN_MIN_WIDTH_FALLBACK = 560;
+const MINI_WIDTH_FLOOR = 360;
+const MINI_HEIGHT_FLOOR = 440;
+/** Legacy 460×640 mini window aspect ratio. */
+const MINI_HEIGHT_PER_WIDTH = 640 / 460;
+
+/** Main window minimum width as one third of the display work area. */
+export function mainWindowMinWidthForWorkArea(workAreaWidth: number): number {
+	const width = Number(workAreaWidth);
+	if (!Number.isFinite(width) || width <= 0) return MAIN_MIN_WIDTH_FALLBACK;
+	return Math.max(1, Math.round(width / 3));
+}
+
+/** Mini window size from the cursor display work area (width ≈ ⅓, height by aspect, capped). */
+export function miniWindowSizeForWorkArea(
+	workAreaWidth: number,
+	workAreaHeight: number,
+	screenMargin = 18
+): { width: number; height: number } {
+	const margin = Math.max(0, Number(screenMargin) || 0);
+	const areaH = Number(workAreaHeight);
+	const width = Math.max(MINI_WIDTH_FLOOR, mainWindowMinWidthForWorkArea(workAreaWidth));
+	const maxHeight =
+		Number.isFinite(areaH) && areaH > 0
+			? Math.max(MINI_HEIGHT_FLOOR, areaH - margin * 2)
+			: MINI_HEIGHT_FLOOR;
+	let height = Math.round(width * MINI_HEIGHT_PER_WIDTH);
+	height = Math.min(Math.max(MINI_HEIGHT_FLOOR, height), maxHeight);
+	return { width, height };
+}
+
+export function miniWindowOriginForWorkArea(
+	workArea: { x: number; y: number; width: number; height: number },
+	size: { width: number; height: number },
+	screenMargin = 18
+): { x: number; y: number } {
+	const margin = Math.max(0, Number(screenMargin) || 0);
+	return {
+		x: Math.round(workArea.x + workArea.width - size.width - margin),
+		y: Math.round(workArea.y + workArea.height - size.height - margin)
+	};
+}

--- a/cometline/electron/src/domains/windows.test.ts
+++ b/cometline/electron/src/domains/windows.test.ts
@@ -42,6 +42,7 @@ class FakeWindow {
 	readonly setFullScreen = vi.fn();
 	readonly setFullScreenable = vi.fn();
 	readonly setPosition = vi.fn();
+	readonly setBounds = vi.fn();
 	readonly setVisibleOnAllWorkspaces = vi.fn();
 	readonly setWindowButtonVisibility = vi.fn();
 	readonly show = vi.fn();
@@ -115,6 +116,8 @@ describe('window lifecycle factory', () => {
 		expect(main.options).toMatchObject({
 			titleBarStyle: 'hidden',
 			transparent: true,
+			minWidth: 480,
+			minHeight: 620,
 			webPreferences: {
 				preload: '/runtime/dist/preload.cjs',
 				contextIsolation: true,
@@ -125,7 +128,7 @@ describe('window lifecycle factory', () => {
 			}
 		});
 		expect(main.loadURL).toHaveBeenCalledWith('app://bundle/');
-		expect(mini.options).toMatchObject({ type: 'panel', fullscreenable: false });
+		expect(mini.options).toMatchObject({ type: 'panel', fullscreenable: false, width: 480, height: 668 });
 		expect(mini.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
 			visibleOnFullScreen: true,
 			skipTransformProcessType: true

--- a/cometline/electron/src/domains/windows.ts
+++ b/cometline/electron/src/domains/windows.ts
@@ -14,23 +14,19 @@ import type os from 'node:os';
 import type path from 'node:path';
 
 import { APP_ORIGIN } from './app-protocol.js';
+import { mainWindowMinWidthForWorkArea, miniWindowOriginForWorkArea, miniWindowSizeForWorkArea } from './window-bounds.js';
 import { isExternallyOpenableUrl } from './workspace-preview.js';
 
 const MACOS_LOGIN_ITEMS_SETTINGS_URL =
 	'x-apple.systempreferences:com.apple.LoginItems-Settings.extension';
-const MIN_WINDOW_WIDTH = 560;
 const MIN_WINDOW_HEIGHT = 620;
-const MINI_WINDOW_WIDTH = 460;
-const MINI_WINDOW_HEIGHT = 640;
-const MINI_WINDOW_MIN_WIDTH = 360;
-const MINI_WINDOW_MIN_HEIGHT = 440;
-const SETTINGS_WINDOW_WIDTH = 1040;
+const MINI_WINDOW_SCREEN_MARGIN = 18;
 const SETTINGS_WINDOW_HEIGHT = 760;
 const SETTINGS_WINDOW_MIN_WIDTH = 900;
 const SETTINGS_WINDOW_MIN_HEIGHT = 640;
 const SETTINGS_WINDOW_MAX_WIDTH = 1280;
 const SETTINGS_WINDOW_MAX_HEIGHT = 920;
-const MINI_WINDOW_SCREEN_MARGIN = 18;
+const SETTINGS_WINDOW_WIDTH = 1040;
 const AUXILIARY_WINDOW_ACTIVATE_SUPPRESS_MS = 1000;
 
 type BrowserWindowFactory = new (options: BrowserWindowConstructorOptions) => BrowserWindow;
@@ -136,21 +132,26 @@ export function createWindows(dependencies: WindowsDependencies) {
 		});
 	}
 
-	function positionMiniWindowBottomRight() {
+	function displayAtCursor() {
+		const cursorPoint = screen.getCursorScreenPoint();
+		return screen.getDisplayNearestPoint(cursorPoint);
+	}
+
+	function resolveMainWindowMinWidth() {
+		return mainWindowMinWidthForWorkArea(displayAtCursor().workArea.width);
+	}
+
+	function layoutMiniWindowOnCursorDisplay() {
 		const window = miniWindow;
 		if (!windowCanShow(window)) return;
-		const cursorPoint = screen.getCursorScreenPoint();
-		const display = screen.getDisplayNearestPoint(cursorPoint);
-		const { width, height } = window.getBounds();
-		window.setPosition(
-			Math.round(
-				display.workArea.x + display.workArea.width - width - MINI_WINDOW_SCREEN_MARGIN
-			),
-			Math.round(
-				display.workArea.y + display.workArea.height - height - MINI_WINDOW_SCREEN_MARGIN
-			),
-			false
+		const display = displayAtCursor();
+		const size = miniWindowSizeForWorkArea(
+			display.workArea.width,
+			display.workArea.height,
+			MINI_WINDOW_SCREEN_MARGIN
 		);
+		const origin = miniWindowOriginForWorkArea(display.workArea, size, MINI_WINDOW_SCREEN_MARGIN);
+		window.setBounds({ ...origin, ...size }, false);
 	}
 
 	function suppressSpuriousActivate() {
@@ -209,7 +210,7 @@ export function createWindows(dependencies: WindowsDependencies) {
 		const window = new BrowserWindow({
 			width: 1200,
 			height: 800,
-			minWidth: MIN_WINDOW_WIDTH,
+			minWidth: resolveMainWindowMinWidth(),
 			minHeight: MIN_WINDOW_HEIGHT,
 			titleBarStyle: 'hidden',
 			...(platform === 'darwin'
@@ -263,11 +264,15 @@ export function createWindows(dependencies: WindowsDependencies) {
 
 	async function createMiniWindow() {
 		const appIcon = getAppIconImage(getPersonaId());
+		const display = displayAtCursor();
+		const miniSize = miniWindowSizeForWorkArea(
+			display.workArea.width,
+			display.workArea.height,
+			MINI_WINDOW_SCREEN_MARGIN
+		);
 		const window = new BrowserWindow({
-			width: MINI_WINDOW_WIDTH,
-			height: MINI_WINDOW_HEIGHT,
-			minWidth: MINI_WINDOW_MIN_WIDTH,
-			minHeight: MINI_WINDOW_MIN_HEIGHT,
+			width: miniSize.width,
+			height: miniSize.height,
 			resizable: false,
 			titleBarStyle: platform === 'darwin' ? 'hidden' : 'default',
 			...(platform === 'darwin'
@@ -294,10 +299,10 @@ export function createWindows(dependencies: WindowsDependencies) {
 		applyMiniWindowPresentation(window);
 		attachExternalNavigationGuards(window);
 		shortcuts.attachMiniWindowShortcuts(window.webContents);
-		positionMiniWindowBottomRight();
+		layoutMiniWindowOnCursorDisplay();
 		await loadAppRoute(window, '/mini');
 		window.once('ready-to-show', () => {
-			positionMiniWindowBottomRight();
+			layoutMiniWindowOnCursorDisplay();
 			applyMiniWindowPresentation();
 			miniWindow?.show();
 			miniWindow?.focus();
@@ -379,6 +384,7 @@ export function createWindows(dependencies: WindowsDependencies) {
 			return;
 		}
 		if (window.isMinimized()) window.restore();
+		layoutMiniWindowOnCursorDisplay();
 		applyMiniWindowPresentation();
 		window.show();
 		window.focus();

--- a/cometline/scripts/build-electron.mjs
+++ b/cometline/scripts/build-electron.mjs
@@ -6,7 +6,7 @@ const shared = {
 	packages: 'external',
 	platform: 'node',
 	target: 'node22',
-	sourcemap: true,
+	sourcemap: false,
 	logLevel: 'info'
 };
 

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -30,6 +30,7 @@
 	import { createComposerMentionsController } from '$lib/components/composer/composer-mentions.svelte';
 	import { createComposerSlashController } from '$lib/components/composer/composer-slash.svelte';
 	import { stepHistoryIndex } from '$lib/components/composer/composer-history';
+	import { nextAttachmentRemoval } from '$lib/components/composer/composer-attachment-keydown';
 
 	let {
 		onSend,
@@ -336,6 +337,28 @@
 	function onKeydown(e: KeyboardEvent) {
 		if (slash.handleMenuKeydown(e)) return;
 		if (mentions.handleMentionMenuKeydown(e)) return;
+		if (
+			!e.isComposing &&
+			!e.metaKey &&
+			!e.ctrlKey &&
+			!e.altKey &&
+			(e.key === 'Backspace' || e.key === 'Delete')
+		) {
+			const sel = window.getSelection();
+			if (!sel || sel.isCollapsed) {
+				const removal = nextAttachmentRemoval(value, images, pendingWebContexts.length);
+				if (removal?.kind === 'image') {
+					e.preventDefault();
+					attachments.removeImage(removal.id);
+					return;
+				}
+				if (removal?.kind === 'webContext') {
+					e.preventDefault();
+					shellStore.removeWebContextAt(removal.index);
+					return;
+				}
+			}
+		}
 		if (
 			!e.isComposing &&
 			!e.metaKey &&

--- a/cometline/src/lib/components/composer/composer-attachment-keydown.test.ts
+++ b/cometline/src/lib/components/composer/composer-attachment-keydown.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { nextAttachmentRemoval } from './composer-attachment-keydown';
+
+describe('nextAttachmentRemoval', () => {
+	it('returns null when text is non-empty', () => {
+		expect(
+			nextAttachmentRemoval('hello', [{ id: 'img-1' }], 2)
+		).toBeNull();
+		expect(
+			nextAttachmentRemoval('  x  ', [{ id: 'img-1' }], 2)
+		).toBeNull();
+	});
+
+	it('treats empty string and whitespace-only as empty', () => {
+		expect(nextAttachmentRemoval('', [{ id: 'img-1' }], 0)).toEqual({
+			kind: 'image',
+			id: 'img-1'
+		});
+		expect(nextAttachmentRemoval('   \n\t  ', [{ id: 'img-1' }], 0)).toEqual({
+			kind: 'image',
+			id: 'img-1'
+		});
+	});
+
+	it('prefers the last image with an id', () => {
+		expect(
+			nextAttachmentRemoval('', [{ id: 'a' }, { id: 'b' }, { id: 'c' }], 3)
+		).toEqual({ kind: 'image', id: 'c' });
+	});
+
+	it('skips images without ids and falls through to web context', () => {
+		expect(nextAttachmentRemoval('', [{}, {}], 2)).toEqual({
+			kind: 'webContext',
+			index: 1
+		});
+	});
+
+	it('removes the last web context when there are no images', () => {
+		expect(nextAttachmentRemoval('', [], 3)).toEqual({
+			kind: 'webContext',
+			index: 2
+		});
+	});
+
+	it('returns null when empty and nothing is attached', () => {
+		expect(nextAttachmentRemoval('', [], 0)).toBeNull();
+		expect(nextAttachmentRemoval('  ', [{}], 0)).toBeNull();
+	});
+});

--- a/cometline/src/lib/components/composer/composer-attachment-keydown.ts
+++ b/cometline/src/lib/components/composer/composer-attachment-keydown.ts
@@ -1,0 +1,29 @@
+/** Decide which external composer attachment to remove when text is empty. */
+
+export type AttachmentRemoval =
+	| { kind: 'image'; id: string }
+	| { kind: 'webContext'; index: number }
+	| null;
+
+/**
+ * When the composer text is empty, prefer removing the last image, then the
+ * last web-context chip. Returns null when there is nothing to remove.
+ */
+export function nextAttachmentRemoval(
+	text: string,
+	images: { id?: string }[],
+	webContextCount: number
+): AttachmentRemoval {
+	if (text.trim() !== '') return null;
+
+	for (let i = images.length - 1; i >= 0; i--) {
+		const id = images[i]?.id;
+		if (id) return { kind: 'image', id };
+	}
+
+	if (webContextCount > 0) {
+		return { kind: 'webContext', index: webContextCount - 1 };
+	}
+
+	return null;
+}

--- a/cometline/src/lib/keyboard-shortcuts.test.ts
+++ b/cometline/src/lib/keyboard-shortcuts.test.ts
@@ -90,6 +90,19 @@ describe('keyboard-shortcuts', () => {
 		).toBe(true);
 	});
 
+	it('does not treat Ctrl+Cmd as a lone command chord (macOS fullscreen, etc.)', () => {
+		const focusSearch = { command: true, key: 'f' };
+		expect(matchesShortcut(keyEvent({ key: 'f', code: 'KeyF', metaKey: true }), focusSearch)).toBe(
+			true
+		);
+		expect(
+			matchesShortcut(
+				keyEvent({ key: 'f', code: 'KeyF', metaKey: true, ctrlKey: true }),
+				focusSearch
+			)
+		).toBe(false);
+	});
+
 	it('matches session navigation by physical arrow code under IME', () => {
 		expect(
 			matchesShortcut(

--- a/cometline/src/lib/keyboard-shortcuts.ts
+++ b/cometline/src/lib/keyboard-shortcuts.ts
@@ -378,6 +378,8 @@ export function matchesShortcut(
 	if (expectsCommand) {
 		const hasCommand = event.ctrlKey || event.metaKey;
 		if (!hasCommand) return false;
+		// ⌘-style bindings must not swallow ⌃⌘ chords (e.g. macOS ⌃⌘F fullscreen).
+		if (binding.ctrl !== true && event.ctrlKey && event.metaKey) return false;
 		if (binding.alt !== undefined ? binding.alt !== event.altKey : event.altKey) return false;
 		if (binding.shift !== undefined ? binding.shift !== event.shiftKey : event.shiftKey)
 			return false;


### PR DESCRIPTION
## Background

Composer attachments should be removable with the keyboard when the input is empty, and desktop window behavior should remain predictable across macOS shortcut combinations and displays with different work areas.

[c89f603](https://github.com/Cometline/cometline/commit/c89f6038d1be0103cdad803ec71a2b204d1ad6e): The composer removes the last image or web-context attachment on Backspace or Delete when no text remains, with focused unit coverage for removal order and empty states.

[5ec327a](https://github.com/Cometline/cometline/commit/5ec327a06ebab21c408707fbe4047cc0b7c6f528): Shortcut matching excludes Ctrl+Cmd from command-only bindings, and mini and main windows derive their sizing and placement from the active display work area. The Electron build also disables source maps for the packaged main process.
