### PR TITLE
[main] feat: sync external workspace changes

### DIFF
--- a/cometline/electron/src/domains/ipc.ts
+++ b/cometline/electron/src/domains/ipc.ts
@@ -19,6 +19,7 @@ export interface IpcHandlers {
 	browseWorkspacePath: Invoker;
 	selectBackupFolder: Invoker;
 	setWorkspacePath: Invoker;
+	watchWorkspace: Invoker;
 	listRecentWorkspaces: Invoker;
 	removeRecentWorkspacePath: Invoker;
 	filterExistingWorkspacePaths: Invoker;
@@ -88,6 +89,7 @@ export function registerIpcHandlers(handlers: IpcHandlers) {
 	ipcMain.handle('cometline:browse-workspace-path', handlers.browseWorkspacePath);
 	ipcMain.handle('cometline:select-backup-folder', handlers.selectBackupFolder);
 	ipcMain.handle('cometline:set-workspace-path', handlers.setWorkspacePath);
+	ipcMain.handle('cometline:watch-workspace', handlers.watchWorkspace);
 	ipcMain.handle('cometline:list-recent-workspaces', handlers.listRecentWorkspaces);
 	ipcMain.handle('cometline:remove-recent-workspace-path', handlers.removeRecentWorkspacePath);
 	ipcMain.handle('cometline:filter-existing-workspace-paths', handlers.filterExistingWorkspacePaths);

--- a/cometline/electron/src/domains/runtime-ipc.ts
+++ b/cometline/electron/src/domains/runtime-ipc.ts
@@ -19,6 +19,7 @@ import type { createTerminalManager, TerminalCreateInput } from './terminal.js';
 import type { createWindowChrome } from './window-chrome.js';
 import type { createWindows } from './windows.js';
 import { isExternallyOpenableUrl, readWorkspaceFileForPreview } from './workspace-preview.js';
+import type { createWorkspaceWatcher } from './workspace-watcher.js';
 
 type SettingsDomain = ReturnType<typeof createSettingsDomain>;
 type Windows = ReturnType<typeof createWindows>;
@@ -30,6 +31,7 @@ type CometMindLifecycle = ReturnType<typeof createCometMindLifecycle>;
 type AutoUpdater = ReturnType<typeof createAutoUpdater>;
 type Shortcuts = ReturnType<typeof createShortcutCoordinator>;
 type WindowChrome = ReturnType<typeof createWindowChrome>;
+type WorkspaceWatcher = ReturnType<typeof createWorkspaceWatcher>;
 
 interface NotificationService {
 	isSupported(): boolean;
@@ -54,6 +56,7 @@ export interface RuntimeIpcDependencies {
 	shortcuts: Pick<Shortcuts, 'refreshGlobalShortcuts'>;
 	applicationMenuTray: { configureApplicationMenu(): void };
 	windowChrome: Pick<WindowChrome, 'animateWindowButtons'>;
+	workspaceWatcher: WorkspaceWatcher;
 	broadcastProviderSettingsChanged(settings: ProviderSettings): void;
 }
 
@@ -141,6 +144,9 @@ export function registerRuntimeIpcHandlers(dependencies: RuntimeIpcDependencies)
 		selectBackupFolder: () => dependencies.selectBackupFolder(),
 		setWorkspacePath: (_event: IpcMainInvokeEvent, workspacePath: unknown) =>
 			dependencies.settings.writeStoredWorkspacePath(String(workspacePath || '')),
+		watchWorkspace: (_event: IpcMainInvokeEvent, workspacePath: unknown) => {
+			dependencies.workspaceWatcher.watch(String(workspacePath || ''));
+		},
 		listRecentWorkspaces: () => dependencies.settings.listRecentWorkspacePaths(),
 		removeRecentWorkspacePath: (_event: IpcMainInvokeEvent, workspacePath: unknown) =>
 			dependencies.settings.removeRecentWorkspacePath(String(workspacePath || '')),

--- a/cometline/electron/src/domains/runtime.ts
+++ b/cometline/electron/src/domains/runtime.ts
@@ -36,6 +36,7 @@ import { createShortcutCoordinator } from './shortcuts.js';
 import { createTerminalManager } from './terminal.js';
 import { createWindowChrome } from './window-chrome.js';
 import { createWindows } from './windows.js';
+import { createWorkspaceWatcher } from './workspace-watcher.js';
 
 // Keep production path resolution stable after compiling this source into electron/dist.
 const runtimeDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -148,6 +149,17 @@ export function initializeRuntime() {
 		isPreferred: () => Boolean(settingsDomain.readProviderSettings().app?.screenCapturePreferred)
 	});
 	const terminals = createTerminalManager(() => windows?.getMainWindow() ?? null);
+	const workspaceWatcher = createWorkspaceWatcher({
+		fs,
+		path,
+		onChange: (change) => {
+			for (const window of BrowserWindow.getAllWindows()) {
+				if (!window.isDestroyed()) window.webContents.send('cometline:workspace-changed', change);
+			}
+		},
+		setTimeout,
+		clearTimeout
+	});
 
 	function broadcastProviderSettingsChanged(settings: ProviderSettings) {
 		for (const window of BrowserWindow.getAllWindows()) {
@@ -359,6 +371,7 @@ export function initializeRuntime() {
 		shortcuts,
 		applicationMenuTray,
 		windowChrome,
+		workspaceWatcher,
 		broadcastProviderSettingsChanged
 	});
 
@@ -424,6 +437,7 @@ export function initializeRuntime() {
 		await browserSearch.stop();
 		await screenCapture.stop();
 		terminals.terminateAll();
+		workspaceWatcher.close();
 		await cometMind.syncDiscordGateway({
 			cometmind: { gateway: { discord: { enabled: false } } }
 		});
@@ -434,6 +448,7 @@ export function initializeRuntime() {
 	});
 	process.on('exit', () => {
 		terminals.terminateAll();
+		workspaceWatcher.close();
 		cometMind.terminateForExit();
 	});
 }

--- a/cometline/electron/src/domains/workspace-watcher.test.ts
+++ b/cometline/electron/src/domains/workspace-watcher.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createWorkspaceWatcher, type WorkspaceChange } from './workspace-watcher.js';
+
+type Listener = (eventType: string, filename: string | Buffer | null) => void;
+
+describe('workspace watcher', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces workspace files and Git metadata into one change event', () => {
+		vi.useFakeTimers();
+		const changes: WorkspaceChange[] = [];
+		let emit: Listener = () => {};
+		const watcher = createWorkspaceWatcher({
+			fs: {
+				statSync: () => ({ isDirectory: () => true }),
+				watch: (_path: unknown, _options: unknown, callback: unknown) => {
+					emit = callback as Listener;
+					return { close: vi.fn(), on: vi.fn() };
+				}
+			} as never,
+			path: { resolve: (value: string) => value },
+			onChange: (change) => changes.push(change),
+			setTimeout,
+			clearTimeout
+		});
+
+		watcher.watch('/workspace');
+		emit('change', 'src/app.ts');
+		emit('rename', Buffer.from('README.md'));
+		emit('change', '.git/index');
+		vi.advanceTimersByTime(300);
+
+		expect(changes).toEqual([
+			{ workspacePath: '/workspace', paths: ['README.md', 'src/app.ts'], gitChanged: true }
+		]);
+	});
+
+	it('ignores generated output and closes the prior watcher on workspace switch', () => {
+		vi.useFakeTimers();
+		const changes: WorkspaceChange[] = [];
+		const close = vi.fn();
+		const listeners: Listener[] = [];
+		const watcher = createWorkspaceWatcher({
+			fs: {
+				statSync: () => ({ isDirectory: () => true }),
+				watch: (_path: unknown, _options: unknown, callback: unknown) => {
+					listeners.push(callback as Listener);
+					return { close, on: vi.fn() };
+				}
+			} as never,
+			path: { resolve: (value: string) => value },
+			onChange: (change) => changes.push(change),
+			setTimeout,
+			clearTimeout
+		});
+
+		watcher.watch('/first');
+		listeners[0]?.('change', 'node_modules/library/index.js');
+		vi.advanceTimersByTime(300);
+		expect(changes).toEqual([]);
+
+		watcher.watch('/second');
+		expect(close).toHaveBeenCalledTimes(1);
+		listeners[0]?.('change', 'src/stale.ts');
+		listeners[1]?.('change', 'src/new.ts');
+		vi.advanceTimersByTime(300);
+		expect(changes).toEqual([
+			{ workspacePath: '/second', paths: ['src/new.ts'], gitChanged: false }
+		]);
+	});
+});

