### PR TITLE
[main] fix: keep browsed workspace out of default

### DIFF
--- a/cometline/electron/src/domains/ipc.ts
+++ b/cometline/electron/src/domains/ipc.ts
@@ -16,6 +16,7 @@ export interface IpcHandlers {
 	getWorkspacePath: Invoker;
 	openSessionInMainWindow: Invoker;
 	selectWorkspacePath: Invoker;
+	browseWorkspacePath: Invoker;
 	selectBackupFolder: Invoker;
 	setWorkspacePath: Invoker;
 	listRecentWorkspaces: Invoker;
@@ -84,6 +85,7 @@ export function registerIpcHandlers(handlers: IpcHandlers) {
 	ipcMain.handle('cometline:get-workspace-path', handlers.getWorkspacePath);
 	ipcMain.handle('cometline:open-session-in-main-window', handlers.openSessionInMainWindow);
 	ipcMain.handle('cometline:select-workspace-path', handlers.selectWorkspacePath);
+	ipcMain.handle('cometline:browse-workspace-path', handlers.browseWorkspacePath);
 	ipcMain.handle('cometline:select-backup-folder', handlers.selectBackupFolder);
 	ipcMain.handle('cometline:set-workspace-path', handlers.setWorkspacePath);
 	ipcMain.handle('cometline:list-recent-workspaces', handlers.listRecentWorkspaces);

--- a/cometline/electron/src/domains/runtime-ipc.ts
+++ b/cometline/electron/src/domains/runtime-ipc.ts
@@ -137,6 +137,7 @@ export function registerRuntimeIpcHandlers(dependencies: RuntimeIpcDependencies)
 		openSessionInMainWindow: (_event: IpcMainInvokeEvent, sessionId: unknown) =>
 			dependencies.windows.openSessionInMainWindow(sessionId),
 		selectWorkspacePath: () => dependencies.settings.selectWorkspacePath(),
+		browseWorkspacePath: () => dependencies.settings.browseWorkspacePath(),
 		selectBackupFolder: () => dependencies.selectBackupFolder(),
 		setWorkspacePath: (_event: IpcMainInvokeEvent, workspacePath: unknown) =>
 			dependencies.settings.writeStoredWorkspacePath(String(workspacePath || '')),

--- a/cometline/electron/src/domains/settings-domain.test.ts
+++ b/cometline/electron/src/domains/settings-domain.test.ts
@@ -51,7 +51,14 @@ function settingsWithProviders(providers: ProviderConfig[]): ProviderSettings {
 	return settings;
 }
 
-function createTestDomain(homeDirectory: string, environment: Record<string, string | undefined> = {}) {
+function createTestDomain(
+	homeDirectory: string,
+	environment: Record<string, string | undefined> = {},
+	showOpenDialog: () => Promise<{ canceled: boolean; filePaths: string[] }> = async () => ({
+		canceled: true,
+		filePaths: []
+	})
+) {
 	return createSettingsDomain({
 		fs,
 		path,
@@ -63,7 +70,7 @@ function createTestDomain(homeDirectory: string, environment: Record<string, str
 		resolveNextPersonaId: (settings, current) => settings.app?.personaId ?? current.app.personaId,
 		resolveSystemPromptPath: (personaId) => `/souls/${personaId}.md`,
 		getFocusedWindow: () => null,
-		showOpenDialog: async () => ({ canceled: true, filePaths: [] })
+		showOpenDialog
 	});
 }
 
@@ -190,6 +197,25 @@ describe('recent workspace paths', () => {
 });
 
 describe('settings domain factory', () => {
+	it('browses for a workspace without changing the stored default', async () => {
+		const homeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-domain-'));
+		temporaryDirectories.push(homeDirectory);
+		const storedWorkspace = path.join(homeDirectory, 'stored-workspace');
+		const browsedWorkspace = path.join(homeDirectory, 'browsed-workspace');
+		fs.mkdirSync(storedWorkspace);
+		fs.mkdirSync(browsedWorkspace);
+		const domain = createTestDomain(homeDirectory, {}, async () => ({
+			canceled: false,
+			filePaths: [browsedWorkspace]
+		}));
+
+		domain.writeStoredWorkspacePath(storedWorkspace);
+
+		expect(await domain.browseWorkspacePath()).toBe(browsedWorkspace);
+		expect(domain.getWorkspacePath()).toBe(storedWorkspace);
+		expect(domain.listRecentWorkspacePaths()).toEqual([storedWorkspace]);
+	});
+
 	it('persists split settings, mini state, workspace store, and composer history without Electron lifecycle', () => {
 		const homeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-domain-'));
 		temporaryDirectories.push(homeDirectory);

--- a/cometline/electron/src/domains/settings.ts
+++ b/cometline/electron/src/domains/settings.ts
@@ -189,14 +189,23 @@ export function createSettingsDomain(dependencies: SettingsDomainDependencies) {
 		return readStoredWorkspacePath() || defaultWorkspacePath();
 	}
 
-	async function selectWorkspacePath() {
+	async function chooseWorkspacePath() {
 		const result = await dependencies.showOpenDialog(dependencies.getFocusedWindow(), {
 			properties: ['openDirectory', 'createDirectory'],
 			buttonLabel: 'Select workspace',
 			title: 'Choose a workspace folder'
 		});
 		if (result.canceled || result.filePaths.length === 0) return null;
-		return writeStoredWorkspacePath(result.filePaths[0]);
+		return path.resolve(result.filePaths[0]);
+	}
+
+	async function selectWorkspacePath() {
+		const selected = await chooseWorkspacePath();
+		return selected ? writeStoredWorkspacePath(selected) : null;
+	}
+
+	async function browseWorkspacePath() {
+		return chooseWorkspacePath();
 	}
 
 	function normalizeOptions(personaId = 'minako', settings: unknown = undefined) {
@@ -398,6 +407,7 @@ export function createSettingsDomain(dependencies: SettingsDomainDependencies) {
 		readProviderSettings,
 		readSavedProviderSettings,
 		removeRecentWorkspacePath,
+		browseWorkspacePath,
 		selectWorkspacePath,
 		writeMiniWindowState,
 		writeProviderSettings,

--- a/cometline/electron/src/preload.ts
+++ b/cometline/electron/src/preload.ts
@@ -18,6 +18,7 @@ const electronAPI: ElectronAPI = {
 	openExternal: (url) => ipcRenderer.invoke('cometline:open-external', url),
 	getWorkspacePath: () => ipcRenderer.invoke('cometline:get-workspace-path'),
 	selectWorkspacePath: () => ipcRenderer.invoke('cometline:select-workspace-path'),
+	browseWorkspacePath: () => ipcRenderer.invoke('cometline:browse-workspace-path'),
 	selectBackupFolder: () => ipcRenderer.invoke('cometline:select-backup-folder'),
 	setWorkspacePath: (workspacePath) =>
 		ipcRenderer.invoke('cometline:set-workspace-path', workspacePath),

--- a/cometline/electron/src/shared/api.ts
+++ b/cometline/electron/src/shared/api.ts
@@ -78,6 +78,7 @@ export interface ElectronAPI {
 	onFullScreenChange(callback: (isFullScreen: boolean) => void): () => void;
 	getWorkspacePath(): Promise<string>;
 	selectWorkspacePath(): Promise<string | null>;
+	browseWorkspacePath(): Promise<string | null>;
 	selectBackupFolder(): Promise<SettingsFileResult>;
 	setWorkspacePath(workspacePath: string): Promise<string>;
 	listRecentWorkspaces(): Promise<string[]>;

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -490,6 +490,7 @@ declare global {
 		onFullScreenChange?: (callback: (isFullScreen: boolean) => void) => () => void;
 		getWorkspacePath?: () => Promise<string>;
 		selectWorkspacePath?: () => Promise<string | null>;
+		browseWorkspacePath?: () => Promise<string | null>;
 		selectBackupFolder?: () => Promise<SettingsFileResult>;
 		setWorkspacePath?: (workspacePath: string) => Promise<string>;
 		listRecentWorkspaces?: () => Promise<string[]>;

--- a/cometline/src/lib/components/WorkspacePathField.svelte
+++ b/cometline/src/lib/components/WorkspacePathField.svelte
@@ -58,7 +58,7 @@
 
 	async function browseFolder() {
 		if (disabled) return;
-		const picked = await window.electronAPI?.selectWorkspacePath?.();
+		const picked = await window.electronAPI?.browseWorkspacePath?.();
 		if (!picked) return;
 		value = picked;
 		panelOpen = false;

--- a/cometline/src/lib/components/composer/composer-slash.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-slash.svelte.ts
@@ -305,7 +305,7 @@ export function createComposerSlashController(deps: {
 
 	async function selectWorkspaceOption(option: WorkspaceMenuOption) {
 		if (option.kind === 'browse') {
-			const picked = await window.electronAPI?.selectWorkspacePath?.();
+			const picked = await window.electronAPI?.browseWorkspacePath?.();
 			if (!picked) return;
 			await applyWorkspaceChange(picked);
 			return;


### PR DESCRIPTION
## Background

Browsing a folder from Composer `/change` or a job workspace field was using the Settings picker and could overwrite the persisted default workspace. The picker paths now have separate persisted and non-persisted flows so new sessions continue using the configured default.

[8b1fa4e](https://github.com/Cometline/cometline/commit/8b1fa4e49e7799b59f3e7541ce6e446ee4ee8a06): Separates folder browsing from default workspace selection, routes Composer and job workspace fields through the non-persisted picker, and adds regression coverage for the stored default.