### PR TITLE
[main] feat: slide activity group toggle

### DIFF
--- a/cometline/src/lib/components/chat/AssistantActivityGroup.svelte
+++ b/cometline/src/lib/components/chat/AssistantActivityGroup.svelte
@@ -71,6 +71,7 @@
 	}
 
 	const CHILD_FADE = { duration: 500 };
+	const ACTIVITY_GROUP_SLIDE = { duration: 180 };
 	const CHILD_SLIDE_IN = { duration: 350, easing: cubicOut };
 	const CHILD_SLIDE_OUT = { duration: 280, easing: cubicOut };
 
@@ -132,7 +133,11 @@
 			<ChevronDown size={13} class={parentExpanded ? 'expanded' : ''} />
 		</button>
 		{#if parentExpanded}
-			<div id={bodyId} class="fold-body activity-group-body scrollbar-none">
+			<div
+				id={bodyId}
+				class="fold-body activity-group-body scrollbar-none"
+				transition:slide={ACTIVITY_GROUP_SLIDE}
+			>
 				{#if firstEntry.kind === 'memory'}
 					<MemoryCard
 						memories={firstEntry.memories}


### PR DESCRIPTION
## Background

Activity groups currently appear and disappear immediately when toggled, which makes the chat timeline feel abrupt. A short slide transition brings this fold panel in line with the other expandable activity panels.

[23209ad](https://github.com/Cometline/cometline/commit/23209ad93dece55a3ae8b5a1c322eb52ac5840a4): Added a 180ms bidirectional slide transition to the activity group body so expanding and collapsing feels consistent with the surrounding fold panels.