### PR TITLE
[main] feat: add model reasoning effort controls

### DIFF
--- a/comet-sdk/internal/responsesproto/protocol.go
+++ b/comet-sdk/internal/responsesproto/protocol.go
@@ -45,9 +45,10 @@ type Request struct {
 	Include         []string    `json:"include,omitempty"`
 }
 
-// Reasoning requests displayable reasoning summaries.
+// Reasoning requests displayable reasoning summaries and optional effort.
 type Reasoning struct {
 	Summary string `json:"summary,omitempty"`
+	Effort  string `json:"effort,omitempty"`
 }
 
 // InputItem is one input entry: a role message, a reasoning item, a function
@@ -140,10 +141,15 @@ func BuildRequest(req *cometsdk.Request, opts RequestOptions) ([]byte, error) {
 		Stream:       true,
 		Temperature:  req.Temperature,
 	}
-	if !opts.DisableReasoningSummary {
+	if !opts.DisableReasoningSummary || req.ReasoningEffort != "" {
 		// Ask for a displayable summary when the model supports it. Providers
 		// retry without this field if a model rejects it.
-		out.Reasoning = &Reasoning{Summary: "auto"}
+		reasoning := &Reasoning{}
+		if !opts.DisableReasoningSummary {
+			reasoning.Summary = "auto"
+		}
+		reasoning.Effort = req.ReasoningEffort
+		out.Reasoning = reasoning
 	}
 	if req.MaxTokens > 0 && !opts.DisableMaxOutputTokens {
 		out.MaxOutputTokens = req.MaxTokens

--- a/comet-sdk/provider/anthropic/convert.go
+++ b/comet-sdk/provider/anthropic/convert.go
@@ -13,12 +13,13 @@ import (
 // ─── Outgoing: SDK Request → Anthropic JSON ───────────────────────────────────
 
 type anthropicRequest struct {
-	Model     string             `json:"model"`
-	MaxTokens int                `json:"max_tokens"`
-	System    string             `json:"system,omitempty"`
-	Messages  []anthropicMessage `json:"messages"`
-	Tools     []anthropicTool    `json:"tools,omitempty"`
-	Stream    bool               `json:"stream"`
+	Model           string             `json:"model"`
+	MaxTokens       int                `json:"max_tokens"`
+	System          string             `json:"system,omitempty"`
+	Messages        []anthropicMessage `json:"messages"`
+	Tools           []anthropicTool    `json:"tools,omitempty"`
+	Effort          string             `json:"effort,omitempty"`
+	Stream          bool               `json:"stream"`
 }
 
 type anthropicMessage struct {
@@ -82,6 +83,7 @@ func toAnthropicRequest(req *cometsdk.Request) ([]byte, error) {
 		MaxTokens: maxTokens,
 		System:    req.System,
 		Messages:  msgs,
+		Effort:    req.ReasoningEffort,
 		Stream:    true,
 	}
 

--- a/comet-sdk/provider/anthropic/convert.go
+++ b/comet-sdk/provider/anthropic/convert.go
@@ -13,13 +13,17 @@ import (
 // ─── Outgoing: SDK Request → Anthropic JSON ───────────────────────────────────
 
 type anthropicRequest struct {
-	Model           string             `json:"model"`
-	MaxTokens       int                `json:"max_tokens"`
-	System          string             `json:"system,omitempty"`
-	Messages        []anthropicMessage `json:"messages"`
-	Tools           []anthropicTool    `json:"tools,omitempty"`
-	Effort          string             `json:"effort,omitempty"`
-	Stream          bool               `json:"stream"`
+	Model        string                 `json:"model"`
+	MaxTokens    int                    `json:"max_tokens"`
+	System       string                 `json:"system,omitempty"`
+	Messages     []anthropicMessage     `json:"messages"`
+	Tools        []anthropicTool        `json:"tools,omitempty"`
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+	Stream       bool                   `json:"stream"`
+}
+
+type anthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 type anthropicMessage struct {
@@ -83,8 +87,10 @@ func toAnthropicRequest(req *cometsdk.Request) ([]byte, error) {
 		MaxTokens: maxTokens,
 		System:    req.System,
 		Messages:  msgs,
-		Effort:    req.ReasoningEffort,
 		Stream:    true,
+	}
+	if req.ReasoningEffort != "" {
+		ar.OutputConfig = &anthropicOutputConfig{Effort: req.ReasoningEffort}
 	}
 
 	for _, t := range req.Tools {

--- a/comet-sdk/provider/anthropic/convert_test.go
+++ b/comet-sdk/provider/anthropic/convert_test.go
@@ -80,6 +80,31 @@ func TestConvertRequest_ToolCall(t *testing.T) {
 	require.JSONEq(t, `{"path":"main.go"}`, string(block.Input))
 }
 
+func TestConvertRequest_ReasoningEffort(t *testing.T) {
+	req := &cometsdk.Request{
+		Model:           "claude-sonnet-4-5",
+		ReasoningEffort: "high",
+		Messages: []cometsdk.Message{
+			{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}},
+		},
+	}
+
+	data, err := toAnthropicRequest(req)
+	require.NoError(t, err)
+
+	var out anthropicRequest
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Equal(t, "high", out.Effort)
+
+	// Empty effort is omitted entirely.
+	data, err = toAnthropicRequest(&cometsdk.Request{
+		Model:    "claude-sonnet-4-5",
+		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "effort")
+}
+
 func TestConvertRequest_EmptyContentFiltered(t *testing.T) {
 	// Anthropic rejects messages with empty content arrays.
 	req := &cometsdk.Request{

--- a/comet-sdk/provider/anthropic/convert_test.go
+++ b/comet-sdk/provider/anthropic/convert_test.go
@@ -94,15 +94,20 @@ func TestConvertRequest_ReasoningEffort(t *testing.T) {
 
 	var out anthropicRequest
 	require.NoError(t, json.Unmarshal(data, &out))
-	require.Equal(t, "high", out.Effort)
+	require.NotNil(t, out.OutputConfig)
+	require.Equal(t, "high", out.OutputConfig.Effort)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.NotContains(t, raw, "effort")
+	require.Equal(t, map[string]any{"effort": "high"}, raw["output_config"])
 
-	// Empty effort is omitted entirely.
+	// Empty effort omits output_config entirely.
 	data, err = toAnthropicRequest(&cometsdk.Request{
 		Model:    "claude-sonnet-4-5",
 		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
 	})
 	require.NoError(t, err)
-	require.NotContains(t, string(data), "effort")
+	require.NotContains(t, string(data), "output_config")
 }
 
 func TestConvertRequest_EmptyContentFiltered(t *testing.T) {

--- a/comet-sdk/provider/codex/convert_test.go
+++ b/comet-sdk/provider/codex/convert_test.go
@@ -478,6 +478,35 @@ func TestStream_UsesSSE(t *testing.T) {
 	require.Contains(t, events, cometsdk.DoneEvent{})
 }
 
+func TestConvertRequest_ReasoningEffort(t *testing.T) {
+	req := &cometsdk.Request{
+		Model:           "gpt-5.6-luna",
+		ReasoningEffort: "high",
+		Messages: []cometsdk.Message{
+			{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}},
+		},
+	}
+
+	data, err := toCodexRequest(req, false, false, false)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	reasoning, ok := raw["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "high", reasoning["effort"])
+	require.Equal(t, "auto", reasoning["summary"])
+
+	// Empty effort keeps only the summary.
+	data, err = toCodexRequest(&cometsdk.Request{
+		Model:    "gpt-5.4",
+		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
+	}, false, false, false)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Equal(t, map[string]any{"summary": "auto"}, raw["reasoning"])
+}
+
 func writeTestAuthFile(t *testing.T, path string) string {
 	t.Helper()
 	exp := time.Now().Add(time.Hour).Unix()

--- a/comet-sdk/provider/openai/convert.go
+++ b/comet-sdk/provider/openai/convert.go
@@ -17,6 +17,7 @@ type openAIRequest struct {
 	Tools               []openAITool    `json:"tools,omitempty"`
 	MaxTokens           int             `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+	ReasoningEffort     string          `json:"reasoning_effort,omitempty"`
 	Stream              bool            `json:"stream"`
 	StreamOptions       *streamOptions  `json:"stream_options,omitempty"`
 	ReasoningSplit      *bool           `json:"reasoning_split,omitempty"`
@@ -96,6 +97,9 @@ func toOpenAIRequest(req *cometsdk.Request, disableImageContent bool, enableReas
 		} else {
 			or.MaxTokens = req.MaxTokens
 		}
+	}
+	if req.ReasoningEffort != "" {
+		or.ReasoningEffort = req.ReasoningEffort
 	}
 
 	for _, t := range req.Tools {

--- a/comet-sdk/provider/openai/convert_test.go
+++ b/comet-sdk/provider/openai/convert_test.go
@@ -30,6 +30,30 @@ func TestConvertRequest_SystemPromptPrepended(t *testing.T) {
 	require.Equal(t, "user", out.Messages[1].Role)
 }
 
+func TestConvertRequest_ReasoningEffort(t *testing.T) {
+	req := &cometsdk.Request{
+		Model:           "gpt-5.5",
+		ReasoningEffort: "high",
+		Messages: []cometsdk.Message{
+			{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hello"}}},
+		},
+	}
+
+	data, err := toOpenAIRequest(req, false, true, false)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Equal(t, "high", out["reasoning_effort"])
+
+	// Empty effort is omitted entirely.
+	data, err = toOpenAIRequest(&cometsdk.Request{
+		Model:    "gpt-4o",
+		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
+	}, false, true, false)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "reasoning_effort")
+}
 func TestConvertRequest_ToolResultRole(t *testing.T) {
 	req := &cometsdk.Request{
 		Model: "gpt-4o",

--- a/comet-sdk/sdk.go
+++ b/comet-sdk/sdk.go
@@ -49,6 +49,12 @@ type Request struct {
 	// Temperature controls randomness. nil means use the provider default.
 	Temperature *float64
 
+	// ReasoningEffort requests a specific reasoning effort level when the
+	// model supports it (e.g. "low", "medium", "high"). Empty means the
+	// provider default. Providers that do not support the value reject the
+	// request, so callers should only set values the model advertises.
+	ReasoningEffort string
+
 	// Options holds provider-specific overrides.
 	// Most callers leave this nil.
 	Options map[string]any

--- a/cometline/src/lib/actions/start-chat.ts
+++ b/cometline/src/lib/actions/start-chat.ts
@@ -23,6 +23,8 @@ export interface ChatTurnPayload {
 	images?: ImageAttachment[];
 	filePaths?: string[];
 	webContexts?: WebContext[];
+	/** Per-turn reasoning effort override; empty means the runtime default. */
+	reasoningEffort?: string;
 }
 
 export interface StartChatAdapter {

--- a/cometline/src/lib/actions/start-chat.ts
+++ b/cometline/src/lib/actions/start-chat.ts
@@ -23,7 +23,7 @@ export interface ChatTurnPayload {
 	images?: ImageAttachment[];
 	filePaths?: string[];
 	webContexts?: WebContext[];
-	/** Per-turn reasoning effort override; empty means the runtime default. */
+	/** Per-turn reasoning effort override; empty means the provider default. */
 	reasoningEffort?: string;
 }
 

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -369,6 +369,11 @@
 				runShortcutAction('openSettings');
 				return;
 			}
+			if (matchesShortcut(event, shortcuts.cycleReasoningEffort)) {
+				// Owned by the composer (cycles reasoning effort when the active
+				// model supports it); must not fall through to newChat.
+				return;
+			}
 			if (matchesShortcut(event, shortcuts.newChat)) {
 				event.preventDefault();
 				runShortcutAction('newChat');

--- a/cometline/src/lib/components/MiniShell.svelte
+++ b/cometline/src/lib/components/MiniShell.svelte
@@ -53,6 +53,11 @@
 			shellStore.requestSessionFind();
 			return;
 		}
+		if (matchesShortcut(event, settingsStore.settings.shortcuts.cycleReasoningEffort)) {
+			// Owned by the composer (cycles reasoning effort when the active
+			// model supports it); must not fall through to newChat.
+			return;
+		}
 		if (matchesShortcut(event, settingsStore.settings.shortcuts.newChat)) {
 			event.preventDefault();
 			void createSession();

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -146,6 +146,7 @@
 		getDisabled: () => disabled,
 		getHasSelectedModel: () => Boolean(modelStore.selected),
 		getReasoningEffort: () => getReasoningEffort(sessionId),
+		getReasoningEffortOptions: () => modelStore.selected?.reasoningEffortOptions ?? [],
 		clearDraft
 	});
 
@@ -184,7 +185,7 @@
 			images = next;
 		},
 		sendTurn: (payload) => inputController.sendTurn(payload),
-		onModelChange: (option) => onModelChange?.(option),
+		onModelChange: changeModel,
 		onWorkspaceChanged: () => onWorkspaceChanged?.(),
 		onTranscriptCleared: () => onTranscriptCleared?.(),
 		setDropMessage: (message) => attachments.setDropMessage(message),
@@ -409,10 +410,23 @@
 		onRemoveQueued?.(id);
 	}
 
+	async function changeModel(option: ModelOption) {
+		const current = getReasoningEffort(sessionId);
+		if (current && !(option.reasoningEffortOptions ?? []).includes(current)) {
+			setReasoningEffort(sessionId, '');
+		}
+		await onModelChange?.(option);
+	}
+
+	function currentReasoningEffort() {
+		const current = getReasoningEffort(sessionId);
+		return (modelStore.selected?.reasoningEffortOptions ?? []).includes(current) ? current : '';
+	}
+
 	function cycleReasoningEffort() {
 		const supported = modelStore.selected?.reasoningEffortOptions ?? [];
 		if (supported.length === 0) return;
-		const next = nextReasoningEffort(getReasoningEffort(sessionId), supported);
+		const next = nextReasoningEffort(currentReasoningEffort(), supported);
 		setReasoningEffort(sessionId, next);
 	}
 </script>
@@ -492,8 +506,8 @@
 		{streaming}
 		{canSubmit}
 		{disabled}
-		{onModelChange}
-		reasoningEffort={getReasoningEffort(sessionId)}
+		onModelChange={changeModel}
+		reasoningEffort={currentReasoningEffort()}
 		reasoningEffortOptions={modelStore.selected?.reasoningEffortOptions ?? []}
 		onCycleReasoningEffort={cycleReasoningEffort}
 		onOpenChangeWorkspace={slash.openChangeWorkspace}

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -28,6 +28,8 @@
 	import { createComposerSlashController } from '$lib/components/composer/composer-slash.svelte';
 	import { stepHistoryIndex } from '$lib/components/composer/composer-history';
 	import { nextAttachmentRemoval } from '$lib/components/composer/composer-attachment-keydown';
+	import { nextReasoningEffort } from '$lib/composer/reasoning-effort';
+	import { getReasoningEffort, setReasoningEffort } from '$lib/stores/reasoning-effort.svelte';
 
 	let {
 		onSend,
@@ -143,6 +145,7 @@
 		getImages: () => images,
 		getDisabled: () => disabled,
 		getHasSelectedModel: () => Boolean(modelStore.selected),
+		getReasoningEffort: () => getReasoningEffort(sessionId),
 		clearDraft
 	});
 
@@ -336,6 +339,14 @@
 	}
 
 	function onKeydown(e: KeyboardEvent) {
+		if (
+			!e.isComposing &&
+			matchesShortcut(e, settingsStore.settings.shortcuts.cycleReasoningEffort)
+		) {
+			e.preventDefault();
+			cycleReasoningEffort();
+			return;
+		}
 		if (slash.handleMenuKeydown(e)) return;
 		if (mentions.handleMentionMenuKeydown(e)) return;
 		if (
@@ -396,6 +407,13 @@
 
 	function removeQueued(id: string) {
 		onRemoveQueued?.(id);
+	}
+
+	function cycleReasoningEffort() {
+		const supported = modelStore.selected?.reasoningEffortOptions ?? [];
+		if (supported.length === 0) return;
+		const next = nextReasoningEffort(getReasoningEffort(sessionId), supported);
+		setReasoningEffort(sessionId, next);
 	}
 </script>
 
@@ -475,6 +493,9 @@
 		{canSubmit}
 		{disabled}
 		{onModelChange}
+		reasoningEffort={getReasoningEffort(sessionId)}
+		reasoningEffortOptions={modelStore.selected?.reasoningEffortOptions ?? []}
+		onCycleReasoningEffort={cycleReasoningEffort}
 		onOpenChangeWorkspace={slash.openChangeWorkspace}
 		{onStop}
 		onSubmit={() => void submit()}

--- a/cometline/src/lib/components/composer/ComposerToolbar.svelte
+++ b/cometline/src/lib/components/composer/ComposerToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Folder, Send, Square } from '@lucide/svelte';
+	import { Brain, Folder, Send, Square } from '@lucide/svelte';
 	import ContextWindowRing from '$lib/components/composer/ContextWindowRing.svelte';
 	import ModelPicker from '$lib/components/composer/ModelPicker.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
@@ -15,6 +15,9 @@
 		canSubmit,
 		disabled,
 		onModelChange,
+		reasoningEffort,
+		reasoningEffortOptions,
+		onCycleReasoningEffort,
 		onOpenChangeWorkspace,
 		onStop,
 		onSubmit
@@ -27,17 +30,25 @@
 		canSubmit: boolean;
 		disabled: boolean;
 		onModelChange?: (option: ModelOption) => void | Promise<void>;
+		reasoningEffort: string;
+		reasoningEffortOptions: string[];
+		onCycleReasoningEffort: () => void;
 		onOpenChangeWorkspace: () => void;
 		onStop?: () => void;
 		onSubmit: () => void;
 	} = $props();
 
 	const sendLabel = $derived(streaming ? 'Queue follow-up' : 'Send');
+	const effortSupported = $derived(reasoningEffortOptions.length > 0);
+	const effortLabel = $derived(
+		reasoningEffort
+			? reasoningEffort.charAt(0).toUpperCase() + reasoningEffort.slice(1)
+			: 'Auto'
+	);
 </script>
 
 <div class="composer-footer">
 	<div class="composer-tools">
-		<ModelPicker {onModelChange} />
 		{#if hasWorkspace}
 			<button
 				type="button"
@@ -51,6 +62,28 @@
 				<span>{currentWorkspaceLabel}</span>
 			</button>
 		{/if}
+		<ModelPicker {onModelChange} />
+		<Tooltip
+			label={effortSupported
+				? `Reasoning effort: ${effortLabel}`
+				: 'Reasoning effort unavailable for this model'}
+			action="cycleReasoningEffort"
+			disabled={!effortSupported}
+		>
+			<button
+				type="button"
+				class="effort-button"
+				class:active={Boolean(reasoningEffort)}
+				disabled={!effortSupported}
+				onclick={onCycleReasoningEffort}
+				aria-label={effortSupported
+					? `Reasoning effort: ${effortLabel}. Cycle effort.`
+					: 'Reasoning effort unavailable for this model'}
+			>
+				<Brain size={15} stroke-width={1.8} />
+				<span class="effort-label">{effortLabel}</span>
+			</button>
+		</Tooltip>
 	</div>
 
 	<div class="composer-actions">
@@ -127,6 +160,44 @@
 	.composer-footer button:disabled {
 		opacity: 0.4;
 		cursor: not-allowed;
+	}
+
+	.effort-button {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 5px 6px;
+		line-height: 1;
+	}
+
+	.effort-button.active {
+		color: var(--text-muted);
+	}
+
+	.effort-button :global(svg) {
+		color: color-mix(
+			in srgb,
+			var(--hero-composer-glow-color, #72c0ff) 58%,
+			var(--accent, #0066cc)
+		);
+		transition:
+			color 160ms ease,
+			filter 160ms ease;
+	}
+
+	.effort-button.active :global(svg) {
+		color: var(--hero-composer-glow-color, #72c0ff);
+		filter: drop-shadow(0 0 5px var(--hero-composer-glow-ring, rgba(114, 192, 255, 0.2)));
+	}
+
+	.effort-label {
+		max-width: 5.5rem;
+		overflow: hidden;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.send-button {

--- a/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
@@ -9,6 +9,7 @@ function deps(overrides: Partial<Parameters<typeof createComposerInputController
 		getDisabled: () => false,
 		getHasSelectedModel: () => true,
 		getReasoningEffort: () => '',
+		getReasoningEffortOptions: () => [],
 		clearDraft: vi.fn(),
 		...overrides
 	};
@@ -35,12 +36,25 @@ describe('createComposerInputController', () => {
 
 	it('buildSubmitPayload attaches the reasoning effort when set', () => {
 		const controller = createComposerInputController(
-			deps({ getReasoningEffort: () => 'high' })
+			deps({
+				getReasoningEffort: () => 'high',
+				getReasoningEffortOptions: () => ['low', 'medium', 'high']
+			})
 		);
 		expect(controller.buildSubmitPayload([])).toEqual({
 			text: 'hello',
 			reasoningEffort: 'high'
 		});
+	});
+
+	it('buildSubmitPayload omits an effort unsupported by the selected model', () => {
+		const controller = createComposerInputController(
+			deps({
+				getReasoningEffort: () => 'high',
+				getReasoningEffortOptions: () => ['low', 'medium']
+			})
+		);
+		expect(controller.buildSubmitPayload([])).toEqual({ text: 'hello' });
 	});
 
 	it('submitDraft sends payload and clears draft', () => {

--- a/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
@@ -1,57 +1,52 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createComposerInputController } from './composer-controller.svelte';
 
+function deps(overrides: Partial<Parameters<typeof createComposerInputController>[0]> = {}) {
+	return {
+		onSend: vi.fn(),
+		getValue: () => 'hello',
+		getImages: () => [],
+		getDisabled: () => false,
+		getHasSelectedModel: () => true,
+		getReasoningEffort: () => '',
+		clearDraft: vi.fn(),
+		...overrides
+	};
+}
+
 describe('createComposerInputController', () => {
 	it('canSubmit is true when text or images exist', () => {
-		const controller = createComposerInputController({
-			onSend: vi.fn(),
-			getValue: () => 'hello',
-			getImages: () => [],
-			getDisabled: () => false,
-			getHasSelectedModel: () => true,
-			clearDraft: vi.fn()
-		});
+		const controller = createComposerInputController(deps());
 		expect(controller.canSubmit()).toBe(true);
 	});
 
 	it('buildSubmitPayload returns null when disabled or no model', () => {
-		const controller = createComposerInputController({
-			onSend: vi.fn(),
-			getValue: () => 'hello',
-			getImages: () => [],
-			getDisabled: () => true,
-			getHasSelectedModel: () => true,
-			clearDraft: vi.fn()
-		});
+		const controller = createComposerInputController(deps({ getDisabled: () => true }));
 		expect(controller.buildSubmitPayload([])).toBeNull();
 	});
 
 	it('buildSubmitPayload includes text and file paths', () => {
-		const controller = createComposerInputController({
-			onSend: vi.fn(),
-			getValue: () => '  run tests  ',
-			getImages: () => [],
-			getDisabled: () => false,
-			getHasSelectedModel: () => true,
-			clearDraft: vi.fn()
-		});
+		const controller = createComposerInputController(deps({ getValue: () => '  run tests  ' }));
 		expect(controller.buildSubmitPayload(['/tmp/a.ts'])).toEqual({
 			text: 'run tests',
 			filePaths: ['/tmp/a.ts']
 		});
 	});
 
+	it('buildSubmitPayload attaches the reasoning effort when set', () => {
+		const controller = createComposerInputController(
+			deps({ getReasoningEffort: () => 'high' })
+		);
+		expect(controller.buildSubmitPayload([])).toEqual({
+			text: 'hello',
+			reasoningEffort: 'high'
+		});
+	});
+
 	it('submitDraft sends payload and clears draft', () => {
 		const onSend = vi.fn();
 		const clearDraft = vi.fn();
-		const controller = createComposerInputController({
-			onSend,
-			getValue: () => 'go',
-			getImages: () => [],
-			getDisabled: () => false,
-			getHasSelectedModel: () => true,
-			clearDraft
-		});
+		const controller = createComposerInputController(deps({ onSend, getValue: () => 'go', clearDraft }));
 		expect(controller.submitDraft([])).toBe(true);
 		expect(onSend).toHaveBeenCalledWith({ text: 'go' });
 		expect(clearDraft).toHaveBeenCalledOnce();

--- a/cometline/src/lib/components/composer/composer-controller.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.ts
@@ -8,6 +8,7 @@ export function createComposerInputController(deps: {
 	getDisabled: () => boolean;
 	getHasSelectedModel: () => boolean;
 	getReasoningEffort: () => string;
+	getReasoningEffortOptions: () => string[];
 	clearDraft: () => void;
 }) {
 	function canSubmit() {
@@ -26,11 +27,15 @@ export function createComposerInputController(deps: {
 		const trimmed = deps.getValue().trim();
 		if (!canSubmit() || deps.getDisabled() || !deps.getHasSelectedModel()) return null;
 		const images = deps.getImages();
+		const effort = deps.getReasoningEffort();
+		const supportedEffort = deps.getReasoningEffortOptions().includes(effort)
+			? effort
+			: undefined;
 		return {
 			text: trimmed,
 			images: images.length > 0 ? images : undefined,
 			filePaths: filePaths.length > 0 ? filePaths : undefined,
-			reasoningEffort: deps.getReasoningEffort() || undefined
+			reasoningEffort: supportedEffort || undefined
 		};
 	}
 

--- a/cometline/src/lib/components/composer/composer-controller.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.ts
@@ -7,6 +7,7 @@ export function createComposerInputController(deps: {
 	getImages: () => ImageAttachment[];
 	getDisabled: () => boolean;
 	getHasSelectedModel: () => boolean;
+	getReasoningEffort: () => string;
 	clearDraft: () => void;
 }) {
 	function canSubmit() {
@@ -28,7 +29,8 @@ export function createComposerInputController(deps: {
 		return {
 			text: trimmed,
 			images: images.length > 0 ? images : undefined,
-			filePaths: filePaths.length > 0 ? filePaths : undefined
+			filePaths: filePaths.length > 0 ? filePaths : undefined,
+			reasoningEffort: deps.getReasoningEffort() || undefined
 		};
 	}
 

--- a/cometline/src/lib/composer/reasoning-effort.test.ts
+++ b/cometline/src/lib/composer/reasoning-effort.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { nextReasoningEffort } from './reasoning-effort';
+
+describe('nextReasoningEffort', () => {
+	const supported = ['low', 'medium', 'high'];
+
+	it('cycles from auto to the first supported option', () => {
+		expect(nextReasoningEffort('', supported)).toBe('low');
+	});
+
+	it('advances through the supported list', () => {
+		expect(nextReasoningEffort('low', supported)).toBe('medium');
+		expect(nextReasoningEffort('medium', supported)).toBe('high');
+	});
+
+	it('wraps back to auto after the last option', () => {
+		expect(nextReasoningEffort('high', supported)).toBe('');
+	});
+
+	it('resets to auto when current is unknown', () => {
+		expect(nextReasoningEffort('xhigh', supported)).toBe('');
+	});
+
+	it('keeps the current effort when the model supports none', () => {
+		expect(nextReasoningEffort('medium', [])).toBe('medium');
+		expect(nextReasoningEffort('', [])).toBe('');
+	});
+});

--- a/cometline/src/lib/composer/reasoning-effort.ts
+++ b/cometline/src/lib/composer/reasoning-effort.ts
@@ -1,0 +1,15 @@
+/**
+ * Reasoning effort cycling for the composer shortcut.
+ *
+ * Effort cycles through: auto (empty) -> first supported option -> ... ->
+ * last supported option -> auto. Values not in the supported list (or an
+ * empty list) reset to the first supported option; an unsupported model
+ * yields no change.
+ */
+export function nextReasoningEffort(current: string, supported: string[]): string {
+	if (supported.length === 0) return current;
+	const cycle = ['', ...supported];
+	const index = cycle.indexOf(current);
+	const next = cycle[(index + 1) % cycle.length];
+	return next === undefined ? '' : next;
+}

--- a/cometline/src/lib/composer/reasoning-effort.ts
+++ b/cometline/src/lib/composer/reasoning-effort.ts
@@ -2,9 +2,8 @@
  * Reasoning effort cycling for the composer shortcut.
  *
  * Effort cycles through: auto (empty) -> first supported option -> ... ->
- * last supported option -> auto. Values not in the supported list (or an
- * empty list) reset to the first supported option; an unsupported model
- * yields no change.
+ * last supported option -> auto. A value outside the supported list resets
+ * to auto; an unsupported model yields no change.
  */
 export function nextReasoningEffort(current: string, supported: string[]): string {
 	if (supported.length === 0) return current;

--- a/cometline/src/lib/generated/cometmind-api/types.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/types.gen.ts
@@ -283,6 +283,12 @@ export type PostMessageRequest = {
      *
      */
     web_contexts?: Array<WebContext>;
+    /**
+     * Optional per-turn reasoning effort override (e.g. low, medium, high)
+     * for models that support it. Empty means the runtime default.
+     *
+     */
+    reasoning_effort?: string;
 };
 
 export type WebContext = {
@@ -436,6 +442,10 @@ export type ModelEntry = {
      * Normalized catalog input modalities (text, image, video, audio, pdf) when known.
      */
     input_modalities: Array<'text' | 'image' | 'video' | 'audio' | 'pdf'>;
+    /**
+     * Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+     */
+    reasoning_effort_options?: Array<string>;
 };
 
 export type ModelCatalogLookupRequest = {
@@ -461,6 +471,10 @@ export type ModelCatalogLookupEntry = {
      * Normalized catalog input modalities (text, image, video, audio, pdf) when known.
      */
     input_modalities: Array<'text' | 'image' | 'video' | 'audio' | 'pdf'>;
+    /**
+     * Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+     */
+    reasoning_effort_options?: Array<string>;
 };
 
 export type ModelCatalogLookupResponse = {

--- a/cometline/src/lib/generated/cometmind-api/types.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/types.gen.ts
@@ -284,8 +284,8 @@ export type PostMessageRequest = {
      */
     web_contexts?: Array<WebContext>;
     /**
-     * Optional per-turn reasoning effort override (e.g. low, medium, high)
-     * for models that support it. Empty means the runtime default.
+     * Optional per-turn reasoning effort override using a value advertised
+     * by the selected model. Empty means the provider default.
      *
      */
     reasoning_effort?: string;

--- a/cometline/src/lib/keyboard-shortcuts.ts
+++ b/cometline/src/lib/keyboard-shortcuts.ts
@@ -23,6 +23,7 @@ export type ShortcutAction =
 	| 'openJobs'
 	| 'openSkillDrafts'
 	| 'openInbox'
+	| 'cycleReasoningEffort'
 	| 'recentSession';
 
 export interface ShortcutBinding {
@@ -134,6 +135,12 @@ export const SHORTCUT_DEFINITIONS: KeyboardShortcutDefinition[] = [
 		label: 'Stop response',
 		category: 'composer',
 		defaultBinding: { ctrl: true, meta: false, key: 'c' }
+	},
+	{
+		id: 'cycleReasoningEffort',
+		label: 'Cycle reasoning effort',
+		category: 'composer',
+		defaultBinding: { ctrl: true, meta: false, key: 't' }
 	},
 	{
 		id: 'toggleSidebar',

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -637,7 +637,8 @@ function createChatStore() {
 						data: image.data
 					})),
 					file_paths: payload.filePaths,
-					web_contexts: payload.webContexts
+					web_contexts: payload.webContexts,
+					reasoning_effort: payload.reasoningEffort
 				},
 				handle.abort.signal
 			)) {

--- a/cometline/src/lib/stores/model.svelte.ts
+++ b/cometline/src/lib/stores/model.svelte.ts
@@ -19,6 +19,8 @@ export interface ModelOption {
 	vision?: boolean;
 	visionKnown?: boolean;
 	inputModalities?: InputModality[];
+	/** Allowed reasoning effort values when the catalog knows them. */
+	reasoningEffortOptions?: string[];
 }
 
 export type ModelLimitEntry = {
@@ -30,6 +32,7 @@ export type ModelLimitEntry = {
 	vision: boolean;
 	visionKnown: boolean;
 	inputModalities: InputModality[];
+	reasoningEffortOptions: string[];
 };
 
 function labelForModel(modelID: string) {
@@ -47,7 +50,8 @@ function limitFields(limit: ModelLimitEntry) {
 		limitSource: limit.limitSource,
 		vision: limit.vision,
 		visionKnown: limit.visionKnown,
-		inputModalities: limit.inputModalities
+		inputModalities: limit.inputModalities,
+		reasoningEffortOptions: limit.reasoningEffortOptions
 	};
 }
 
@@ -169,16 +173,19 @@ function createModelStore() {
 			const providerId = entry.providerId.trim();
 			const modelId = entry.modelId.trim();
 			if (!providerId || !modelId) continue;
-			next.set(`${providerId}\0${modelId}`, {
-				providerId,
-				modelId,
-				context: entry.context,
-				output: entry.output,
-				limitSource: entry.limitSource,
-				vision: entry.vision,
-				visionKnown: entry.visionKnown,
-				inputModalities: [...entry.inputModalities]
-			});
+		next.set(`${providerId}\0${modelId}`, {
+			providerId,
+			modelId,
+			context: entry.context,
+			output: entry.output,
+			limitSource: entry.limitSource,
+			vision: entry.vision,
+			visionKnown: entry.visionKnown,
+			inputModalities: [...entry.inputModalities],
+			reasoningEffortOptions: entry.reasoningEffortOptions
+				? [...entry.reasoningEffortOptions]
+				: []
+		});
 		}
 		limitsByKey = next;
 		options = options.map((option) => {

--- a/cometline/src/lib/stores/model.test.ts
+++ b/cometline/src/lib/stores/model.test.ts
@@ -30,7 +30,8 @@ describe('modelStore.applyLimits', () => {
 				limitSource: 'catalog',
 				vision: false,
 				visionKnown: true,
-				inputModalities: ['text']
+				inputModalities: ['text'],
+				reasoningEffortOptions: []
 			},
 			{
 				providerId: 'openai',
@@ -40,7 +41,8 @@ describe('modelStore.applyLimits', () => {
 				limitSource: 'catalog',
 				vision: true,
 				visionKnown: true,
-				inputModalities: ['text', 'image']
+				inputModalities: ['text', 'image'],
+				reasoningEffortOptions: ['low', 'medium', 'high']
 			}
 		];
 		modelStore.applyLimits(entries);

--- a/cometline/src/lib/stores/reasoning-effort.svelte.ts
+++ b/cometline/src/lib/stores/reasoning-effort.svelte.ts
@@ -1,0 +1,22 @@
+import { SvelteMap } from 'svelte/reactivity';
+
+/**
+ * Per-session reasoning effort toggle state.
+ *
+ * The composer Ctrl+T shortcut writes here instead of persisting settings,
+ * so toggling is instant (no IPC / settings-file round trip). The value is
+ * attached to each chat turn request and lives for the app session only.
+ */
+const bySession = new SvelteMap<string, string>();
+
+export function getReasoningEffort(sessionId: string): string {
+	return bySession.get(sessionId) ?? '';
+}
+
+export function setReasoningEffort(sessionId: string, effort: string): void {
+	if (effort) {
+		bySession.set(sessionId, effort);
+	} else {
+		bySession.delete(sessionId);
+	}
+}

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -35,6 +35,7 @@ function toLimitEntry(
 		vision: boolean;
 		vision_known: boolean;
 		input_modalities?: Array<'text' | 'image' | 'video' | 'audio' | 'pdf'>;
+		reasoning_effort_options?: Array<string>;
 	}
 ): ModelLimitEntry {
 	return {
@@ -45,7 +46,8 @@ function toLimitEntry(
 		limitSource: entry.limit_source,
 		vision: entry.vision,
 		visionKnown: entry.vision_known,
-		inputModalities: (entry.input_modalities ?? []) as InputModality[]
+		inputModalities: (entry.input_modalities ?? []) as InputModality[],
+		reasoningEffortOptions: entry.reasoning_effort_options ?? []
 	};
 }
 

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -116,6 +116,7 @@ export type ShortcutAction =
 	| 'openJobs'
 	| 'openSkillDrafts'
 	| 'openInbox'
+	| 'cycleReasoningEffort'
 	| 'recentSession';
 
 export interface ShortcutBinding {

--- a/cometmind/internal/agent/reasoning_effort_test.go
+++ b/cometmind/internal/agent/reasoning_effort_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/cometline/cometmind/internal/session"
+)
+
+func TestRunner_ReasoningEffortComesFromTurn(t *testing.T) {
+	r := &Runner{}
+
+	if got := r.reasoningEffortFor(session.AgentTurn{ReasoningEffort: "high"}); got != "high" {
+		t.Fatalf("turn effort = %q, want high", got)
+	}
+	if got := r.reasoningEffortFor(session.AgentTurn{ReasoningEffort: "  medium  "}); got != "medium" {
+		t.Fatalf("trimmed turn effort = %q, want medium", got)
+	}
+}
+
+func TestRunner_ReasoningEffortEmptyWhenUnset(t *testing.T) {
+	r := &Runner{}
+	if got := r.reasoningEffortFor(session.AgentTurn{}); got != "" {
+		t.Fatalf("effort = %q, want empty", got)
+	}
+}

--- a/cometmind/internal/agent/runner.go
+++ b/cometmind/internal/agent/runner.go
@@ -287,6 +287,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 		emitStatus(event.PhaseContactingModel)
 		requestMsgs := DowngradeImagesForNonVision(msgs, sessionBudget.VisionKnown, sessionBudget.Vision)
 		req := BuildRequest(turn.ModelID, system, requestMsgs, requestTools, effectiveMaxTokens)
+		req.ReasoningEffort = r.reasoningEffortFor(turn)
 		if r.Compatibility != nil {
 			req.Compatibility = r.Compatibility.ResolveCapabilityPolicy(ctx, r.CompatibilityScope)
 		}
@@ -418,6 +419,7 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 						msgs = rebuildMsgs
 						requestMsgs := DowngradeImagesForNonVision(msgs, sessionBudget.VisionKnown, sessionBudget.Vision)
 						req = BuildRequest(turn.ModelID, system, requestMsgs, requestTools, effectiveMaxTokens)
+						req.ReasoningEffort = r.reasoningEffortFor(turn)
 						if r.Compatibility != nil {
 							req.Compatibility = r.Compatibility.ResolveCapabilityPolicy(ctx, r.CompatibilityScope)
 						}
@@ -754,6 +756,12 @@ func (r *Runner) extractMemoryAfterTurn(ctx context.Context, turn session.AgentT
 			ch <- event.MemoryUpdated(wire)
 		}
 	}
+}
+
+// reasoningEffortFor resolves the per-turn reasoning effort override. Empty
+// means the provider default; no runtime-wide default is applied.
+func (r *Runner) reasoningEffortFor(turn session.AgentTurn) string {
+	return strings.TrimSpace(turn.ReasoningEffort)
 }
 
 func (r *Runner) systemPrompt() string {

--- a/cometmind/internal/apigen/types.gen.go
+++ b/cometmind/internal/apigen/types.gen.go
@@ -1568,8 +1568,8 @@ type PostMessageRequest struct {
 	// Images Optional base64 image attachments. Supported media types are image/png, image/jpeg, image/gif, and image/webp.
 	Images *[]ImageAttachment `json:"images,omitempty"`
 
-	// ReasoningEffort Optional per-turn reasoning effort override (e.g. low, medium, high)
-	// for models that support it. Empty means the runtime default.
+	// ReasoningEffort Optional per-turn reasoning effort override using a value advertised
+	// by the selected model. Empty means the provider default.
 	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 
 	// Text User input text. Required when images is empty.

--- a/cometmind/internal/apigen/types.gen.go
+++ b/cometmind/internal/apigen/types.gen.go
@@ -1484,8 +1484,11 @@ type ModelCatalogLookupEntry struct {
 	LimitSource     ModelCatalogLookupEntryLimitSource       `json:"limit_source"`
 	ModelId         string                                   `json:"model_id"`
 	Output          int                                      `json:"output"`
-	Vision          bool                                     `json:"vision"`
-	VisionKnown     bool                                     `json:"vision_known"`
+
+	// ReasoningEffortOptions Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+	ReasoningEffortOptions *[]string `json:"reasoning_effort_options,omitempty"`
+	Vision                 bool      `json:"vision"`
+	VisionKnown            bool      `json:"vision_known"`
 }
 
 // ModelCatalogLookupEntryInputModalities defines model for ModelCatalogLookupEntry.InputModalities.
@@ -1528,6 +1531,9 @@ type ModelEntry struct {
 	Output     int    `json:"output"`
 	ProviderId string `json:"provider_id"`
 
+	// ReasoningEffortOptions Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+	ReasoningEffortOptions *[]string `json:"reasoning_effort_options,omitempty"`
+
 	// Vision True when modalities.input includes image (only meaningful when vision_known).
 	Vision bool `json:"vision"`
 
@@ -1561,6 +1567,10 @@ type PostMessageRequest struct {
 
 	// Images Optional base64 image attachments. Supported media types are image/png, image/jpeg, image/gif, and image/webp.
 	Images *[]ImageAttachment `json:"images,omitempty"`
+
+	// ReasoningEffort Optional per-turn reasoning effort override (e.g. low, medium, high)
+	// for models that support it. Empty means the runtime default.
+	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 
 	// Text User input text. Required when images is empty.
 	Text       *string         `json:"text,omitempty"`

--- a/cometmind/internal/config/models.go
+++ b/cometmind/internal/config/models.go
@@ -13,15 +13,16 @@ import (
 
 // ModelEntry is one selectable model from Cometline provider settings.
 type ModelEntry struct {
-	ProviderID      string   `json:"provider_id"`
-	ModelID         string   `json:"model_id"`
-	Name            string   `json:"name"`
-	Context         int      `json:"context"`
-	Output          int      `json:"output"`
-	LimitSource     string   `json:"limit_source"`
-	Vision          bool     `json:"vision"`
-	VisionKnown     bool     `json:"vision_known"`
-	InputModalities []string `json:"input_modalities"`
+	ProviderID            string   `json:"provider_id"`
+	ModelID               string   `json:"model_id"`
+	Name                  string   `json:"name"`
+	Context               int      `json:"context"`
+	Output                int      `json:"output"`
+	LimitSource           string   `json:"limit_source"`
+	Vision                bool     `json:"vision"`
+	VisionKnown           bool     `json:"vision_known"`
+	InputModalities       []string `json:"input_modalities"`
+	ReasoningEffortOptions []string `json:"reasoning_effort_options"`
 }
 
 // LabelForModel formats a model id for display (matches Cometline UI labeling).
@@ -76,15 +77,16 @@ func modelEntriesFromSettings(raw cometlineSettingsJSON) []ModelEntry {
 			seen[key] = struct{}{}
 			limits := modelcatalog.ResolveLimits(provider.Method, provider.ID, modelID)
 			out = append(out, ModelEntry{
-				ProviderID:      strings.TrimSpace(provider.ID),
-				ModelID:         modelID,
-				Name:            LabelForModel(modelID),
-				Context:         limits.Context,
-				Output:          limits.Output,
-				LimitSource:     limits.Source,
-				Vision:          limits.Vision,
-				VisionKnown:     limits.VisionKnown,
-				InputModalities: append([]string(nil), limits.InputModalities...),
+				ProviderID:            strings.TrimSpace(provider.ID),
+				ModelID:               modelID,
+				Name:                  LabelForModel(modelID),
+				Context:               limits.Context,
+				Output:                limits.Output,
+				LimitSource:           limits.Source,
+				Vision:                limits.Vision,
+				VisionKnown:           limits.VisionKnown,
+				InputModalities:       append([]string(nil), limits.InputModalities...),
+				ReasoningEffortOptions: modelcatalog.ResolveReasoningOptions(provider.Method, provider.ID, modelID).Effort,
 			})
 		}
 	}
@@ -191,13 +193,14 @@ func LookupModelCatalog(method, providerID string, modelIDs []string) []ModelCat
 		seen[modelID] = struct{}{}
 		limits := modelcatalog.ResolveLimits(method, providerID, modelID)
 		out = append(out, ModelCatalogLookupEntry{
-			ModelID:         modelID,
-			Context:         limits.Context,
-			Output:          limits.Output,
-			LimitSource:     limits.Source,
-			Vision:          limits.Vision,
-			VisionKnown:     limits.VisionKnown,
-			InputModalities: append([]string(nil), limits.InputModalities...),
+			ModelID:               modelID,
+			Context:               limits.Context,
+			Output:                limits.Output,
+			LimitSource:           limits.Source,
+			Vision:                limits.Vision,
+			VisionKnown:           limits.VisionKnown,
+			InputModalities:       append([]string(nil), limits.InputModalities...),
+			ReasoningEffortOptions: modelcatalog.ResolveReasoningOptions(method, providerID, modelID).Effort,
 		})
 	}
 	return out
@@ -205,11 +208,12 @@ func LookupModelCatalog(method, providerID string, modelIDs []string) []ModelCat
 
 // ModelCatalogLookupEntry is one resolved catalog row for fetch-time enrichment.
 type ModelCatalogLookupEntry struct {
-	ModelID         string   `json:"model_id"`
-	Context         int      `json:"context"`
-	Output          int      `json:"output"`
-	LimitSource     string   `json:"limit_source"`
-	Vision          bool     `json:"vision"`
-	VisionKnown     bool     `json:"vision_known"`
-	InputModalities []string `json:"input_modalities"`
+	ModelID               string   `json:"model_id"`
+	Context               int      `json:"context"`
+	Output                int      `json:"output"`
+	LimitSource           string   `json:"limit_source"`
+	Vision                bool     `json:"vision"`
+	VisionKnown           bool     `json:"vision_known"`
+	InputModalities       []string `json:"input_modalities"`
+	ReasoningEffortOptions []string `json:"reasoning_effort_options"`
 }

--- a/cometmind/internal/modelcatalog/catalog.go
+++ b/cometmind/internal/modelcatalog/catalog.go
@@ -37,7 +37,7 @@ const (
 
 	// diskCacheVersion bumps when the on-disk shape must be invalidated
 	// (e.g. older caches stored only limit fields and dropped modalities).
-	diskCacheVersion = 3
+	diskCacheVersion = 4
 )
 
 // Limits are the resolved context/output caps for one model.
@@ -66,12 +66,20 @@ type modelProviderMeta struct {
 	API string `json:"api"`
 }
 
+type reasoningOption struct {
+	Type   string   `json:"type"`
+	Values []string `json:"values"`
+	Min    *int     `json:"min"`
+	Max    *int     `json:"max"`
+}
+
 type modelEntry struct {
-	ID         string            `json:"id"`
-	Attachment bool              `json:"attachment"`
-	Modalities modelModalities   `json:"modalities"`
-	Limit      modelLimit        `json:"limit"`
-	Provider   *modelProviderMeta `json:"provider"`
+	ID               string            `json:"id"`
+	Attachment       bool              `json:"attachment"`
+	Modalities       modelModalities   `json:"modalities"`
+	Limit            modelLimit        `json:"limit"`
+	Provider         *modelProviderMeta `json:"provider"`
+	ReasoningOptions []reasoningOption `json:"reasoning_options"`
 }
 
 type providerEntry struct {
@@ -241,6 +249,71 @@ func protocolFromEntry(provider providerEntry, entry modelEntry) Protocol {
 		protocol.API = provider.API
 	}
 	return protocol
+}
+
+// ReasoningOptions are the reasoning controls a model advertises via models.dev
+// reasoning_options. Source is SourceCatalog when resolved, SourceFallback when
+// the model is unknown or the method is unscoped.
+type ReasoningOptions struct {
+	// Effort lists the allowed reasoning effort values (e.g. none, low,
+	// medium, high, xhigh, max) for models with an "effort" option.
+	Effort []string
+	// Toggle is true for models that support reasoning on/off.
+	Toggle bool
+	// BudgetMin / BudgetMax bound thinking token budgets when advertised.
+	BudgetMin *int
+	BudgetMax *int
+	Source    string
+}
+
+// ResolveReasoningOptions looks up the reasoning controls for a model. Like
+// ResolveProviderMetadata it only applies to scoped catalog providers;
+// unscoped methods (custom gateways) resolve to an empty fallback.
+func ResolveReasoningOptions(method, providerID, modelID string) ReasoningOptions {
+	fallback := ReasoningOptions{Source: SourceFallback}
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return fallback
+	}
+	key, scoped := catalogProviderKey(method, providerID)
+	if !scoped {
+		return fallback
+	}
+	cat, err := load()
+	if err != nil || cat == nil {
+		return fallback
+	}
+
+	candidates := modelIDCandidates(modelID)
+	if provider, ok := cat.Providers[key]; ok {
+		if entry, ok := findModelInProvider(provider, candidates); ok {
+			return reasoningOptionsFromEntry(entry)
+		}
+	}
+	if alt := opencodeSiblingProvider(key); alt != "" {
+		if provider, ok := cat.Providers[alt]; ok {
+			if entry, ok := findModelInProvider(provider, candidates); ok {
+				return reasoningOptionsFromEntry(entry)
+			}
+		}
+	}
+	return fallback
+}
+
+func reasoningOptionsFromEntry(entry modelEntry) ReasoningOptions {
+	out := ReasoningOptions{Source: SourceCatalog}
+	for _, option := range entry.ReasoningOptions {
+		switch option.Type {
+		case "effort":
+			out.Effort = append([]string(nil), option.Values...)
+		case "toggle":
+			out.Toggle = true
+		case "budget_tokens":
+			out.BudgetMin = option.Min
+			out.BudgetMax = option.Max
+		}
+	}
+	return out
 }
 
 // modelIDCandidates expands a runtime model id into lookup variants.

--- a/cometmind/internal/modelcatalog/catalog_test.go
+++ b/cometmind/internal/modelcatalog/catalog_test.go
@@ -559,3 +559,53 @@ func TestResolveProviderMetadataUnscopedAlwaysDefaults(t *testing.T) {
 		t.Fatalf("unscoped source = %q, want fallback", got.Source)
 	}
 }
+
+func TestResolveReasoningOptionsEffort(t *testing.T) {
+	loadProtocolFixture(t)
+
+	got := modelcatalog.ResolveReasoningOptions("opencode-go", "opencode-go", "gpt-5.6-luna")
+	if got.Source != modelcatalog.SourceCatalog {
+		t.Fatalf("source = %q, want catalog", got.Source)
+	}
+	want := []string{"none", "low", "medium", "high", "xhigh", "max"}
+	if len(got.Effort) != len(want) {
+		t.Fatalf("effort = %v, want %v", got.Effort, want)
+	}
+	for i := range want {
+		if got.Effort[i] != want[i] {
+			t.Fatalf("effort = %v, want %v", got.Effort, want)
+		}
+	}
+	if got.Toggle {
+		t.Fatal("luna must not advertise toggle")
+	}
+}
+
+func TestResolveReasoningOptionsToggleAndBudget(t *testing.T) {
+	loadProtocolFixture(t)
+
+	got := modelcatalog.ResolveReasoningOptions("opencode-go", "opencode-go", "qwen3.7-plus")
+	if got.Source != modelcatalog.SourceCatalog || !got.Toggle {
+		t.Fatalf("qwen3.7-plus = %+v, want catalog toggle", got)
+	}
+	if got.BudgetMax == nil || *got.BudgetMax != 262144 {
+		t.Fatalf("qwen3.7-plus budget max = %v, want 262144", got.BudgetMax)
+	}
+	if len(got.Effort) != 0 {
+		t.Fatalf("qwen3.7-plus effort = %v, want none", got.Effort)
+	}
+}
+
+func TestResolveReasoningOptionsMissAndUnscoped(t *testing.T) {
+	loadProtocolFixture(t)
+
+	miss := modelcatalog.ResolveReasoningOptions("opencode-go", "opencode-go", "not-a-real-model")
+	if miss.Source != modelcatalog.SourceFallback || len(miss.Effort) != 0 || miss.Toggle {
+		t.Fatalf("miss = %+v, want fallback", miss)
+	}
+
+	unscoped := modelcatalog.ResolveReasoningOptions("openai-compatible", "company-gateway", "gpt-5.6-luna")
+	if unscoped.Source != modelcatalog.SourceFallback || len(unscoped.Effort) != 0 {
+		t.Fatalf("unscoped = %+v, want fallback", unscoped)
+	}
+}

--- a/cometmind/internal/modelcatalog/testdata/models-dev-protocol-snippet.json
+++ b/cometmind/internal/modelcatalog/testdata/models-dev-protocol-snippet.json
@@ -14,6 +14,12 @@
           "context": 1050000,
           "output": 8096
         },
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "provider": {
           "npm": "@ai-sdk/openai"
         }
@@ -27,7 +33,13 @@
         "limit": {
           "context": 1000000,
           "output": 384000
-        }
+        },
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["high", "max"]
+          }
+        ]
       },
       "qwen3.7-plus": {
         "id": "qwen3.7-plus",
@@ -39,6 +51,15 @@
           "context": 1000000,
           "output": 65536
         },
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens",
+            "max": 262144
+          }
+        ],
         "provider": {
           "npm": "@ai-sdk/anthropic"
         }

--- a/cometmind/internal/session/agent_turn.go
+++ b/cometmind/internal/session/agent_turn.go
@@ -6,7 +6,7 @@ type AgentTurn struct {
 	ModelID    string
 	ProviderID string
 	// ReasoningEffort is an optional per-turn reasoning effort override
-	// (e.g. "low", "medium", "high"). Empty means the runtime default.
+	// using a value advertised by the selected model. Empty means the provider default.
 	ReasoningEffort string
 }
 

--- a/cometmind/internal/session/agent_turn.go
+++ b/cometmind/internal/session/agent_turn.go
@@ -5,6 +5,9 @@ type AgentTurn struct {
 	ID         string
 	ModelID    string
 	ProviderID string
+	// ReasoningEffort is an optional per-turn reasoning effort override
+	// (e.g. "low", "medium", "high"). Empty means the runtime default.
+	ReasoningEffort string
 }
 
 // AgentTurnFromSession builds a turn handle from a loaded session row.

--- a/cometmind/openapi.yaml
+++ b/cometmind/openapi.yaml
@@ -2922,6 +2922,11 @@ components:
             contexts may use empty content for path-only viewing references.
           items:
             $ref: '#/components/schemas/WebContext'
+        reasoning_effort:
+          type: string
+          description: |
+            Optional per-turn reasoning effort override (e.g. low, medium, high)
+            for models that support it. Empty means the runtime default.
 
     WebContext:
       type: object
@@ -3125,6 +3130,11 @@ components:
           items:
             type: string
             enum: [text, image, video, audio, pdf]
+        reasoning_effort_options:
+          type: array
+          description: Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+          items:
+            type: string
 
     ModelCatalogLookupRequest:
       type: object
@@ -3167,6 +3177,11 @@ components:
           items:
             type: string
             enum: [text, image, video, audio, pdf]
+        reasoning_effort_options:
+          type: array
+          description: Allowed reasoning effort values (models.dev reasoning_options effort) when known; empty when the model or method is not catalogued.
+          items:
+            type: string
 
     ModelCatalogLookupResponse:
       type: object

--- a/cometmind/openapi.yaml
+++ b/cometmind/openapi.yaml
@@ -2925,8 +2925,8 @@ components:
         reasoning_effort:
           type: string
           description: |
-            Optional per-turn reasoning effort override (e.g. low, medium, high)
-            for models that support it. Empty means the runtime default.
+            Optional per-turn reasoning effort override using a value advertised
+            by the selected model. Empty means the provider default.
 
     WebContext:
       type: object

--- a/cometmind/server/messages.go
+++ b/cometmind/server/messages.go
@@ -40,12 +40,13 @@ var supportedImageMediaTypes = map[string]bool{
 }
 
 type postMessageRequest struct {
-	Text        string               `json:"text"`
-	DisplayText string               `json:"display_text,omitempty"`
-	Images      []messageImageInput  `json:"images,omitempty"`
-	FilePaths   []string             `json:"file_paths,omitempty"`
-	WebContext  *webPageContextInput `json:"web_context,omitempty"`
-	WebContexts []webContextInput    `json:"web_contexts,omitempty"`
+	Text            string               `json:"text"`
+	DisplayText     string               `json:"display_text,omitempty"`
+	Images          []messageImageInput  `json:"images,omitempty"`
+	FilePaths       []string             `json:"file_paths,omitempty"`
+	WebContext      *webPageContextInput `json:"web_context,omitempty"`
+	WebContexts     []webContextInput    `json:"web_contexts,omitempty"`
+	ReasoningEffort string               `json:"reasoning_effort,omitempty"`
 }
 
 type webPageContextInput struct {
@@ -140,7 +141,9 @@ func (a *App) handlePostMessage(c *gin.Context) {
 
 	clientGone := false
 	errorPersisted := false
-	runErr := agent.RunHostedTurn(runCtx, runner, session.AgentTurnFromSession(sess), func(ev event.Event) {
+	turn := session.AgentTurnFromSession(sess)
+	turn.ReasoningEffort = strings.TrimSpace(req.ReasoningEffort)
+	runErr := agent.RunHostedTurn(runCtx, runner, turn, func(ev event.Event) {
 		if ev.Kind == event.KindError && strings.TrimSpace(ev.Message) != "" {
 			msg := userFacingMessageError(ev.Message)
 			ev.Message = msg

--- a/cometmind/server/server.go
+++ b/cometmind/server/server.go
@@ -403,15 +403,16 @@ func (a *App) handleListModels(c *gin.Context) {
 	items := make([]apigen.ModelEntry, 0, len(models))
 	for _, m := range models {
 		items = append(items, apigen.ModelEntry{
-			ProviderId:      m.ProviderID,
-			ModelId:         m.ModelID,
-			Name:            m.Name,
-			Context:         m.Context,
-			Output:          m.Output,
-			LimitSource:     apigen.ModelEntryLimitSource(m.LimitSource),
-			Vision:          m.Vision,
-			VisionKnown:     m.VisionKnown,
-			InputModalities: toModelEntryInputModalities(m.InputModalities),
+			ProviderId:            m.ProviderID,
+			ModelId:               m.ModelID,
+			Name:                  m.Name,
+			Context:               m.Context,
+			Output:                m.Output,
+			LimitSource:           apigen.ModelEntryLimitSource(m.LimitSource),
+			Vision:                m.Vision,
+			VisionKnown:           m.VisionKnown,
+			InputModalities:       toModelEntryInputModalities(m.InputModalities),
+			ReasoningEffortOptions: optionalStringSlice(m.ReasoningEffortOptions),
 		})
 	}
 	c.JSON(http.StatusOK, apigen.ModelListResponse{Models: items})
@@ -443,13 +444,14 @@ func (a *App) handleLookupModelCatalog(c *gin.Context) {
 	items := make([]apigen.ModelCatalogLookupEntry, 0, len(looked))
 	for _, m := range looked {
 		items = append(items, apigen.ModelCatalogLookupEntry{
-			ModelId:         m.ModelID,
-			Context:         m.Context,
-			Output:          m.Output,
-			LimitSource:     apigen.ModelCatalogLookupEntryLimitSource(m.LimitSource),
-			Vision:          m.Vision,
-			VisionKnown:     m.VisionKnown,
-			InputModalities: toModelCatalogLookupInputModalities(m.InputModalities),
+			ModelId:               m.ModelID,
+			Context:               m.Context,
+			Output:                m.Output,
+			LimitSource:           apigen.ModelCatalogLookupEntryLimitSource(m.LimitSource),
+			Vision:                m.Vision,
+			VisionKnown:           m.VisionKnown,
+			InputModalities:       toModelCatalogLookupInputModalities(m.InputModalities),
+			ReasoningEffortOptions: optionalStringSlice(m.ReasoningEffortOptions),
 		})
 	}
 	c.JSON(http.StatusOK, apigen.ModelCatalogLookupResponse{Models: items})
@@ -750,4 +752,13 @@ func toModelCatalogLookupInputModalities(in []string) []apigen.ModelCatalogLooku
 		out = append(out, apigen.ModelCatalogLookupEntryInputModalities(m))
 	}
 	return out
+}
+
+// optionalStringSlice returns nil for an empty slice so optional response
+// fields are omitted from the wire instead of serialized as empty arrays.
+func optionalStringSlice(in []string) *[]string {
+	if len(in) == 0 {
+		return nil
+	}
+	return &in
 }


### PR DESCRIPTION
## Background

Models advertise distinct reasoning effort choices through models.dev, but Cometline could not expose or submit them. The model-aware control preserves provider defaults and rejects stale values when users switch models.

[fd0a645](https://github.com/Cometline/cometline/commit/fd0a645dba1b6c9fb1bbcf11014510a67e2e837d): Comet SDK carries reasoning effort through OpenAI Chat Completions, OpenAI Responses, and Anthropic request conversion.

[2c04c0c](https://github.com/Cometline/cometline/commit/2c04c0c591d9068c423d3586fa8d6717552ed63c): CometMind reads per-model effort options from models.dev, exposes them through the API contract, and applies per-turn overrides in the agent runner.

[0ae140c](https://github.com/Cometline/cometline/commit/0ae140c381f1125dd9688e3fc0582122239e4ded): Cometline adds the model-adjacent effort control, Ctrl+T cycling, reactive per-session state, and per-turn request wiring.

[3e886de](https://github.com/Cometline/cometline/commit/3e886dec4cb7741df88d377b2d316428fe138332): Provider handling now nests Anthropic effort under output_config, filters unsupported stale values, and aligns contract descriptions with provider-default behavior.