--- a/cometline/electron/src/domains/workspace-watcher.ts
+++ b/cometline/electron/src/domains/workspace-watcher.ts
@@ -1,0 +1,122 @@
+import type fs from 'node:fs';
+import type path from 'node:path';
+
+const DEBOUNCE_MS = 300;
+const SKIPPED_DIRECTORIES = new Set([
+	'node_modules',
+	'vendor',
+	'dist',
+	'build',
+	'.next',
+	'out',
+	'coverage',
+	'__pycache__'
+]);
+
+export type WorkspaceChange = {
+	workspacePath: string;
+	paths: string[];
+	gitChanged: boolean;
+};
+
+type WorkspaceWatcherDependencies = {
+	fs: Pick<typeof fs, 'statSync' | 'watch'>;
+	path: Pick<typeof path, 'resolve'>;
+	onChange(change: WorkspaceChange): void;
+	setTimeout: typeof setTimeout;
+	clearTimeout: typeof clearTimeout;
+};
+
+function normalizeRelativePath(filePath: string): string {
+	return filePath.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+function isGitMetadata(filePath: string): boolean {
+	return filePath === '.git' || filePath.startsWith('.git/');
+}
+
+function shouldSkip(filePath: string): boolean {
+	return filePath.split('/').some((segment) => SKIPPED_DIRECTORIES.has(segment));
+}
+
+/** Watches one active workspace and coalesces filesystem noise into useful UI refreshes. */
+export function createWorkspaceWatcher(dependencies: WorkspaceWatcherDependencies) {
+	let watcher: fs.FSWatcher | null = null;
+	let workspacePath = '';
+	const changedPaths = new Set<string>();
+	let gitChanged = false;
+	let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function flush() {
+		flushTimer = null;
+		if (!workspacePath) return;
+		const paths = [...changedPaths].sort();
+		changedPaths.clear();
+		const changedGit = gitChanged;
+		gitChanged = false;
+		if (paths.length === 0 && !changedGit) return;
+		dependencies.onChange({ workspacePath, paths, gitChanged: changedGit });
+	}
+
+	function scheduleFlush() {
+		if (flushTimer) dependencies.clearTimeout(flushTimer);
+		flushTimer = dependencies.setTimeout(flush, DEBOUNCE_MS);
+	}
+
+	function record(filename: string | Buffer | null) {
+		if (!workspacePath) return;
+		if (filename === null) {
+			gitChanged = true;
+			scheduleFlush();
+			return;
+		}
+		const relativePath = normalizeRelativePath(String(filename));
+		if (!relativePath) {
+			gitChanged = true;
+			scheduleFlush();
+			return;
+		}
+		if (isGitMetadata(relativePath)) {
+			gitChanged = true;
+			scheduleFlush();
+			return;
+		}
+		if (shouldSkip(relativePath)) return;
+		changedPaths.add(relativePath);
+		scheduleFlush();
+	}
+
+	function close() {
+		watcher?.close();
+		watcher = null;
+		workspacePath = '';
+		changedPaths.clear();
+		gitChanged = false;
+		if (flushTimer) dependencies.clearTimeout(flushTimer);
+		flushTimer = null;
+	}
+
+	function watch(nextWorkspacePath: string) {
+		const next = dependencies.path.resolve(String(nextWorkspacePath || '').trim());
+		if (!next || next === workspacePath) return;
+		close();
+
+		try {
+			if (!dependencies.fs.statSync(next).isDirectory()) return;
+			workspacePath = next;
+			watcher = dependencies.fs.watch(next, { recursive: true }, (_eventType, filename) => {
+				if (workspacePath !== next) return;
+				record(filename);
+			});
+			watcher.on('error', () => {
+				// A future focus refresh recovers the UI if an OS watcher is invalidated.
+				gitChanged = true;
+				scheduleFlush();
+			});
+		} catch {
+			close();
+		}
+	}
+
+	return { close, watch };
+}

--- a/cometline/electron/src/preload.ts
+++ b/cometline/electron/src/preload.ts
@@ -22,6 +22,7 @@ const electronAPI: ElectronAPI = {
 	selectBackupFolder: () => ipcRenderer.invoke('cometline:select-backup-folder'),
 	setWorkspacePath: (workspacePath) =>
 		ipcRenderer.invoke('cometline:set-workspace-path', workspacePath),
+	watchWorkspace: (workspacePath) => ipcRenderer.invoke('cometline:watch-workspace', workspacePath),
 	listRecentWorkspaces: () => ipcRenderer.invoke('cometline:list-recent-workspaces'),
 	removeRecentWorkspacePath: (workspacePath) =>
 		ipcRenderer.invoke('cometline:remove-recent-workspace-path', workspacePath),
@@ -82,6 +83,7 @@ const electronAPI: ElectronAPI = {
 		subscribe('cometline:fullscreen-changed', (isFullScreen) =>
 			callback(Boolean(isFullScreen))
 		),
+	onWorkspaceChanged: (callback) => subscribe('cometline:workspace-changed', callback),
 	getAppVersion: () => ipcRenderer.invoke('cometline:get-app-version'),
 	getUpdateState: () => ipcRenderer.invoke('cometline:get-update-state'),
 	checkForUpdates: () => ipcRenderer.invoke('cometline:check-for-updates'),

--- a/cometline/electron/src/shared/api.ts
+++ b/cometline/electron/src/shared/api.ts
@@ -76,11 +76,13 @@ export interface ElectronAPI {
 	setSidebarOpen(state: SidebarChromeState): void;
 	getFullScreen(): Promise<boolean>;
 	onFullScreenChange(callback: (isFullScreen: boolean) => void): () => void;
+	onWorkspaceChanged(callback: (change: WorkspaceChange) => void): () => void;
 	getWorkspacePath(): Promise<string>;
 	selectWorkspacePath(): Promise<string | null>;
 	browseWorkspacePath(): Promise<string | null>;
 	selectBackupFolder(): Promise<SettingsFileResult>;
 	setWorkspacePath(workspacePath: string): Promise<string>;
+	watchWorkspace(workspacePath: string): Promise<void>;
 	listRecentWorkspaces(): Promise<string[]>;
 	removeRecentWorkspacePath(workspacePath: string): Promise<{ removed: boolean }>;
 	filterExistingWorkspacePaths(paths: string[]): Promise<string[]>;
@@ -146,6 +148,12 @@ export interface OllamaPullProgress {
 	completed?: number;
 	percent?: number;
 	done?: boolean;
+}
+
+export interface WorkspaceChange {
+	workspacePath: string;
+	paths: string[];
+	gitChanged: boolean;
 }
 
 export interface TerminalCreatePayload {

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -488,11 +488,15 @@ declare global {
 		setSidebarOpen?: (state: SidebarChromeState) => void;
 		getFullScreen?: () => Promise<boolean>;
 		onFullScreenChange?: (callback: (isFullScreen: boolean) => void) => () => void;
+		onWorkspaceChanged?: (
+			callback: (change: { workspacePath: string; paths: string[]; gitChanged: boolean }) => void
+		) => () => void;
 		getWorkspacePath?: () => Promise<string>;
 		selectWorkspacePath?: () => Promise<string | null>;
 		browseWorkspacePath?: () => Promise<string | null>;
 		selectBackupFolder?: () => Promise<SettingsFileResult>;
 		setWorkspacePath?: (workspacePath: string) => Promise<string>;
+		watchWorkspace?: (workspacePath: string) => Promise<void>;
 		listRecentWorkspaces?: () => Promise<string[]>;
 		removeRecentWorkspacePath?: (workspacePath: string) => Promise<{ removed: boolean }>;
 		filterExistingWorkspacePaths?: (paths: string[]) => Promise<string[]>;

--- a/cometline/src/lib/components/FilePreview.svelte
+++ b/cometline/src/lib/components/FilePreview.svelte
@@ -35,6 +35,9 @@
 	} from '$lib/workspace/workspace-panel-prefs';
 	import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
 	import { workspaceFileChangeVersion } from '$lib/workspace/workspace-change.svelte';
+	import { createFileDiff } from '$lib/workspace/file-diff';
+	import { highlightGitDiffLines, type HighlightedDiffLine } from '$lib/workspace/git-diff-highlight';
+	import { parseGitDiffLines } from '$lib/workspace/git-diff-lines';
 	import {
 		isWikiReadOnlyPath,
 		isWikiUiPath,
@@ -92,8 +95,9 @@
 		lineRange: SelectionLineRange | null;
 	} | null>(null);
 	let externalChangePending = $state(false);
-	let externalComparisonContent = $state<string | null>(null);
+	let externalComparisonLines = $state<HighlightedDiffLine[] | null>(null);
 	let externalComparisonError = $state<string | null>(null);
+	let externalComparisonOpen = $state(false);
 	let lastObservedFileChangeVersion = 0;
 
 	const readOnly = $derived(isWikiUiPath(filePath) && isWikiReadOnlyPath(filePath));
@@ -189,8 +193,9 @@
 
 	function keepEditingAfterExternalChange() {
 		externalChangePending = false;
-		externalComparisonContent = null;
+		externalComparisonLines = null;
 		externalComparisonError = null;
+		externalComparisonOpen = false;
 	}
 
 	function reloadAfterExternalChange() {
@@ -199,9 +204,17 @@
 	}
 
 	async function compareExternalChange() {
+		if (externalComparisonOpen) {
+			externalComparisonLines = null;
+			externalComparisonError = null;
+			externalComparisonOpen = false;
+			return;
+		}
 		const currentWorkspacePath = workspacePath;
 		const currentFilePath = filePath;
+		const currentDraftContent = draftContent;
 		externalComparisonError = null;
+		clearSelectionPopup();
 		try {
 			const result = isWikiUiPath(currentFilePath)
 				? await readWikiFileContent(toWikiRelative(currentFilePath))
@@ -211,7 +224,19 @@
 				externalComparisonError = 'The external version is not text.';
 				return;
 			}
-			externalComparisonContent = result.content;
+			const diff = createFileDiff(currentDraftContent, result.content);
+			const lines = await highlightGitDiffLines(
+				parseGitDiffLines(diff),
+				languageFromPath(currentFilePath) ?? languageFromExtension(result.extension)
+			);
+			if (
+				workspacePath !== currentWorkspacePath ||
+				filePath !== currentFilePath ||
+				draftContent !== currentDraftContent
+			)
+				return;
+			externalComparisonLines = lines;
+			externalComparisonOpen = true;
 		} catch (err) {
 			if (workspacePath !== currentWorkspacePath || filePath !== currentFilePath) return;
 			externalComparisonError =
@@ -316,8 +341,9 @@
 			workspaceFileChangeVersion(workspacePath, filePath)
 		);
 		externalChangePending = false;
-		externalComparisonContent = null;
+		externalComparisonLines = null;
 		externalComparisonError = null;
+		externalComparisonOpen = false;
 		void loadPreview();
 	});
 
@@ -327,8 +353,9 @@
 		lastObservedFileChangeVersion = changeVersion;
 		if (dirty) {
 			externalChangePending = true;
-			externalComparisonContent = null;
+			externalComparisonLines = null;
 			externalComparisonError = null;
+			externalComparisonOpen = false;
 			return;
 		}
 		void loadPreview();
@@ -412,7 +439,29 @@
 		</div>
 	{:else if previewKind === 'text'}
 		<div class="file-preview-editor-wrap">
-			{#if showMarkdownToggle}
+			{#if externalComparisonOpen && externalComparisonLines !== null}
+				<div class="external-diff-full-page" aria-label="External file comparison">
+					<header class="external-diff-toolbar">
+						<span>External change diff</span>
+						<div class="external-change-actions">
+							<button type="button" onclick={reloadAfterExternalChange}>Reload</button>
+							<button type="button" onclick={keepEditingAfterExternalChange}>Keep editing</button>
+							<button type="button" onclick={() => void compareExternalChange()}>
+								Close diff
+							</button>
+						</div>
+					</header>
+					<div class="external-diff-body">
+						{#if externalComparisonLines.length === 0}
+							<p>No content differences found.</p>
+						{:else}
+							<!-- prettier-ignore -->
+							<pre class="external-diff" data-lang={language ?? ''}><code>{#each externalComparisonLines as line, i (i)}<span class="diff-line kind-{line.kind}">{#if line.prefix}<span class="diff-prefix">{line.prefix}</span>{/if}<span class="diff-code">{@html line.html}</span></span>{/each}</code></pre>
+						{/if}
+					</div>
+				</div>
+			{:else}
+				{#if showMarkdownToggle}
 				<div class="md-view-toggle" role="group" aria-label="Markdown view mode">
 					<button
 						type="button"
@@ -431,11 +480,11 @@
 						Source
 					</button>
 				</div>
-			{/if}
-			{#if saveError}
+				{/if}
+				{#if saveError}
 				<div class="file-preview-save-error">{saveError}</div>
-			{/if}
-			{#if externalChangePending}
+				{/if}
+				{#if externalChangePending}
 				<div class="external-change-notice" role="status">
 					<span>This file changed outside Cometline.</span>
 					<div class="external-change-actions">
@@ -446,20 +495,9 @@
 				</div>
 				{#if externalComparisonError}
 					<div class="file-preview-save-error">{externalComparisonError}</div>
-				{:else if externalComparisonContent !== null}
-					<div class="external-comparison" aria-label="External file comparison">
-						<section>
-							<h3>Current draft</h3>
-							<pre>{draftContent}</pre>
-						</section>
-						<section>
-							<h3>Disk version</h3>
-							<pre>{externalComparisonContent}</pre>
-						</section>
-					</div>
 				{/if}
-			{/if}
-			{#if effectiveViewMode === 'preview'}
+				{/if}
+				{#if effectiveViewMode === 'preview'}
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div class="file-preview-markdown scrollbar-none" onmouseup={onPreviewMouseUp}>
 					<AssistantMarkdown
@@ -481,7 +519,7 @@
 						{@render backlinksSection()}
 					{/if}
 				</div>
-			{:else}
+				{:else}
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div class="file-preview-source-wrap" onmouseup={onSourceMouseUp}>
 					<FileEditor
@@ -503,6 +541,7 @@
 						{@render backlinksSection()}
 					{/if}
 				</div>
+				{/if}
 			{/if}
 		</div>
 	{/if}
@@ -744,35 +783,73 @@
 		border-color: var(--text-soft);
 	}
 
-	.external-comparison {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 1px;
-		max-height: 260px;
-		overflow: auto;
-		border-bottom: 1px solid var(--border-soft);
-		background: var(--border-soft);
+	.external-diff-full-page {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-height: 0;
 	}
 
-	.external-comparison section {
-		min-width: 0;
-		background: #fff;
-	}
-
-	.external-comparison h3 {
-		margin: 0;
+	.external-diff-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
 		padding: 6px 8px;
 		border-bottom: 1px solid var(--border-soft);
-		font-size: 11px;
+		color: var(--text-main);
+		font-size: 12px;
 		font-weight: 600;
 	}
 
-	.external-comparison pre {
+	.external-diff-body {
+		flex: 1;
+		min-height: 0;
+		overflow: auto;
+		background: #fff;
+	}
+
+	.external-diff-body p {
 		margin: 0;
-		padding: 8px;
+		padding: 10px;
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+
+	.external-diff {
+		margin: 0;
 		overflow: auto;
 		font: 11px/1.45 var(--font-mono, monospace);
-		white-space: pre-wrap;
+		white-space: pre;
+	}
+
+	.diff-line {
+		display: block;
+		padding: 0 8px;
+		white-space: pre;
+	}
+
+	.kind-meta,
+	.kind-hunk,
+	.kind-other,
+	.kind-ctx {
+		color: var(--text-muted);
+	}
+
+	.kind-add {
+		background: color-mix(in srgb, var(--status-success) 16%, transparent);
+	}
+
+	.kind-del {
+		background: color-mix(in srgb, var(--status-error) 14%, transparent);
+	}
+
+	.kind-add .diff-prefix {
+		color: var(--status-success);
+	}
+
+	.kind-del .diff-prefix {
+		color: var(--status-error);
 	}
 
 	@media (max-width: 640px) {
@@ -780,9 +857,9 @@
 			align-items: flex-start;
 			flex-direction: column;
 		}
-
-		.external-comparison {
-			grid-template-columns: 1fr;
+		.external-diff-toolbar {
+			align-items: flex-start;
+			flex-direction: column;
 		}
 	}
 

--- a/cometline/src/lib/components/FilePreview.svelte
+++ b/cometline/src/lib/components/FilePreview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Loader } from '@lucide/svelte';
+	import { untrack } from 'svelte';
 	import AssistantMarkdown from '$lib/components/AssistantMarkdown.svelte';
 	import FileEditor from '$lib/components/FileEditor.svelte';
 	import { portal } from '$lib/components/portal';
@@ -33,6 +34,7 @@
 		type MarkdownFileViewMode
 	} from '$lib/workspace/workspace-panel-prefs';
 	import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
+	import { workspaceFileChangeVersion } from '$lib/workspace/workspace-change.svelte';
 	import {
 		isWikiReadOnlyPath,
 		isWikiUiPath,
@@ -89,6 +91,10 @@
 		text: string;
 		lineRange: SelectionLineRange | null;
 	} | null>(null);
+	let externalChangePending = $state(false);
+	let externalComparisonContent = $state<string | null>(null);
+	let externalComparisonError = $state<string | null>(null);
+	let lastObservedFileChangeVersion = 0;
 
 	const readOnly = $derived(isWikiUiPath(filePath) && isWikiReadOnlyPath(filePath));
 	const dirty = $derived(previewKind === 'text' && draftContent !== savedContent && !readOnly);
@@ -179,6 +185,38 @@
 		if (previewKind !== 'text') return;
 		draftContent = savedContent;
 		saveError = null;
+	}
+
+	function keepEditingAfterExternalChange() {
+		externalChangePending = false;
+		externalComparisonContent = null;
+		externalComparisonError = null;
+	}
+
+	function reloadAfterExternalChange() {
+		keepEditingAfterExternalChange();
+		void loadPreview();
+	}
+
+	async function compareExternalChange() {
+		const currentWorkspacePath = workspacePath;
+		const currentFilePath = filePath;
+		externalComparisonError = null;
+		try {
+			const result = isWikiUiPath(currentFilePath)
+				? await readWikiFileContent(toWikiRelative(currentFilePath))
+				: await readWorkspaceFileContent(currentWorkspacePath, currentFilePath);
+			if (workspacePath !== currentWorkspacePath || filePath !== currentFilePath) return;
+			if (result.kind !== 'text') {
+				externalComparisonError = 'The external version is not text.';
+				return;
+			}
+			externalComparisonContent = result.content;
+		} catch (err) {
+			if (workspacePath !== currentWorkspacePath || filePath !== currentFilePath) return;
+			externalComparisonError =
+				err instanceof Error ? err.message : 'Failed to load the external file version';
+		}
 	}
 
 	async function save() {
@@ -274,6 +312,25 @@
 	$effect(() => {
 		// Track both inputs so the editor reloads when either changes.
 		void [workspacePath, filePath];
+		lastObservedFileChangeVersion = untrack(() =>
+			workspaceFileChangeVersion(workspacePath, filePath)
+		);
+		externalChangePending = false;
+		externalComparisonContent = null;
+		externalComparisonError = null;
+		void loadPreview();
+	});
+
+	$effect(() => {
+		const changeVersion = workspaceFileChangeVersion(workspacePath, filePath);
+		if (changeVersion === lastObservedFileChangeVersion) return;
+		lastObservedFileChangeVersion = changeVersion;
+		if (dirty) {
+			externalChangePending = true;
+			externalComparisonContent = null;
+			externalComparisonError = null;
+			return;
+		}
 		void loadPreview();
 	});
 
@@ -377,6 +434,30 @@
 			{/if}
 			{#if saveError}
 				<div class="file-preview-save-error">{saveError}</div>
+			{/if}
+			{#if externalChangePending}
+				<div class="external-change-notice" role="status">
+					<span>This file changed outside Cometline.</span>
+					<div class="external-change-actions">
+						<button type="button" onclick={reloadAfterExternalChange}>Reload</button>
+						<button type="button" onclick={keepEditingAfterExternalChange}>Keep editing</button>
+						<button type="button" onclick={() => void compareExternalChange()}>Compare</button>
+					</div>
+				</div>
+				{#if externalComparisonError}
+					<div class="file-preview-save-error">{externalComparisonError}</div>
+				{:else if externalComparisonContent !== null}
+					<div class="external-comparison" aria-label="External file comparison">
+						<section>
+							<h3>Current draft</h3>
+							<pre>{draftContent}</pre>
+						</section>
+						<section>
+							<h3>Disk version</h3>
+							<pre>{externalComparisonContent}</pre>
+						</section>
+					</div>
+				{/if}
 			{/if}
 			{#if effectiveViewMode === 'preview'}
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -630,6 +711,79 @@
 		background: rgba(180, 35, 24, 0.05);
 		color: var(--status-error);
 		font-size: 12px;
+	}
+
+	.external-change-notice {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding: 8px 10px;
+		border-bottom: 1px solid var(--border-soft);
+		background: color-mix(in srgb, var(--status-warning, #a16207) 10%, #fff);
+		color: var(--text-main);
+		font-size: 12px;
+	}
+
+	.external-change-actions {
+		display: flex;
+		gap: 6px;
+	}
+
+	.external-change-actions button {
+		border: 1px solid var(--border-soft);
+		border-radius: 5px;
+		padding: 3px 6px;
+		background: #fff;
+		color: var(--text-main);
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.external-change-actions button:hover {
+		border-color: var(--text-soft);
+	}
+
+	.external-comparison {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 1px;
+		max-height: 260px;
+		overflow: auto;
+		border-bottom: 1px solid var(--border-soft);
+		background: var(--border-soft);
+	}
+
+	.external-comparison section {
+		min-width: 0;
+		background: #fff;
+	}
+
+	.external-comparison h3 {
+		margin: 0;
+		padding: 6px 8px;
+		border-bottom: 1px solid var(--border-soft);
+		font-size: 11px;
+		font-weight: 600;
+	}
+
+	.external-comparison pre {
+		margin: 0;
+		padding: 8px;
+		overflow: auto;
+		font: 11px/1.45 var(--font-mono, monospace);
+		white-space: pre-wrap;
+	}
+
+	@media (max-width: 640px) {
+		.external-change-notice {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		.external-comparison {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/cometline/src/lib/components/FileTreeBrowser.svelte
+++ b/cometline/src/lib/components/FileTreeBrowser.svelte
@@ -12,6 +12,7 @@
 		type FileTreeNode
 	} from '$lib/workspace/file-tree';
 	import { normalizeWorkspacePath } from '$lib/workspace/file-index';
+	import { workspaceChangeVersion } from '$lib/workspace/workspace-change.svelte';
 
 	const LIST_LIMIT = 10000;
 
@@ -199,7 +200,7 @@
 	}
 
 	$effect(() => {
-		void [filter, normalizedWorkspace];
+		void [filter, normalizedWorkspace, workspaceChangeVersion(normalizedWorkspace)];
 		void loadFiles();
 	});
 

--- a/cometline/src/lib/components/GitChangesBrowser.svelte
+++ b/cometline/src/lib/components/GitChangesBrowser.svelte
@@ -23,6 +23,7 @@
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import { normalizeWorkspacePath } from '$lib/workspace/file-index';
 	import { hasUnstagedSide } from '$lib/workspace/git-file-state';
+	import { workspaceChangeVersion } from '$lib/workspace/workspace-change.svelte';
 
 	type GitFile = WorkspaceGitStatus['files'][number];
 	type DiscardConfirm = { kind: 'one'; path: string } | { kind: 'all' };
@@ -231,7 +232,7 @@
 	}
 
 	$effect(() => {
-		void normalizedWorkspace;
+		void [normalizedWorkspace, workspaceChangeVersion(normalizedWorkspace)];
 		void load();
 	});
 </script>

--- a/cometline/src/lib/components/GitDiffView.svelte
+++ b/cometline/src/lib/components/GitDiffView.svelte
@@ -22,6 +22,7 @@
 		type GitFileStageState
 	} from '$lib/workspace/git-file-state';
 	import { languageFromPath } from '$lib/workspace/file-preview';
+	import { workspaceChangeVersion } from '$lib/workspace/workspace-change.svelte';
 	import { buildFileSnippetContext } from '$lib/workspace/selection-snippet';
 	import {
 		firstSelectionClientRect,
@@ -229,7 +230,7 @@
 	}
 
 	$effect(() => {
-		void [workspacePath, filePath, scope];
+		void [workspacePath, filePath, scope, workspaceChangeVersion(workspacePath)];
 		void load();
 	});
 

--- a/cometline/src/lib/components/composer/composer-mentions.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-mentions.svelte.ts
@@ -14,6 +14,7 @@ import {
 	searchWorkspaceFiles,
 	type MentionPath
 } from '$lib/workspace/file-index';
+import { workspaceChangeVersion } from '$lib/workspace/workspace-change.svelte';
 import type { ComposerInputRef } from '$lib/components/composer/composer-input-ref';
 
 type IdleHandle =
@@ -110,6 +111,7 @@ export function createComposerMentionsController(deps: {
 	$effect(() => {
 		const workspacePath = activeWorkspacePath;
 		if (!workspacePath || workspacePath === '/') return;
+		void workspaceChangeVersion(workspacePath);
 		if (isFileIndexReady(workspacePath)) return;
 		const handle = scheduleIdle(() => {
 			if (

--- a/cometline/src/lib/workspace/file-diff.test.ts
+++ b/cometline/src/lib/workspace/file-diff.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { createFileDiff } from './file-diff';
+
+describe('createFileDiff', () => {
+	it('returns an empty diff when file contents match', () => {
+		expect(createFileDiff('same\n', 'same\n')).toBe('');
+	});
+
+	it('creates a unified hunk with additions, deletions, and context', () => {
+		expect(createFileDiff('one\ntwo\nthree\n', 'one\nsecond\nthree\n')).toBe(
+			[
+				'--- Current draft',
+				'+++ Disk version',
+				'@@ -1,3 +1,3 @@',
+				' one',
+				'-two',
+				'+second',
+				' three',
+				''
+			].join('\n')
+		);
+	});
+});

--- a/cometline/src/lib/workspace/file-diff.ts
+++ b/cometline/src/lib/workspace/file-diff.ts
@@ -1,0 +1,54 @@
+function linesFromText(text: string): string[] {
+	const normalized = String(text ?? '').replace(/\r\n/g, '\n');
+	if (!normalized) return [];
+	return normalized.endsWith('\n') ? normalized.slice(0, -1).split('\n') : normalized.split('\n');
+}
+
+function formatRange(start: number, count: number): string {
+	return count === 1 ? String(start) : `${start},${count}`;
+}
+
+/**
+ * Builds one context hunk around the changed range. This is intentionally
+ * linear so comparing a large dirty draft stays responsive.
+ */
+export function createFileDiff(before: string, after: string): string {
+	const oldLines = linesFromText(before);
+	const newLines = linesFromText(after);
+	let prefix = 0;
+	while (
+		prefix < oldLines.length &&
+		prefix < newLines.length &&
+		oldLines[prefix] === newLines[prefix]
+	) {
+		prefix += 1;
+	}
+	if (prefix === oldLines.length && prefix === newLines.length) return '';
+
+	let suffix = 0;
+	while (
+		suffix < oldLines.length - prefix &&
+		suffix < newLines.length - prefix &&
+		oldLines[oldLines.length - suffix - 1] === newLines[newLines.length - suffix - 1]
+	) {
+		suffix += 1;
+	}
+
+	const contextStart = Math.max(0, prefix - 3);
+	const oldChangedEnd = oldLines.length - suffix;
+	const newChangedEnd = newLines.length - suffix;
+	const oldEnd = Math.min(oldLines.length, oldChangedEnd + 3);
+	const newEnd = Math.min(newLines.length, newChangedEnd + 3);
+	const diff = ['--- Current draft', '+++ Disk version'];
+	diff.push(
+		`@@ -${formatRange(contextStart + 1, oldEnd - contextStart)} +${formatRange(
+			contextStart + 1,
+			newEnd - contextStart
+		)} @@`
+	);
+	for (let i = contextStart; i < prefix; i += 1) diff.push(` ${oldLines[i]}`);
+	for (let i = prefix; i < oldChangedEnd; i += 1) diff.push(`-${oldLines[i]}`);
+	for (let i = prefix; i < newChangedEnd; i += 1) diff.push(`+${newLines[i]}`);
+	for (let i = oldChangedEnd; i < oldEnd; i += 1) diff.push(` ${oldLines[i]}`);
+	return `${diff.join('\n')}\n`;
+}

--- a/cometline/src/lib/workspace/workspace-change.svelte.test.ts
+++ b/cometline/src/lib/workspace/workspace-change.svelte.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyWorkspaceChange,
+	refreshWorkspace,
+	workspaceChangeVersion,
+	workspaceFileChangeVersion
+} from './workspace-change.svelte';
+
+describe('workspace change store', () => {
+	it('tracks changed paths without reloading unrelated file previews', () => {
+		const workspace = `/tmp/workspace-change-${crypto.randomUUID()}`;
+
+		applyWorkspaceChange({
+			workspacePath: workspace,
+			paths: ['src\\app.ts'],
+			gitChanged: false
+		});
+
+		expect(workspaceChangeVersion(workspace)).toBe(1);
+		expect(workspaceFileChangeVersion(workspace, 'src/app.ts')).toBe(1);
+		expect(workspaceFileChangeVersion(workspace, 'README.md')).toBe(0);
+	});
+
+	it('refreshes all file previews for an unknown external change', () => {
+		const workspace = `/tmp/workspace-refresh-${crypto.randomUUID()}`;
+
+		refreshWorkspace(workspace);
+
+		expect(workspaceChangeVersion(workspace)).toBe(1);
+		expect(workspaceFileChangeVersion(workspace, 'README.md')).toBe(1);
+	});
+
+	it('keeps Git-only changes out of file preview refreshes', () => {
+		const workspace = `/tmp/workspace-git-${crypto.randomUUID()}`;
+
+		applyWorkspaceChange({ workspacePath: workspace, paths: [], gitChanged: true });
+
+		expect(workspaceChangeVersion(workspace)).toBe(1);
+		expect(workspaceFileChangeVersion(workspace, 'README.md')).toBe(0);
+	});
+});

--- a/cometline/src/lib/workspace/workspace-change.svelte.ts
+++ b/cometline/src/lib/workspace/workspace-change.svelte.ts
@@ -1,0 +1,61 @@
+import { clearFileIndex, normalizeWorkspacePath } from './file-index';
+
+export type WorkspaceChange = {
+	workspacePath: string;
+	paths: string[];
+	gitChanged: boolean;
+};
+
+type WorkspaceChangeState = {
+	version: number;
+	unknownFileVersion: number;
+	fileVersions: Record<string, number>;
+};
+
+const changes = $state<Record<string, WorkspaceChangeState>>({});
+
+function normalizeFilePath(filePath: string): string {
+	return filePath.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+function stateFor(workspacePath: string): WorkspaceChangeState | undefined {
+	return changes[normalizeWorkspacePath(workspacePath)];
+}
+
+function recordChange(workspacePath: string, paths: string[], unknownFiles: boolean) {
+	const workspace = normalizeWorkspacePath(workspacePath);
+	if (!workspace || workspace === '/') return;
+	const current = changes[workspace] ?? { version: 0, unknownFileVersion: 0, fileVersions: {} };
+	const fileVersions = { ...current.fileVersions };
+	for (const rawPath of paths) {
+		const filePath = normalizeFilePath(rawPath);
+		if (filePath) fileVersions[filePath] = (fileVersions[filePath] ?? 0) + 1;
+	}
+	changes[workspace] = {
+		version: current.version + 1,
+		unknownFileVersion: current.unknownFileVersion + (unknownFiles ? 1 : 0),
+		fileVersions
+	};
+	if (paths.length > 0 || unknownFiles) clearFileIndex(workspace);
+}
+
+/** Applies a coalesced Electron filesystem watcher notification. */
+export function applyWorkspaceChange(change: WorkspaceChange): void {
+	const paths = change.paths.map(normalizeFilePath).filter(Boolean);
+	recordChange(change.workspacePath, paths, paths.length === 0 && !change.gitChanged);
+}
+
+/** Refreshes stale state after this window regains focus. */
+export function refreshWorkspace(workspacePath: string): void {
+	recordChange(workspacePath, [], true);
+}
+
+export function workspaceChangeVersion(workspacePath: string): number {
+	return stateFor(workspacePath)?.version ?? 0;
+}
+
+export function workspaceFileChangeVersion(workspacePath: string, filePath: string): number {
+	const state = stateFor(workspacePath);
+	if (!state) return 0;
+	return state.unknownFileVersion + (state.fileVersions[normalizeFilePath(filePath)] ?? 0);
+}

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
 		resolveWorkspacePanelRatio,
 		widthFromRatio
 	} from '$lib/layout/workspace-panel-width';
+	import { applyWorkspaceChange, refreshWorkspace } from '$lib/workspace/workspace-change.svelte';
 
 	let { children } = $props();
 
@@ -88,6 +89,14 @@
 				personaAvatarCache.invalidate(personaId);
 			}
 		);
+		const unsubscribeWorkspaceChanged = window.electronAPI?.onWorkspaceChanged?.(
+			applyWorkspaceChange
+		);
+		const refreshOnFocus = () => {
+			if (isMiniRoute || isSettingsRoute) return;
+			refreshWorkspace(shellStore.workspacePath);
+		};
+		window.addEventListener('focus', refreshOnFocus);
 		void settingsStore.load().then(() => {
 			settingsLoaded = true;
 			stopStorageRetentionSync = startStorageRetentionSync(
@@ -115,6 +124,8 @@
 			stopStorageRetentionSync?.();
 			unsubscribeSettingsChanged?.();
 			unsubscribePersonaAvatar?.();
+			unsubscribeWorkspaceChanged?.();
+			window.removeEventListener('focus', refreshOnFocus);
 		};
 	});
 
@@ -177,6 +188,13 @@
 
 	let sessionsLoaded = false;
 	let lastEnsuredWorkspace = '';
+
+	$effect(() => {
+		const workspacePath = shellStore.workspacePath;
+		if (isMiniRoute || isSettingsRoute) return;
+		if (!workspacePath || workspacePath === '/') return;
+		void window.electronAPI?.watchWorkspace?.(workspacePath);
+	});
 
 	$effect(() => {
 		const workspacePath = shellStore.workspacePath;


### PR DESCRIPTION
## Background

Workspace views remained stale when files changed outside Cometline. Electron now watches the active workspace so edits from IDEs, terminals, Git operations, and agents refresh the relevant UI without chat tool-specific invalidation.

[68a10ba](https://github.com/Cometline/cometline/commit/68a10ba842c07dd0983429a074f6bcdc92c16d20): Adds a debounced Electron workspace watcher and the preload IPC contract used to broadcast file and Git metadata changes.

[5b63365](https://github.com/Cometline/cometline/commit/5b63365d228e3d3755f6119feaf1a4557a077faf): Connects watcher events and focus refreshes to the workspace tree, Git views, and file mention index.

[3cc4889](https://github.com/Cometline/cometline/commit/3cc4889bbd43a9c18dbb45374cd2903115abaffd): Preserves dirty editor drafts when a file changes externally and offers reload, keep editing, and comparison actions.

[037d603](https://github.com/Cometline/cometline/commit/037d603ce3435aba72079f06dde716fb838f288f): Renders the external comparison as a full-pane, syntax-highlighted unified diff.