### PR TITLE
[main] feat: add plan mode controls and enforcement

### DIFF
--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -23,6 +23,15 @@
 	--status-error-border: rgba(244, 63, 94, 0.18);
 	--overlay-scrim: rgba(251, 251, 250, 0.86);
 
+	/* Plan mode (read-only agent mode) — subtle yellow, not a warning/error tone */
+	--plan-border: #d8c876;
+	--plan-ring: rgba(216, 200, 118, 0.16);
+	--plan-chip-bg: rgba(216, 200, 118, 0.16);
+	--plan-chip-bg-strong: rgba(216, 200, 118, 0.28);
+	--plan-chip-text: #7a6a22;
+	--plan-chip-text-strong: #5f521a;
+	--plan-chip-border: rgba(216, 200, 118, 0.55);
+
 	/* Effects */
 	--shadow-card: 0 8px 28px rgba(15, 23, 42, 0.08);
 	--content-panel-inset: 6px;

--- a/cometline/src/lib/actions/activate-after-session-deleted.test.ts
+++ b/cometline/src/lib/actions/activate-after-session-deleted.test.ts
@@ -47,6 +47,7 @@ function session(id: string, workspacePath = '/ws'): Session {
 		origin: 'user',
 		token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 		pinned: false,
+			agent_mode: 'auto',
 		created_at: 0,
 		updated_at: id === 'b' ? 2 : 1
 	};

--- a/cometline/src/lib/actions/chat-turn-queue.test.ts
+++ b/cometline/src/lib/actions/chat-turn-queue.test.ts
@@ -222,4 +222,38 @@ describe('createChatTurnQueue', () => {
 			displayText: '/job Fix login'
 		});
 	});
+
+	it('keeps the agent mode captured at submission while draining', async () => {
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const runTurn = vi.fn().mockImplementation(async (payload: ChatTurnPayload) => {
+			if (payload.text === 'first') await firstGate;
+		});
+		const queue = createChatTurnQueue(runTurn);
+
+		void queue.enqueue({ text: 'first', agentMode: 'auto' });
+		await vi.waitFor(() => expect(queue.processing).toBe(true));
+
+		// Queued in Plan, then the composer switches to Auto before the turn runs.
+		void queue.enqueue({ text: 'second', agentMode: 'plan' });
+		expect(queue.pendingMessages[0].agentMode).toBe('plan');
+
+		releaseFirst!();
+		await vi.waitFor(() => expect(queue.processing).toBe(false));
+		expect(runTurn).toHaveBeenCalledTimes(2);
+		expect(runTurn).toHaveBeenLastCalledWith({ text: 'second', agentMode: 'plan' });
+	});
+
+	it('deduplicates identical payloads but distinguishes different agent modes', async () => {
+		const runTurn = vi.fn().mockResolvedValue(undefined);
+		const queue = createChatTurnQueue(runTurn);
+
+		await queue.enqueue({ text: 'same' });
+		await expect(queue.enqueue({ text: 'same', agentMode: 'plan' })).resolves.toBe(true);
+		expect(runTurn).toHaveBeenCalledTimes(2);
+		expect(runTurn).toHaveBeenNthCalledWith(1, { text: 'same' });
+		expect(runTurn).toHaveBeenNthCalledWith(2, { text: 'same', agentMode: 'plan' });
+	});
 });

--- a/cometline/src/lib/actions/chat-turn-queue.ts
+++ b/cometline/src/lib/actions/chat-turn-queue.ts
@@ -48,7 +48,9 @@ export function createChatTurnQueue(
 			displayText: payload.displayText ?? '',
 			images: payload.images?.map((image) => image.data) ?? [],
 			filePaths: payload.filePaths ?? [],
-			webContexts: payload.webContexts ?? []
+			webContexts: payload.webContexts ?? [],
+			reasoningEffort: payload.reasoningEffort ?? '',
+			agentMode: payload.agentMode ?? ''
 		});
 	}
 
@@ -98,9 +100,18 @@ export function createChatTurnQueue(
 				await runTurnSafely(initialPayload);
 			}
 			while (queue.length > 0) {
-				const { text, displayText, images, filePaths, webContexts } = queue.shift()!;
+				const { text, displayText, images, filePaths, webContexts, reasoningEffort, agentMode } =
+					queue.shift()!;
 				notifyChange();
-				await runTurnSafely({ text, displayText, images, filePaths, webContexts });
+				await runTurnSafely({
+					text,
+					displayText,
+					images,
+					filePaths,
+					webContexts,
+					reasoningEffort,
+					agentMode
+				});
 			}
 		} finally {
 			activeTurnSignature = null;

--- a/cometline/src/lib/actions/commit-sidebar-workspace.test.ts
+++ b/cometline/src/lib/actions/commit-sidebar-workspace.test.ts
@@ -33,6 +33,7 @@ function session(overrides: Partial<Session> = {}): Session {
 			cache_write: 0
 		},
 		pinned: false,
+			agent_mode: 'auto',
 		created_at: 0,
 		updated_at: 0,
 		...overrides

--- a/cometline/src/lib/actions/create-new-session.test.ts
+++ b/cometline/src/lib/actions/create-new-session.test.ts
@@ -55,6 +55,7 @@ const session: Session = {
 	origin: 'user',
 	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 	pinned: false,
+	agent_mode: 'auto',
 	created_at: 0,
 	updated_at: 0
 };

--- a/cometline/src/lib/actions/navigate-to-session.test.ts
+++ b/cometline/src/lib/actions/navigate-to-session.test.ts
@@ -49,6 +49,7 @@ function session(overrides: Partial<Session> = {}): Session {
 			cache_write: 0
 		},
 		pinned: false,
+			agent_mode: 'auto',
 		created_at: 0,
 		updated_at: 0,
 		...overrides

--- a/cometline/src/lib/actions/new-chat.ts
+++ b/cometline/src/lib/actions/new-chat.ts
@@ -16,7 +16,8 @@ export async function startNewChat() {
 						text: pending.text,
 						images: pending.images,
 						filePaths: pending.filePaths,
-						webContexts: pending.webContexts
+						webContexts: pending.webContexts,
+						agentMode: pending.agentMode
 					},
 					{ skipUser: false }
 				)

--- a/cometline/src/lib/actions/start-chat.ts
+++ b/cometline/src/lib/actions/start-chat.ts
@@ -8,7 +8,7 @@
  * - The session is refreshed after every send so the title can update.
  */
 
-import type { ImageAttachment } from '$lib/types';
+import type { AgentMode, ImageAttachment } from '$lib/types';
 
 export interface WebContext {
 	kind: 'page' | 'file' | 'terminal' | 'message';
@@ -25,6 +25,8 @@ export interface ChatTurnPayload {
 	webContexts?: WebContext[];
 	/** Per-turn reasoning effort override; empty means the provider default. */
 	reasoningEffort?: string;
+	/** Per-turn agent mode override; omitted means the session's persisted mode. */
+	agentMode?: AgentMode;
 }
 
 export interface StartChatAdapter {

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -255,6 +255,7 @@
 			agentModeKnown = false;
 			return;
 		}
+		if (agentModePending) return;
 		const session = sessionStore.sessions.find((item) => item.id === id);
 		agentMode = session?.agent_mode === 'plan' ? 'plan' : 'auto';
 		agentModeKnown = true;
@@ -273,13 +274,13 @@
 		try {
 			const updated = await updateSession(id, { agent_mode: next });
 			sessionStore.upsertSession(updated);
+			modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
 		} catch {
 			agentMode = previous;
 			modeAnnouncement = 'Failed to change mode';
 		} finally {
 			agentModePending = false;
 		}
-		modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
 	}
 
 	function cycleAgentMode() {

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -17,6 +17,7 @@
 	import MessageContextChips from '$lib/components/chat/MessageContextChips.svelte';
 	import { messageContextRefsFromPending } from '$lib/chat/message-context';
 	import { chatStore } from '$lib/stores/chat.svelte';
+	import { sessionStore } from '$lib/stores/session.svelte';
 	import { composerHistoryStore } from '$lib/stores/composer-history.svelte';
 	import { DEFAULT_CONTEXT_WINDOW_LIMIT, resolveContextWindowUsage } from '$lib/context-window';
 	import { workspaceLabel } from '$lib/sessions/group-by-workspace';
@@ -30,6 +31,8 @@
 	import { nextAttachmentRemoval } from '$lib/components/composer/composer-attachment-keydown';
 	import { nextReasoningEffort } from '$lib/composer/reasoning-effort';
 	import { getReasoningEffort, setReasoningEffort } from '$lib/stores/reasoning-effort.svelte';
+	import { updateSession } from '$lib/client/cometmind';
+	import type { AgentMode } from '$lib/types';
 
 	let {
 		onSend,
@@ -74,6 +77,13 @@
 	let trackedSessionId = $state<string | null>(null);
 	let skippingEmptyStash = $state(false);
 	let lastNonEmptyDraft = $state('');
+	// Agent mode: sourced from the persisted session (source of truth). Auto is
+	// the default for every new session; Plan only appears after an explicit
+	// Tab/control action in this session's composer.
+	let agentMode = $state<AgentMode>('auto');
+	let agentModeKnown = $state(false);
+	let agentModePending = $state(false);
+	let modeAnnouncement = $state('');
 	const heroPlaceholders = [
 		'Type something. Anything.',
 		'Ask a question.',
@@ -147,6 +157,7 @@
 		getHasSelectedModel: () => Boolean(modelStore.selected),
 		getReasoningEffort: () => getReasoningEffort(sessionId),
 		getReasoningEffortOptions: () => modelStore.selected?.reasoningEffortOptions ?? [],
+		getAgentMode: () => agentMode,
 		clearDraft
 	});
 
@@ -235,6 +246,46 @@
 		applyComposerText('');
 	});
 
+	// Keep the composer mode in sync with the persisted session record. The
+	// backend session value is authoritative; no renderer-local preference map.
+	$effect(() => {
+		const id = sessionId;
+		if (!id) {
+			agentMode = 'auto';
+			agentModeKnown = false;
+			return;
+		}
+		const session = sessionStore.sessions.find((item) => item.id === id);
+		agentMode = session?.agent_mode === 'plan' ? 'plan' : 'auto';
+		agentModeKnown = true;
+	});
+
+	async function setAgentMode(next: AgentMode) {
+		if (agentModePending || next === agentMode) return;
+		const id = sessionId;
+		const previous = agentMode;
+		agentMode = next;
+		if (!id) {
+			modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
+			return;
+		}
+		agentModePending = true;
+		try {
+			const updated = await updateSession(id, { agent_mode: next });
+			sessionStore.upsertSession(updated);
+		} catch {
+			agentMode = previous;
+			modeAnnouncement = 'Failed to change mode';
+		} finally {
+			agentModePending = false;
+		}
+		modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
+	}
+
+	function cycleAgentMode() {
+		void setAgentMode(agentMode === 'plan' ? 'auto' : 'plan');
+	}
+
 	$effect(() => {
 		if (!autofocus || shellStore.focusedPane !== 'chat') return;
 		void sessionId;
@@ -275,6 +326,7 @@
 		const action = slash.resolveSubmitAction(trimmed);
 		if (action.kind === 'handled') return;
 		if (!canSubmit || disabled || resolvingWebContext || !modelStore.selected) return;
+		if (agentModePending) return;
 		const filePaths = input?.getFilePaths() ?? [];
 		const contextsBeforeResolve = pendingWebContexts.length;
 		resolvingWebContext = contextsBeforeResolve > 0;
@@ -350,6 +402,20 @@
 		}
 		if (slash.handleMenuKeydown(e)) return;
 		if (mentions.handleMentionMenuKeydown(e)) return;
+		// Plain Tab toggles the agent mode only when no slash/mention menu owns
+		// the key. Shift+Tab and modified combinations keep native behavior.
+		if (
+			!e.isComposing &&
+			!e.metaKey &&
+			!e.ctrlKey &&
+			!e.altKey &&
+			e.key === 'Tab' &&
+			!e.shiftKey
+		) {
+			e.preventDefault();
+			cycleAgentMode();
+			return;
+		}
 		if (
 			!e.isComposing &&
 			!e.metaKey &&
@@ -433,15 +499,17 @@
 
 <div
 	class="composer"
+	class:hero={variant === 'hero'}
+	class:plan={agentMode === 'plan'}
+	class:dragging={attachments.dragActive}
 	role="group"
 	aria-label="Message composer"
-	class:hero={variant === 'hero'}
-	class:dragging={attachments.dragActive}
 	ondragenter={attachments.onDragEnter}
 	ondragover={attachments.onDragOver}
 	ondragleave={attachments.onDragLeave}
 	ondrop={attachments.onDrop}
 >
+	<div class="sr-only" role="status" aria-live="polite">{modeAnnouncement}</div>
 	{#if attachments.dragActive}
 		<div class="drop-overlay" aria-hidden="true">
 			<FileText size={18} stroke-width={1.8} />
@@ -510,6 +578,9 @@
 		reasoningEffort={currentReasoningEffort()}
 		reasoningEffortOptions={modelStore.selected?.reasoningEffortOptions ?? []}
 		onCycleReasoningEffort={cycleReasoningEffort}
+		agentMode={agentMode}
+		agentModeKnown={agentModeKnown}
+		onSwitchToAuto={() => void setAgentMode('auto')}
 		onOpenChangeWorkspace={slash.openChangeWorkspace}
 		{onStop}
 		onSubmit={() => void submit()}
@@ -542,6 +613,27 @@
 	.composer.dragging {
 		border-color: rgba(37, 99, 235, 0.26);
 		background: #f8fbff;
+		box-shadow:
+			var(--shadow-card),
+			0 0 0 4px rgba(37, 99, 235, 0.08);
+	}
+
+	.composer.plan {
+		border-color: var(--plan-border);
+		box-shadow:
+			var(--shadow-card),
+			0 0 0 3px var(--plan-ring);
+	}
+
+	.composer.plan.hero {
+		box-shadow:
+			0 18px 60px rgba(15, 23, 42, 0.12),
+			0 0 0 3px var(--plan-ring);
+	}
+
+	/* Drag feedback stays visible over plan styling. */
+	.composer.plan.dragging {
+		border-color: rgba(37, 99, 235, 0.26);
 		box-shadow:
 			var(--shadow-card),
 			0 0 0 4px rgba(37, 99, 235, 0.08);

--- a/cometline/src/lib/components/composer/ComposerToolbar.svelte
+++ b/cometline/src/lib/components/composer/ComposerToolbar.svelte
@@ -5,6 +5,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { modelStore, type ModelOption } from '$lib/stores/model.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
+	import type { AgentMode } from '$lib/types';
 
 	let {
 		hasWorkspace,
@@ -18,6 +19,9 @@
 		reasoningEffort,
 		reasoningEffortOptions,
 		onCycleReasoningEffort,
+		agentMode,
+		agentModeKnown,
+		onSwitchToAuto,
 		onOpenChangeWorkspace,
 		onStop,
 		onSubmit
@@ -33,6 +37,9 @@
 		reasoningEffort: string;
 		reasoningEffortOptions: string[];
 		onCycleReasoningEffort: () => void;
+		agentMode: AgentMode;
+		agentModeKnown: boolean;
+		onSwitchToAuto: () => void | Promise<void>;
 		onOpenChangeWorkspace: () => void;
 		onStop?: () => void;
 		onSubmit: () => void;
@@ -87,6 +94,18 @@
 	</div>
 
 	<div class="composer-actions">
+		{#if agentMode === 'plan' && agentModeKnown}
+			<Tooltip label="Plan mode: read-only. Press Tab to switch to Auto.">
+				<button
+					type="button"
+					class="plan-chip"
+					onclick={() => void onSwitchToAuto()}
+					aria-label="Plan mode: read-only. Click to switch to Auto."
+				>
+					plan
+				</button>
+			</Tooltip>
+		{/if}
 		{#if contextWindowUsage}
 			<ContextWindowRing
 				usedTokens={contextWindowUsage.used}
@@ -137,6 +156,30 @@
 	.composer-actions {
 		flex: 0 0 auto;
 		margin-left: auto;
+	}
+
+	.composer-footer .plan-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 3px 8px;
+		border: 1px solid var(--plan-chip-border, var(--plan-border));
+		border-radius: 999px;
+		background: var(--plan-chip-bg);
+		color: var(--plan-chip-text);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		line-height: 1;
+		text-transform: uppercase;
+		cursor: pointer;
+		transition:
+			background 140ms ease,
+			color 140ms ease;
+	}
+
+	.composer-footer .plan-chip:hover:not(:disabled) {
+		background: var(--plan-chip-bg-strong, var(--plan-chip-bg));
+		color: var(--plan-chip-text-strong, var(--plan-chip-text));
 	}
 
 	.composer-footer button {

--- a/cometline/src/lib/components/composer/MessageQueuePanel.svelte
+++ b/cometline/src/lib/components/composer/MessageQueuePanel.svelte
@@ -57,6 +57,9 @@
 					{#each queuedMessages as message, index (message.id)}
 						<li class="queue-preview-item">
 							<span class="queue-preview-index">{index + 1}</span>
+							{#if message.agentMode === 'plan'}
+								<span class="queue-mode" title="This queued message runs in Plan mode">plan</span>
+							{/if}
 							<p class="queue-preview-text">{message.text}</p>
 							<button
 								type="button"
@@ -172,6 +175,21 @@
 		font-weight: 700;
 		color: var(--text-soft);
 		padding-top: 2px;
+	}
+
+	.queue-mode {
+		flex: 0 0 auto;
+		padding: 2px 6px;
+		border: 1px solid var(--plan-chip-border, var(--plan-border));
+		border-radius: 999px;
+		background: var(--plan-chip-bg);
+		color: var(--plan-chip-text);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		line-height: 1.2;
+		text-transform: uppercase;
+		margin-top: 1px;
 	}
 
 	.queue-preview-text {

--- a/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { AgentMode } from '$lib/types';
 import { createComposerInputController } from './composer-controller.svelte';
 
 function deps(overrides: Partial<Parameters<typeof createComposerInputController>[0]> = {}) {
@@ -10,6 +11,7 @@ function deps(overrides: Partial<Parameters<typeof createComposerInputController
 		getHasSelectedModel: () => true,
 		getReasoningEffort: () => '',
 		getReasoningEffortOptions: () => [],
+		getAgentMode: (): AgentMode => 'auto',
 		clearDraft: vi.fn(),
 		...overrides
 	};
@@ -30,7 +32,8 @@ describe('createComposerInputController', () => {
 		const controller = createComposerInputController(deps({ getValue: () => '  run tests  ' }));
 		expect(controller.buildSubmitPayload(['/tmp/a.ts'])).toEqual({
 			text: 'run tests',
-			filePaths: ['/tmp/a.ts']
+			filePaths: ['/tmp/a.ts'],
+			agentMode: 'auto'
 		});
 	});
 
@@ -43,7 +46,8 @@ describe('createComposerInputController', () => {
 		);
 		expect(controller.buildSubmitPayload([])).toEqual({
 			text: 'hello',
-			reasoningEffort: 'high'
+			reasoningEffort: 'high',
+			agentMode: 'auto'
 		});
 	});
 
@@ -54,7 +58,12 @@ describe('createComposerInputController', () => {
 				getReasoningEffortOptions: () => ['low', 'medium']
 			})
 		);
-		expect(controller.buildSubmitPayload([])).toEqual({ text: 'hello' });
+		expect(controller.buildSubmitPayload([])).toEqual({ text: 'hello', agentMode: 'auto' });
+	});
+
+	it('buildSubmitPayload attaches plan mode when active', () => {
+		const controller = createComposerInputController(deps({ getAgentMode: () => 'plan' }));
+		expect(controller.buildSubmitPayload([])).toEqual({ text: 'hello', agentMode: 'plan' });
 	});
 
 	it('submitDraft sends payload and clears draft', () => {
@@ -62,7 +71,21 @@ describe('createComposerInputController', () => {
 		const clearDraft = vi.fn();
 		const controller = createComposerInputController(deps({ onSend, getValue: () => 'go', clearDraft }));
 		expect(controller.submitDraft([])).toBe(true);
-		expect(onSend).toHaveBeenCalledWith({ text: 'go' });
+		expect(onSend).toHaveBeenCalledWith({ text: 'go', agentMode: 'auto' });
 		expect(clearDraft).toHaveBeenCalledOnce();
+	});
+
+	it('sendTurn attaches the active agent mode to string payloads', () => {
+		const onSend = vi.fn();
+		const controller = createComposerInputController(deps({ onSend, getAgentMode: () => 'plan' }));
+		controller.sendTurn('go');
+		expect(onSend).toHaveBeenCalledWith({ text: 'go', agentMode: 'plan' });
+	});
+
+	it('sendTurn keeps an explicit payload agent mode over the composer state', () => {
+		const onSend = vi.fn();
+		const controller = createComposerInputController(deps({ onSend, getAgentMode: () => 'auto' }));
+		controller.sendTurn({ text: 'go', agentMode: 'plan' });
+		expect(onSend).toHaveBeenCalledWith({ text: 'go', agentMode: 'plan' });
 	});
 });

--- a/cometline/src/lib/components/composer/composer-controller.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-controller.svelte.ts
@@ -1,4 +1,4 @@
-import type { ImageAttachment } from '$lib/types';
+import type { AgentMode, ImageAttachment } from '$lib/types';
 import type { ChatTurnPayload } from '$lib/actions/start-chat';
 
 export function createComposerInputController(deps: {
@@ -9,6 +9,7 @@ export function createComposerInputController(deps: {
 	getHasSelectedModel: () => boolean;
 	getReasoningEffort: () => string;
 	getReasoningEffortOptions: () => string[];
+	getAgentMode: () => AgentMode;
 	clearDraft: () => void;
 }) {
 	function canSubmit() {
@@ -17,10 +18,10 @@ export function createComposerInputController(deps: {
 
 	function sendTurn(payload: ChatTurnPayload | string) {
 		if (typeof payload === 'string') {
-			deps.onSend({ text: payload });
+			deps.onSend({ text: payload, agentMode: deps.getAgentMode() });
 			return;
 		}
-		deps.onSend(payload);
+		deps.onSend({ ...payload, agentMode: payload.agentMode ?? deps.getAgentMode() });
 	}
 
 	function buildSubmitPayload(filePaths: string[]): ChatTurnPayload | null {
@@ -35,7 +36,8 @@ export function createComposerInputController(deps: {
 			text: trimmed,
 			images: images.length > 0 ? images : undefined,
 			filePaths: filePaths.length > 0 ? filePaths : undefined,
-			reasoningEffort: supportedEffort || undefined
+			reasoningEffort: supportedEffort || undefined,
+			agentMode: deps.getAgentMode()
 		};
 	}
 

--- a/cometline/src/lib/conversation/conversation-controller.ts
+++ b/cometline/src/lib/conversation/conversation-controller.ts
@@ -218,7 +218,8 @@ export function createConversationController(
 					displayText: pending.displayText,
 					images: pending.images,
 					filePaths: pending.filePaths,
-					webContexts: pending.webContexts
+					webContexts: pending.webContexts,
+					agentMode: pending.agentMode
 				});
 				return;
 			}

--- a/cometline/src/lib/generated/cometmind-api/types.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/types.gen.ts
@@ -26,6 +26,15 @@ export type CreateSessionRequest = {
     provider_id?: string;
 };
 
+/**
+ * Agent capability surface for a session or turn. `auto` preserves the full
+ * agent toolset; `plan` is a read-only planning mode that removes command,
+ * file-write, and mutation tools while keeping host-wide reads, network
+ * access, and read-only research delegation.
+ *
+ */
+export type AgentMode = 'auto' | 'plan';
+
 export type UpdateSessionRequest = {
     model_id?: string;
     provider_id?: string;
@@ -37,6 +46,10 @@ export type UpdateSessionRequest = {
      * Display name shown in the sidebar session list.
      */
     title?: string;
+    /**
+     * Persist the preferred mode for this session. New sessions always start in `auto`.
+     */
+    agent_mode?: AgentMode;
 };
 
 export type ChangeSessionWorkspaceRequest = {
@@ -289,6 +302,12 @@ export type PostMessageRequest = {
      *
      */
     reasoning_effort?: string;
+    /**
+     * Optional per-turn agent mode override. When omitted, the session's
+     * persisted mode is used. New sessions always start in `auto`.
+     *
+     */
+    agent_mode?: AgentMode;
 };
 
 export type WebContext = {
@@ -357,6 +376,10 @@ export type Session = {
      */
     origin: 'user' | 'autonomy';
     token_usage: TokenUsage;
+    /**
+     * Active agent mode for the session. `auto` unless the user switched this session to `plan`.
+     */
+    agent_mode: AgentMode;
     /**
      * Whether the session is pinned to the top of its workspace group.
      */

--- a/cometline/src/lib/jobs/start-job-in-chat.ts
+++ b/cometline/src/lib/jobs/start-job-in-chat.ts
@@ -31,7 +31,9 @@ async function sendViaQueue(sessionId: string, payload: ChatTurnPayload): Promis
 		payload.text,
 		payload.images,
 		payload.filePaths,
-		payload.displayText
+		payload.displayText,
+		payload.webContexts,
+		payload.agentMode
 	);
 	await goto(sessionRouteFor(sessionId));
 }

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -55,6 +55,7 @@ const session: Session = {
 	origin: 'user',
 	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 	pinned: false,
+	agent_mode: 'auto',
 	created_at: 0,
 	updated_at: 0
 };

--- a/cometline/src/lib/sessions/group-by-workspace.test.ts
+++ b/cometline/src/lib/sessions/group-by-workspace.test.ts
@@ -25,6 +25,7 @@ function session(id: string, workspacePath: string, updatedAt: number, pinned = 
 			cache_write: 0
 		},
 		pinned,
+		agent_mode: 'auto',
 		created_at: updatedAt,
 		updated_at: updatedAt
 	};

--- a/cometline/src/lib/sessions/next-session-after-delete.test.ts
+++ b/cometline/src/lib/sessions/next-session-after-delete.test.ts
@@ -14,6 +14,7 @@ function session(id: string): Session {
 		origin: 'user',
 		token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 		pinned: false,
+			agent_mode: 'auto',
 		created_at: 0,
 		updated_at: 0
 	};

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -92,6 +92,7 @@ describe('chatStore session switching', () => {
 				origin: 'user',
 				token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 				pinned: false,
+				agent_mode: 'auto',
 				created_at: 0,
 				updated_at: 0
 			}
@@ -261,6 +262,7 @@ describe('chatStore session switching', () => {
 			origin: 'user',
 			token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
 			pinned: false,
+			agent_mode: 'auto',
 			created_at: 0,
 			updated_at: 0
 		});
@@ -620,6 +622,7 @@ describe('chatStore clear and subagents', () => {
 						cache_write: 0
 					},
 					pinned: false,
+					agent_mode: 'auto',
 					parent_session_id: 'sess-a',
 					purpose: 'refactor auth',
 					delegation_status: 'completed',

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -638,7 +638,8 @@ function createChatStore() {
 					})),
 					file_paths: payload.filePaths,
 					web_contexts: payload.webContexts,
-					reasoning_effort: payload.reasoningEffort
+					reasoning_effort: payload.reasoningEffort,
+					agent_mode: payload.agentMode
 				},
 				handle.abort.signal
 			)) {

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import type { ImageAttachment, Session } from '$lib/types';
+import type { AgentMode, ImageAttachment, Session } from '$lib/types';
 import type { WebContext } from '$lib/actions/start-chat';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 
@@ -10,6 +10,7 @@ export interface PendingMessage {
 	images?: ImageAttachment[];
 	filePaths?: string[];
 	webContexts?: WebContext[];
+	agentMode?: AgentMode;
 }
 
 function createSessionStore() {
@@ -79,14 +80,16 @@ function createSessionStore() {
 		images?: ImageAttachment[],
 		filePaths?: string[],
 		displayText?: string,
-		webContexts?: WebContext[]
+		webContexts?: WebContext[],
+		agentMode?: AgentMode
 	) {
 		pendingMessages = new Map(pendingMessages).set(sessionId, {
 			text,
 			images,
 			filePaths,
 			displayText,
-			webContexts
+			webContexts,
+			agentMode
 		});
 	}
 

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -6,6 +6,7 @@ import type {
 } from '$lib/generated/cometmind-api';
 
 export type {
+	AgentMode,
 	CreateSessionRequest,
 	ImageAttachment,
 	MemoryWire,

--- a/cometmind/cmd/serve.go
+++ b/cometmind/cmd/serve.go
@@ -96,8 +96,8 @@ func runServe(_ *cobra.Command, _ []string) error {
 		ACPMgr:       rt.ACPManager(),
 		MCPMgr:       rt.MCPManager(),
 		SubagentOrch: rt.SubagentOrchestrator(),
-		NewRunner: func(sess session.Session, workspacePath string) (server.Runner, error) {
-			return rt.RunnerFor(sess, workspacePath)
+		NewRunner: func(sess session.Session, workspacePath string, mode session.AgentMode) (server.Runner, error) {
+			return rt.RunnerForMode(sess, workspacePath, mode)
 		},
 	})
 	if err != nil {

--- a/cometmind/internal/agent/request.go
+++ b/cometmind/internal/agent/request.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	cometsdk "github.com/cometline/comet-sdk"
+	"github.com/cometline/cometmind/internal/session"
 )
 
 const (
@@ -27,19 +28,32 @@ func FormatOutputBudgetPromptBlock(maxTokens int) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"Each assistant step is capped at roughly %d output tokens. After tool results arrive, respond concisely—summarize findings and next steps instead of repeating large tool output or full file contents. When creating or overwriting multiple files, emit only one complete write_file (or a few small tools) per step so the full tool arguments fit under this cap—never start many large parallel write_file calls that may be truncated unfinished.",
+		"Each assistant step is capped at roughly %d output tokens. After tool results arrive, respond concisely; summarize findings and next steps instead of repeating large tool output or full file contents. Emit only one large tool call (or a few small tool calls) per step so the full arguments fit under this cap; never start many large parallel tool calls that may be truncated unfinished.",
 		maxTokens,
 	)
 }
 
+// FormatAgentModePrompt describes how the agent should use its mode-specific
+// tool surface. Tool registration remains the enforcement boundary.
+func FormatAgentModePrompt(mode session.AgentMode) string {
+	switch mode {
+	case session.AgentModeAuto:
+		return "Auto mode is active. Complete the user's request end to end using the tools available to you. When implementation is requested, inspect the relevant code, make the necessary changes, verify them, and report the result. Do not stop at a plan unless the user explicitly asks for planning only. For large file writes, emit one complete write_file call per step so its arguments fit within the output limit."
+	case session.AgentModePlan:
+		return "Plan mode is active. Research and design only; do not attempt to edit or write files, run commands, mutate settings, jobs, or memory, or delegate coding work. Use the available read, network, skill, and research-agent tools to understand the request. Return a concrete implementation plan with affected files, key decisions, risks, and verification steps. Do not claim that changes were made. These mode restrictions supersede generic implementation instructions."
+	default:
+		return ""
+	}
+}
+
 // FormatOutputTruncationContinueBlock nudges the model to finish after a truncated step.
 func FormatOutputTruncationContinueBlock() string {
-	return "Your previous assistant message in this turn was cut off at the output token limit. Stop long prose. Continue unfinished work with tools instead: emit one complete, smaller write_file (or another small tool call) that fits under the output cap. Do not repeat text already written. Do not start multiple large parallel write_file calls."
+	return "Your previous assistant message in this turn was cut off at the output token limit. Stop long prose. Continue unfinished work with exactly one complete, smaller tool call if needed, or finish with a concise response. Do not repeat text already written. Do not start multiple large parallel tool calls."
 }
 
 // FormatIncompleteToolTruncationContinueBlock nudges after tool-call args were truncated.
 func FormatIncompleteToolTruncationContinueBlock() string {
-	return "Your previous tool call(s) were cut off at the output token limit before they finished, so they were not executed. Retry with exactly one smaller, complete tool call (for example one write_file whose full content fits under the output cap). Do not repeat assistant text already written. Do not re-issue the truncated parallel batch."
+	return "Your previous tool call(s) were cut off at the output token limit before they finished, so they were not executed. Retry with exactly one smaller, complete tool call whose full arguments fit under the output cap. Do not repeat assistant text already written. Do not re-issue the truncated parallel batch."
 }
 
 // FormatWaitForSubagentsBlock reminds the model to join any in-flight

--- a/cometmind/internal/agent/request_test.go
+++ b/cometmind/internal/agent/request_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cometsdk "github.com/cometline/comet-sdk"
+	"github.com/cometline/cometmind/internal/session"
 )
 
 func TestContinueUserNudgeMessages_EmptyWhenNoFlags(t *testing.T) {
@@ -69,10 +70,89 @@ func TestFinalAnswerNudgeMessages_IsTrailingUserInstruction(t *testing.T) {
 	}
 }
 
-func TestFormatOutputBudgetPromptBlock_MentionsOneWriteFilePerStep(t *testing.T) {
+func TestFormatOutputBudgetPromptBlock_IsModeNeutral(t *testing.T) {
 	t.Parallel()
 	got := FormatOutputBudgetPromptBlock(4096)
-	for _, want := range []string{"4096", "one complete write_file", "parallel"} {
+	for _, want := range []string{"4096", "one large tool call", "parallel"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "write_file") {
+		t.Fatalf("mode-neutral budget prompt mentions write_file:\n%s", got)
+	}
+}
+
+func TestOutputContinuationPrompts_AreModeNeutral(t *testing.T) {
+	t.Parallel()
+	for name, prompt := range map[string]string{
+		"text truncation":      FormatOutputTruncationContinueBlock(),
+		"incomplete tool call": FormatIncompleteToolTruncationContinueBlock(),
+	} {
+		if strings.Contains(prompt, "write_file") {
+			t.Fatalf("%s prompt mentions write_file:\n%s", name, prompt)
+		}
+		if !strings.Contains(prompt, "one") || !strings.Contains(prompt, "tool call") {
+			t.Fatalf("%s prompt lacks bounded tool guidance:\n%s", name, prompt)
+		}
+	}
+}
+
+func TestFormatAgentModePrompt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		mode    session.AgentMode
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "empty",
+			notWant: []string{"mode is active"},
+		},
+		{
+			name:    "auto",
+			mode:    session.AgentModeAuto,
+			want:    []string{"Auto mode is active", "end to end", "write_file"},
+			notWant: []string{"Research and design only"},
+		},
+		{
+			name:    "plan",
+			mode:    session.AgentModePlan,
+			want:    []string{"Plan mode is active", "Research and design only", "Do not claim that changes were made"},
+			notWant: []string{"write_file", "make the necessary changes"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatAgentModePrompt(tt.mode)
+			if tt.name == "empty" && got != "" {
+				t.Fatalf("empty mode prompt = %q, want empty", got)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("missing %q in:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("unexpected %q in:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSystemPrompt_AppendsAgentModeLast(t *testing.T) {
+	t.Parallel()
+	r := &Runner{SystemPrompt: "base", AgentMode: session.AgentModePlan}
+	got := r.buildSystemPrompt("summary", 4096)
+	mode := FormatAgentModePrompt(session.AgentModePlan)
+	if !strings.HasSuffix(got, mode) {
+		t.Fatalf("mode prompt is not last:\n%s", got)
+	}
+	for _, want := range []string{"base", "Earlier conversation summary", "4096", mode} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)
 		}

--- a/cometmind/internal/agent/runner.go
+++ b/cometmind/internal/agent/runner.go
@@ -62,6 +62,7 @@ type Runner struct {
 	MaxTokens              int
 	MemoryRetrievalTimeout time.Duration
 	SystemPrompt           string
+	AgentMode              session.AgentMode
 	SkillIndex             string
 	JobIndex               string
 	SubagentOrchestrator   *subagent.Orchestrator
@@ -782,6 +783,9 @@ func (r *Runner) buildSystemPrompt(contextSummary string, maxTokens int) string 
 		parts = append(parts, block)
 	}
 	if block := FormatOutputBudgetPromptBlock(maxTokens); block != "" {
+		parts = append(parts, block)
+	}
+	if block := FormatAgentModePrompt(r.AgentMode); block != "" {
 		parts = append(parts, block)
 	}
 	if len(parts) == 0 {

--- a/cometmind/internal/apigen/types.gen.go
+++ b/cometmind/internal/apigen/types.gen.go
@@ -10,6 +10,24 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// Defines values for AgentMode.
+const (
+	Auto AgentMode = "auto"
+	Plan AgentMode = "plan"
+)
+
+// Valid indicates whether the value is a known member of the AgentMode enum.
+func (e AgentMode) Valid() bool {
+	switch e {
+	case Auto:
+		return true
+	case Plan:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AssistantImageEventMediaType.
 const (
 	AssistantImageEventMediaTypeImagegif  AssistantImageEventMediaType = "image/gif"
@@ -919,6 +937,12 @@ func (e GetWorkspaceGitStatusParamsScope) Valid() bool {
 	}
 }
 
+// AgentMode Agent capability surface for a session or turn. `auto` preserves the full
+// agent toolset; `plan` is a read-only planning mode that removes command,
+// file-write, and mutation tools while keeping host-wide reads, network
+// access, and read-only research delegation.
+type AgentMode string
+
 // AssistantImageEvent defines model for AssistantImageEvent.
 type AssistantImageEvent struct {
 	Alt *string `json:"alt,omitempty"`
@@ -1554,6 +1578,10 @@ type ModelListResponse struct {
 
 // PostMessageRequest defines model for PostMessageRequest.
 type PostMessageRequest struct {
+	// AgentMode Optional per-turn agent mode override. When omitted, the session's
+	// persisted mode is used. New sessions always start in `auto`.
+	AgentMode *AgentMode `json:"agent_mode,omitempty"`
+
 	// DisplayText Optional transcript label for the user bubble. When set, the UI shows this instead of text while the agent still receives text.
 	DisplayText *string `json:"display_text,omitempty"`
 
@@ -1675,6 +1703,9 @@ type SearchMemoryRequest struct {
 type Session struct {
 	// AcpSessionId External ACP session ID recorded for diagnostics.
 	AcpSessionId *string `json:"acp_session_id,omitempty"`
+
+	// AgentMode Active agent mode for the session. `auto` unless the user switched this session to `plan`.
+	AgentMode AgentMode `json:"agent_mode"`
 
 	// CreatedAt Unix epoch milliseconds.
 	CreatedAt        int64                    `json:"created_at"`
@@ -1939,7 +1970,9 @@ type UpdateScheduledJobRequest struct {
 
 // UpdateSessionRequest defines model for UpdateSessionRequest.
 type UpdateSessionRequest struct {
-	ModelId *string `json:"model_id,omitempty"`
+	// AgentMode Persist the preferred mode for this session. New sessions always start in `auto`.
+	AgentMode *AgentMode `json:"agent_mode,omitempty"`
+	ModelId   *string    `json:"model_id,omitempty"`
 
 	// Pinned Pin the session to the top of its workspace group in the sidebar.
 	Pinned     *bool   `json:"pinned,omitempty"`

--- a/cometmind/internal/db/migrate.go
+++ b/cometmind/internal/db/migrate.go
@@ -462,6 +462,10 @@ var alterStatements = [][]string{
 			archived, retention_policy, application_policy, kind, last_accessed_at, created_at
 		)`,
 	},
+	// v26 -> v27: per-session agent mode (auto/plan) for composer mode switching.
+	{
+		"ALTER TABLE sessions ADD COLUMN agent_mode TEXT NOT NULL DEFAULT 'auto' CHECK (agent_mode IN ('auto', 'plan'))",
+	},
 }
 
 // execAlter runs one incremental DDL statement, tolerating idempotent failures
@@ -500,7 +504,7 @@ func splitStatements(sql string) []string {
 	return out
 }
 
-const schemaVersion = 26
+const schemaVersion = 27
 
 // EnsureSchema runs [Migrate] once per database file using PRAGMA user_version.
 // For existing databases, it applies incremental ALTER statements to upgrade

--- a/cometmind/internal/db/migrate_test.go
+++ b/cometmind/internal/db/migrate_test.go
@@ -37,6 +37,28 @@ func TestEnsureSchemaV26MigratesMemoryPoliciesAndIsolatesLegacyOutcomes(t *testi
 			t.Fatal(err)
 		}
 	}
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE sessions (
+		id TEXT PRIMARY KEY,
+		workspace_id TEXT NOT NULL,
+		title TEXT NOT NULL DEFAULT '',
+		model_id TEXT NOT NULL,
+		provider_id TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'active',
+		token_usage TEXT NOT NULL DEFAULT '{}',
+		parent_session_id TEXT,
+		purpose TEXT NOT NULL DEFAULT '',
+		delegation_status TEXT NOT NULL DEFAULT '',
+		output_summary TEXT NOT NULL DEFAULT '',
+		acp_session_id TEXT NOT NULL DEFAULT '',
+		pending_question TEXT NOT NULL DEFAULT '',
+		subagent_kind TEXT NOT NULL DEFAULT '',
+		pinned INTEGER NOT NULL DEFAULT 0,
+		context_summary TEXT NOT NULL DEFAULT '',
+		created_at INTEGER NOT NULL DEFAULT 0,
+		updated_at INTEGER NOT NULL DEFAULT 0
+	)`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := conn.ExecContext(ctx, "PRAGMA user_version = 25"); err != nil {
 		t.Fatal(err)
 	}

--- a/cometmind/internal/db/models.go
+++ b/cometmind/internal/db/models.go
@@ -185,6 +185,7 @@ type Session struct {
 	AcpSessionID            string         `json:"acp_session_id"`
 	PendingQuestion         string         `json:"pending_question"`
 	SubagentKind            string         `json:"subagent_kind"`
+	AgentMode               string         `json:"agent_mode"`
 	Pinned                  int64          `json:"pinned"`
 	ContextSummary          string         `json:"context_summary"`
 	CompactedUntilMessageID sql.NullString `json:"compacted_until_message_id"`

--- a/cometmind/internal/db/queries/sessions.sql
+++ b/cometmind/internal/db/queries/sessions.sql
@@ -1,6 +1,6 @@
 -- name: CreateSession :one
-INSERT INTO sessions (id, workspace_id, title, model_id, provider_id, status, origin)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO sessions (id, workspace_id, title, model_id, provider_id, status, origin, agent_mode)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: CreateChildSession :one
@@ -15,9 +15,10 @@ INSERT INTO sessions (
     purpose,
     delegation_status,
     output_summary,
-    subagent_kind
+    subagent_kind,
+    agent_mode
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: ListChildSessions :many
@@ -177,6 +178,14 @@ SET
     pinned = ?,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?;
+
+-- name: UpdateSessionAgentMode :one
+UPDATE sessions
+SET
+    agent_mode = ?,
+    updated_at = unixepoch ('now', 'subsec') * 1000
+WHERE id = ?
+RETURNING *;
 
 -- name: UpdateSessionWorkspace :exec
 UPDATE sessions

--- a/cometmind/internal/db/schema.sql
+++ b/cometmind/internal/db/schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE sessions (
     pending_question   TEXT NOT NULL DEFAULT '',
     subagent_kind      TEXT NOT NULL DEFAULT ''
                        CHECK (subagent_kind IN ('', 'general', 'acp')),
+    agent_mode         TEXT NOT NULL DEFAULT 'auto'
+                       CHECK (agent_mode IN ('auto', 'plan')),
     pinned             INTEGER NOT NULL DEFAULT 0,
     context_summary    TEXT NOT NULL DEFAULT '',
     compacted_until_message_id TEXT,

--- a/cometmind/internal/db/sessions.sql.go
+++ b/cometmind/internal/db/sessions.sql.go
@@ -38,10 +38,11 @@ INSERT INTO sessions (
     purpose,
     delegation_status,
     output_summary,
-    subagent_kind
+    subagent_kind,
+    agent_mode
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 `
 
 type CreateChildSessionParams struct {
@@ -56,6 +57,7 @@ type CreateChildSessionParams struct {
 	DelegationStatus string         `json:"delegation_status"`
 	OutputSummary    string         `json:"output_summary"`
 	SubagentKind     string         `json:"subagent_kind"`
+	AgentMode        string         `json:"agent_mode"`
 }
 
 func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSessionParams) (Session, error) {
@@ -71,6 +73,7 @@ func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSession
 		arg.DelegationStatus,
 		arg.OutputSummary,
 		arg.SubagentKind,
+		arg.AgentMode,
 	)
 	var i Session
 	err := row.Scan(
@@ -89,6 +92,7 @@ func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSession
 		&i.AcpSessionID,
 		&i.PendingQuestion,
 		&i.SubagentKind,
+		&i.AgentMode,
 		&i.Pinned,
 		&i.ContextSummary,
 		&i.CompactedUntilMessageID,
@@ -100,9 +104,9 @@ func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSession
 }
 
 const createSession = `-- name: CreateSession :one
-INSERT INTO sessions (id, workspace_id, title, model_id, provider_id, status, origin)
-VALUES (?, ?, ?, ?, ?, ?, ?)
-RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+INSERT INTO sessions (id, workspace_id, title, model_id, provider_id, status, origin, agent_mode)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 `
 
 type CreateSessionParams struct {
@@ -113,6 +117,7 @@ type CreateSessionParams struct {
 	ProviderID  string `json:"provider_id"`
 	Status      string `json:"status"`
 	Origin      string `json:"origin"`
+	AgentMode   string `json:"agent_mode"`
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error) {
@@ -124,6 +129,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		arg.ProviderID,
 		arg.Status,
 		arg.Origin,
+		arg.AgentMode,
 	)
 	var i Session
 	err := row.Scan(
@@ -142,6 +148,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.AcpSessionID,
 		&i.PendingQuestion,
 		&i.SubagentKind,
+		&i.AgentMode,
 		&i.Pinned,
 		&i.ContextSummary,
 		&i.CompactedUntilMessageID,
@@ -163,7 +170,7 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 }
 
 const getActiveChildForParent = `-- name: GetActiveChildForParent :one
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE
     parent_session_id = ?
@@ -191,6 +198,7 @@ func (q *Queries) GetActiveChildForParent(ctx context.Context, parentSessionID s
 		&i.AcpSessionID,
 		&i.PendingQuestion,
 		&i.SubagentKind,
+		&i.AgentMode,
 		&i.Pinned,
 		&i.ContextSummary,
 		&i.CompactedUntilMessageID,
@@ -203,7 +211,7 @@ func (q *Queries) GetActiveChildForParent(ctx context.Context, parentSessionID s
 
 const getSession = `-- name: GetSession :one
 SELECT
-    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
+    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
     COALESCE(g.platform, '') AS gateway_platform,
     COALESCE(g.platform_channel_id, '') AS gateway_channel_id,
     COALESCE(g.thread_id, '') AS gateway_thread_id
@@ -240,6 +248,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, err
 		&i.Session.AcpSessionID,
 		&i.Session.PendingQuestion,
 		&i.Session.SubagentKind,
+		&i.Session.AgentMode,
 		&i.Session.Pinned,
 		&i.Session.ContextSummary,
 		&i.Session.CompactedUntilMessageID,
@@ -255,7 +264,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, err
 
 const listAllSessions = `-- name: ListAllSessions :many
 SELECT
-    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
+    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
     COALESCE(g.platform, '') AS gateway_platform,
     COALESCE(g.platform_channel_id, '') AS gateway_channel_id,
     COALESCE(g.thread_id, '') AS gateway_thread_id
@@ -299,6 +308,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 			&i.Session.AcpSessionID,
 			&i.Session.PendingQuestion,
 			&i.Session.SubagentKind,
+			&i.Session.AgentMode,
 			&i.Session.Pinned,
 			&i.Session.ContextSummary,
 			&i.Session.CompactedUntilMessageID,
@@ -323,7 +333,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 }
 
 const listChildSessions = `-- name: ListChildSessions :many
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE parent_session_id = ?
 ORDER BY created_at ASC
@@ -354,6 +364,7 @@ func (q *Queries) ListChildSessions(ctx context.Context, parentSessionID sql.Nul
 			&i.AcpSessionID,
 			&i.PendingQuestion,
 			&i.SubagentKind,
+			&i.AgentMode,
 			&i.Pinned,
 			&i.ContextSummary,
 			&i.CompactedUntilMessageID,
@@ -375,7 +386,7 @@ func (q *Queries) ListChildSessions(ctx context.Context, parentSessionID sql.Nul
 }
 
 const listSessionsByWorkspace = `-- name: ListSessionsByWorkspace :many
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE workspace_id = ?
 ORDER BY pinned DESC, updated_at DESC
@@ -406,6 +417,7 @@ func (q *Queries) ListSessionsByWorkspace(ctx context.Context, workspaceID strin
 			&i.AcpSessionID,
 			&i.PendingQuestion,
 			&i.SubagentKind,
+			&i.AgentMode,
 			&i.Pinned,
 			&i.ContextSummary,
 			&i.CompactedUntilMessageID,
@@ -614,6 +626,50 @@ type UpdateSessionACPParams struct {
 func (q *Queries) UpdateSessionACP(ctx context.Context, arg UpdateSessionACPParams) error {
 	_, err := q.db.ExecContext(ctx, updateSessionACP, arg.AcpSessionID, arg.ID)
 	return err
+}
+
+const updateSessionAgentMode = `-- name: UpdateSessionAgentMode :one
+UPDATE sessions
+SET
+    agent_mode = ?,
+    updated_at = unixepoch ('now', 'subsec') * 1000
+WHERE id = ?
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+`
+
+type UpdateSessionAgentModeParams struct {
+	AgentMode string `json:"agent_mode"`
+	ID        string `json:"id"`
+}
+
+func (q *Queries) UpdateSessionAgentMode(ctx context.Context, arg UpdateSessionAgentModeParams) (Session, error) {
+	row := q.db.QueryRowContext(ctx, updateSessionAgentMode, arg.AgentMode, arg.ID)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.ModelID,
+		&i.ProviderID,
+		&i.Status,
+		&i.Origin,
+		&i.TokenUsage,
+		&i.ParentSessionID,
+		&i.Purpose,
+		&i.DelegationStatus,
+		&i.OutputSummary,
+		&i.AcpSessionID,
+		&i.PendingQuestion,
+		&i.SubagentKind,
+		&i.AgentMode,
+		&i.Pinned,
+		&i.ContextSummary,
+		&i.CompactedUntilMessageID,
+		&i.ContextSummaryUpdatedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateSessionContextSummary = `-- name: UpdateSessionContextSummary :exec

--- a/cometmind/internal/retention/retention_test.go
+++ b/cometmind/internal/retention/retention_test.go
@@ -31,7 +31,7 @@ func TestRunner_DeletesStaleSessionAndGatewayMapping(t *testing.T) {
 	}
 	old := time.Now().Add(-100 * 24 * time.Hour).UnixMilli()
 	sess, err := q.CreateSession(ctx, db.CreateSessionParams{
-		ID: "sess-old", WorkspaceID: ws.ID, Title: "old", ModelID: "m", ProviderID: "p", Status: "active", Origin: "user",
+		ID: "sess-old", WorkspaceID: ws.ID, Title: "old", ModelID: "m", ProviderID: "p", Status: "active", Origin: "user", AgentMode: "auto",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestRunner_MaxSessionsPerWorkspace(t *testing.T) {
 	now := time.Now().UnixMilli()
 	for i, id := range []string{"s1", "s2", "s3"} {
 		if _, err := q.CreateSession(ctx, db.CreateSessionParams{
-			ID: id, WorkspaceID: ws.ID, Title: id, ModelID: "m", ProviderID: "p", Status: "active", Origin: "user",
+			ID: id, WorkspaceID: ws.ID, Title: id, ModelID: "m", ProviderID: "p", Status: "active", Origin: "user", AgentMode: "auto",
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -695,6 +695,7 @@ func (r *Runtime) runnerFor(sess session.Session, workspacePath string, opts Run
 	}
 
 	var registry *tools.Registry
+	var agentMode session.AgentMode
 	if opts.Subagent {
 		mode := opts.SubagentMode
 		if mode == "" {
@@ -702,15 +703,15 @@ func (r *Runtime) runnerFor(sess session.Session, workspacePath string, opts Run
 		}
 		registry = tools.NewSubagentRegistry(workspacePath, &skillRegistry, mode)
 	} else {
-		mode := opts.AgentMode
-		if mode == "" {
+		agentMode = opts.AgentMode
+		if agentMode == "" {
 			var err error
-			mode, err = session.ParseAgentMode(sess.AgentMode)
+			agentMode, err = session.ParseAgentMode(sess.AgentMode)
 			if err != nil {
 				return nil, err
 			}
 		}
-		registry = r.toolRegistryWithJobMeta(workspacePath, skillRegistry, sess.ID, platform, opts.SourceChannelID, mode)
+		registry = r.toolRegistryWithJobMeta(workspacePath, skillRegistry, sess.ID, platform, opts.SourceChannelID, agentMode)
 	}
 
 	runner := &agent.Runner{
@@ -723,6 +724,7 @@ func (r *Runtime) runnerFor(sess session.Session, workspacePath string, opts Run
 		MaxSteps:             maxSteps,
 		MaxTokens:            r.Config.MaxTokens,
 		SystemPrompt:         r.SystemPrompt,
+		AgentMode:            agentMode,
 		SkillIndex:           skillRegistry.PromptIndex(),
 		SubagentOrchestrator: r.subagentOrchestratorForRunner(opts.Subagent),
 		MemorySem:            r.memorySem,
@@ -766,11 +768,11 @@ func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry sk
 		JobPlatform:        platform,
 		JobSourceChannelID: sourceChannelID,
 		AgentMode:          mode,
-		BrowserSearchURL:     os.Getenv("COMETLINE_BROWSER_SEARCH_URL"),
-		BrowserSearchToken:   os.Getenv("COMETLINE_BROWSER_SEARCH_TOKEN"),
-		ScreenCaptureURL:     os.Getenv("COMETLINE_SCREEN_CAPTURE_URL"),
-		ScreenCaptureToken:   os.Getenv("COMETLINE_SCREEN_CAPTURE_TOKEN"),
-		SettingsRuntime:      r,
+		BrowserSearchURL:   os.Getenv("COMETLINE_BROWSER_SEARCH_URL"),
+		BrowserSearchToken: os.Getenv("COMETLINE_BROWSER_SEARCH_TOKEN"),
+		ScreenCaptureURL:   os.Getenv("COMETLINE_SCREEN_CAPTURE_URL"),
+		ScreenCaptureToken: os.Getenv("COMETLINE_SCREEN_CAPTURE_TOKEN"),
+		SettingsRuntime:    r,
 		RunnerFactory: func(child session.Session, workspaceRoot string, maxSteps int, mode tools.SubagentMode) (tools.AgentLoopRunner, error) {
 			return r.SubagentRunnerFor(child, workspaceRoot, maxSteps, mode)
 		},

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -637,18 +637,30 @@ func (r *Runtime) SubagentOrchestrator() *subagent.Orchestrator {
 }
 
 // RunnerOptions controls how a runner is assembled. Most callers should use
-// RunnerFor, SubagentRunnerFor, or RunnerForGateway instead.
+// RunnerFor, RunnerForMode, SubagentRunnerFor, or RunnerForGateway instead.
 type RunnerOptions struct {
 	MaxSteps        int
 	Platform        string
 	SourceChannelID string
 	Subagent        bool
 	SubagentMode    tools.SubagentMode
+	AgentMode       session.AgentMode
 }
 
-// RunnerFor returns an agent runner wired for a specific session and workspace.
+// RunnerFor returns an agent runner wired for a specific session and workspace
+// using the session's persisted agent mode.
 func (r *Runtime) RunnerFor(sess session.Session, workspacePath string) (*agent.Runner, error) {
-	return r.runnerFor(sess, workspacePath, RunnerOptions{})
+	mode, err := session.ParseAgentMode(sess.AgentMode)
+	if err != nil {
+		return nil, err
+	}
+	return r.runnerFor(sess, workspacePath, RunnerOptions{AgentMode: mode})
+}
+
+// RunnerForMode returns an agent runner wired for a specific session, workspace,
+// and explicit per-turn agent mode.
+func (r *Runtime) RunnerForMode(sess session.Session, workspacePath string, mode session.AgentMode) (*agent.Runner, error) {
+	return r.runnerFor(sess, workspacePath, RunnerOptions{AgentMode: mode})
 }
 
 // SubagentRunnerFor returns a runner for an in-process subagent child session.
@@ -690,7 +702,15 @@ func (r *Runtime) runnerFor(sess session.Session, workspacePath string, opts Run
 		}
 		registry = tools.NewSubagentRegistry(workspacePath, &skillRegistry, mode)
 	} else {
-		registry = r.toolRegistryWithJobMeta(workspacePath, skillRegistry, sess.ID, platform, opts.SourceChannelID)
+		mode := opts.AgentMode
+		if mode == "" {
+			var err error
+			mode, err = session.ParseAgentMode(sess.AgentMode)
+			if err != nil {
+				return nil, err
+			}
+		}
+		registry = r.toolRegistryWithJobMeta(workspacePath, skillRegistry, sess.ID, platform, opts.SourceChannelID, mode)
 	}
 
 	runner := &agent.Runner{
@@ -727,7 +747,7 @@ func (r *Runtime) subagentOrchestratorForRunner(isSubagent bool) *subagent.Orche
 	return r.SubagentOrchestrator()
 }
 
-func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry skills.Registry, sessionID, platform, sourceChannelID string) *tools.Registry {
+func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry skills.Registry, sessionID, platform, sourceChannelID string, mode session.AgentMode) *tools.Registry {
 	sub := r.Config.EffectiveSubagentSettings()
 	return tools.NewRegistry(workspacePath, tools.RegistryOptions{
 		Sessions:           r.Sessions,
@@ -745,6 +765,7 @@ func (r *Runtime) toolRegistryWithJobMeta(workspacePath string, skillRegistry sk
 		SessionID:          sessionID,
 		JobPlatform:        platform,
 		JobSourceChannelID: sourceChannelID,
+		AgentMode:          mode,
 		BrowserSearchURL:     os.Getenv("COMETLINE_BROWSER_SEARCH_URL"),
 		BrowserSearchToken:   os.Getenv("COMETLINE_BROWSER_SEARCH_TOKEN"),
 		ScreenCaptureURL:     os.Getenv("COMETLINE_SCREEN_CAPTURE_URL"),

--- a/cometmind/internal/runtime/runtime_test.go
+++ b/cometmind/internal/runtime/runtime_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cometline/cometmind/internal/config"
 	"github.com/cometline/cometmind/internal/session"
+	"github.com/cometline/cometmind/internal/tools"
 )
 
 func TestRuntimeWiresServiceAndRunner(t *testing.T) {
@@ -50,6 +51,23 @@ func TestRuntimeWiresServiceAndRunner(t *testing.T) {
 	}
 	if runner == nil {
 		t.Fatal("RunnerFor() returned nil")
+	}
+	if runner.AgentMode != session.AgentModeAuto {
+		t.Fatalf("RunnerFor() AgentMode = %q, want auto", runner.AgentMode)
+	}
+	planRunner, err := rt.RunnerForMode(sess, ws.Path, session.AgentModePlan)
+	if err != nil {
+		t.Fatalf("RunnerForMode(plan) error = %v", err)
+	}
+	if planRunner.AgentMode != session.AgentModePlan {
+		t.Fatalf("RunnerForMode(plan) AgentMode = %q, want plan", planRunner.AgentMode)
+	}
+	subagentRunner, err := rt.SubagentRunnerFor(sess, ws.Path, 1, tools.SubagentModeResearch)
+	if err != nil {
+		t.Fatalf("SubagentRunnerFor() error = %v", err)
+	}
+	if subagentRunner.AgentMode != "" {
+		t.Fatalf("SubagentRunnerFor() AgentMode = %q, want empty", subagentRunner.AgentMode)
 	}
 }
 

--- a/cometmind/internal/session/agent_mode.go
+++ b/cometmind/internal/session/agent_mode.go
@@ -1,0 +1,42 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AgentMode selects the agent capability surface for a session or turn.
+// It is a tool-capability policy, not an OS sandbox: Plan removes command,
+// file-write, and mutation tools while keeping host-wide reads and network.
+type AgentMode string
+
+const (
+	// AgentModeAuto preserves the full parent-agent tool surface.
+	AgentModeAuto AgentMode = "auto"
+	// AgentModePlan is a read-only planning surface: no command, no workspace
+	// mutation, no external coding harness, and research-only subagents.
+	AgentModePlan AgentMode = "plan"
+)
+
+// ValidAgentModes lists the accepted agent mode values.
+var ValidAgentModes = []AgentMode{AgentModeAuto, AgentModePlan}
+
+// ParseAgentMode validates a wire value. Empty defaults to auto; unknown
+// values fail closed with an error so callers can reject the request.
+func ParseAgentMode(raw string) (AgentMode, error) {
+	switch AgentMode(strings.TrimSpace(strings.ToLower(raw))) {
+	case "":
+		return AgentModeAuto, nil
+	case AgentModeAuto:
+		return AgentModeAuto, nil
+	case AgentModePlan:
+		return AgentModePlan, nil
+	default:
+		return "", fmt.Errorf("invalid agent mode %q (expected auto or plan)", raw)
+	}
+}
+
+// IsPlan reports whether the mode is Plan.
+func (m AgentMode) IsPlan() bool {
+	return m == AgentModePlan
+}

--- a/cometmind/internal/session/agent_mode_test.go
+++ b/cometmind/internal/session/agent_mode_test.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/db"
+	_ "modernc.org/sqlite"
+)
+
+func openTestService(t *testing.T) *Service {
+	t.Helper()
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := db.EnsureSchema(context.Background(), conn); err != nil {
+		t.Fatalf("EnsureSchema() error = %v", err)
+	}
+	return New(conn)
+}
+
+func TestNewSessionDefaultsToAuto(t *testing.T) {
+	t.Parallel()
+
+	svc := openTestService(t)
+	ws, err := svc.EnsureWorkspace(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	sess, err := svc.NewSession(context.Background(), ws.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if sess.AgentMode != string(AgentModeAuto) {
+		t.Fatalf("agent mode = %q, want %q", sess.AgentMode, AgentModeAuto)
+	}
+}
+
+func TestUpdateSessionAgentModePersists(t *testing.T) {
+	t.Parallel()
+
+	svc := openTestService(t)
+	ws, err := svc.EnsureWorkspace(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	sess, err := svc.NewSession(context.Background(), ws.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	updated, err := svc.UpdateSessionAgentMode(context.Background(), sess.ID, AgentModePlan)
+	if err != nil {
+		t.Fatalf("UpdateSessionAgentMode() error = %v", err)
+	}
+	if updated.AgentMode != string(AgentModePlan) {
+		t.Fatalf("updated agent mode = %q, want %q", updated.AgentMode, AgentModePlan)
+	}
+
+	reloaded, err := svc.GetSession(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if reloaded.AgentMode != string(AgentModePlan) {
+		t.Fatalf("reloaded agent mode = %q, want %q", reloaded.AgentMode, AgentModePlan)
+	}
+}
+
+func TestNewChildSessionInheritsParentAgentMode(t *testing.T) {
+	t.Parallel()
+
+	svc := openTestService(t)
+	ws, err := svc.EnsureWorkspace(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	parent, err := svc.NewSession(context.Background(), ws.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	parent, err = svc.UpdateSessionAgentMode(context.Background(), parent.ID, AgentModePlan)
+	if err != nil {
+		t.Fatalf("UpdateSessionAgentMode() error = %v", err)
+	}
+
+	child, err := svc.NewChildSession(context.Background(), parent, "research", "general")
+	if err != nil {
+		t.Fatalf("NewChildSession() error = %v", err)
+	}
+	if child.AgentMode != string(AgentModePlan) {
+		t.Fatalf("child agent mode = %q, want %q (inherited from plan parent)", child.AgentMode, AgentModePlan)
+	}
+}
+
+func TestForkSessionStartsInAuto(t *testing.T) {
+	t.Parallel()
+
+	svc := openTestService(t)
+	srcWS, err := svc.EnsureWorkspace(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	src, err := svc.NewSession(context.Background(), srcWS.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	src, err = svc.UpdateSessionAgentMode(context.Background(), src.ID, AgentModePlan)
+	if err != nil {
+		t.Fatalf("UpdateSessionAgentMode() error = %v", err)
+	}
+
+	forked, err := svc.ForkSession(context.Background(), src.ID, t.TempDir())
+	if err != nil {
+		t.Fatalf("ForkSession() error = %v", err)
+	}
+	if forked.AgentMode != string(AgentModeAuto) {
+		t.Fatalf("forked agent mode = %q, want %q (user forks always start in auto)", forked.AgentMode, AgentModeAuto)
+	}
+}

--- a/cometmind/internal/session/model.go
+++ b/cometmind/internal/session/model.go
@@ -34,6 +34,7 @@ type Session struct {
 	ACPSessionID            string
 	PendingQuestion         string
 	SubagentKind            string
+	AgentMode               string
 	Gateway                 *SessionGateway
 	Pinned                  bool
 	ContextSummary          string
@@ -92,6 +93,7 @@ func sessionFromDB(s db.Session) Session {
 		ACPSessionID:            s.AcpSessionID,
 		PendingQuestion:         s.PendingQuestion,
 		SubagentKind:            s.SubagentKind,
+		AgentMode:               s.AgentMode,
 		Pinned:                  s.Pinned != 0,
 		ContextSummary:          s.ContextSummary,
 		CompactedUntilMessageID: compactedUntil,

--- a/cometmind/internal/session/service.go
+++ b/cometmind/internal/session/service.go
@@ -275,6 +275,7 @@ func (s *Service) ForkSession(ctx context.Context, sessionID, absPath string) (S
 		ProviderID:  src.ProviderID,
 		Status:      "active",
 		Origin:      "user",
+		AgentMode:   string(AgentModeAuto),
 	})
 	if err != nil {
 		return Session{}, err
@@ -439,6 +440,7 @@ func (s *Service) newSessionWithOrigin(ctx context.Context, workspaceID string, 
 		ProviderID:  providerID,
 		Status:      "active",
 		Origin:      origin,
+		AgentMode:   string(AgentModeAuto),
 	})
 	if err != nil {
 		return Session{}, err
@@ -615,6 +617,21 @@ func (s *Service) UpdateSessionPinned(ctx context.Context, sessionID string, pin
 		return Session{}, err
 	}
 	return s.GetSession(ctx, sessionID)
+}
+
+// UpdateSessionAgentMode persists the preferred agent mode for a session.
+func (s *Service) UpdateSessionAgentMode(ctx context.Context, sessionID string, mode AgentMode) (Session, error) {
+	if _, err := s.GetSession(ctx, sessionID); err != nil {
+		return Session{}, err
+	}
+	row, err := s.q.UpdateSessionAgentMode(ctx, db.UpdateSessionAgentModeParams{
+		AgentMode: string(mode),
+		ID:        sessionID,
+	})
+	if err != nil {
+		return Session{}, err
+	}
+	return sessionFromDB(row), nil
 }
 
 // UpdateSessionTitle persists a new display title for an existing session.
@@ -1228,6 +1245,7 @@ func (s *Service) NewChildSession(ctx context.Context, parent Session, purpose, 
 		DelegationStatus: DelegationPending.String(),
 		OutputSummary:    "",
 		SubagentKind:     subagentKind,
+		AgentMode:        parent.AgentMode,
 	})
 	if err != nil {
 		return Session{}, err

--- a/cometmind/internal/session/wire.go
+++ b/cometmind/internal/session/wire.go
@@ -26,6 +26,7 @@ func APISession(sess Session, workspacePath string) (apigen.Session, error) {
 		Status:        apigen.SessionStatus(sess.Status),
 		Origin:        apigen.SessionOrigin(sess.Origin),
 		TokenUsage:    usage,
+		AgentMode:     apigen.AgentMode(sess.AgentMode),
 		Pinned:        sess.Pinned,
 		CreatedAt:     sess.CreatedAt,
 		UpdatedAt:     sess.UpdatedAt,

--- a/cometmind/internal/tools/fs/workspace.go
+++ b/cometmind/internal/tools/fs/workspace.go
@@ -36,11 +36,22 @@ func (w Workspace) Resolve(rel string) (string, error) {
 }
 
 // ResolveReadable resolves workspace paths plus explicitly exposed runtime
-// mounts. It does not expose ~/.cometmind as a general filesystem root.
+// mounts. Absolute paths resolve anywhere the CometMind process may read, and
+// relative paths follow symlinks outside the workspace: read tools
+// intentionally have host-wide read capability in every agent mode.
+// It does not expose ~/.cometmind as a general filesystem root.
 func (w Workspace) ResolveReadable(rel string) (string, error) {
 	mount, subpath, ok := runtimeMount(rel)
 	if !ok {
-		return w.Resolve(rel)
+		if filepath.IsAbs(rel) {
+			return filepath.Clean(rel), nil
+		}
+		joined := filepath.Clean(filepath.Join(filepath.Clean(w.Root), rel))
+		resolved, err := filepath.EvalSymlinks(joined)
+		if err != nil {
+			return "", err
+		}
+		return resolved, nil
 	}
 	if mount != runtimeToolOutputMount && mount != runtimeTmpMount && mount != runtimeWikiMount {
 		return "", fmt.Errorf("runtime mount is not readable: %s", mount)
@@ -69,10 +80,15 @@ func (w Workspace) ResolveWritable(rel string) (string, error) {
 	return sandbox.ResolveWorkspacePath(root, subpath)
 }
 
-// ResolveSearchRoot resolves a path that may be a readable runtime mount and
-// returns the display prefix needed to make search results usable by other tools.
+// ResolveSearchRoot resolves a path that may be a readable runtime mount or an
+// absolute external root and returns the display prefix needed to make search
+// results usable by other tools.
 func (w Workspace) ResolveSearchRoot(rel string) (root, displayPrefix string, err error) {
 	if !IsRuntimePath(rel) {
+		if filepath.IsAbs(rel) {
+			clean := filepath.Clean(rel)
+			return clean, clean, nil
+		}
 		root, err = w.Resolve(rel)
 		return root, "", err
 	}
@@ -80,11 +96,14 @@ func (w Workspace) ResolveSearchRoot(rel string) (root, displayPrefix string, er
 	return root, strings.TrimSuffix(filepath.ToSlash(strings.TrimSpace(rel)), "/"), err
 }
 
-// DisplayPath returns the path shown in tool results (workspace-relative or
-// the original @runtime alias when applicable).
+// DisplayPath returns the path shown in tool results (workspace-relative,
+// the original @runtime alias, or the full absolute path for external reads).
 func (w Workspace) DisplayPath(abs, inputRel string) string {
 	if IsRuntimePath(inputRel) {
 		return filepath.ToSlash(inputRel)
+	}
+	if filepath.IsAbs(inputRel) {
+		return filepath.ToSlash(filepath.Clean(inputRel))
 	}
 	rel := strings.TrimPrefix(strings.TrimPrefix(abs, w.Root), string(filepath.Separator))
 	return filepath.ToSlash(rel)

--- a/cometmind/internal/tools/glob.go
+++ b/cometmind/internal/tools/glob.go
@@ -30,12 +30,13 @@ func (Glob) Spec() ToolSpec {
 		Name: "glob",
 		Description: "Find files by name pattern. Supports standard glob syntax " +
 			"including ** for recursive matching. Results sorted by modification time " +
-			"(newest first), capped at 100 files. Skips gitignored paths. The path may be @runtime/wiki.",
+			"(newest first), capped at 100 files. Skips gitignored paths. " +
+			"The path may be @runtime/wiki or an absolute host directory.",
 		Parameters: json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"pattern": {"type": "string", "description": "Glob pattern, e.g. **/*.ts, src/**/*.go, *.{json,yaml}"},
-				"path": {"type": "string", "description": "Optional relative subdirectory to scope the search (default workspace root)"}
+				"path": {"type": "string", "description": "Optional subdirectory to scope the search: workspace-relative or an absolute host directory (default workspace root)"}
 			},
 			"required": ["pattern"]
 		}`),
@@ -72,8 +73,11 @@ func (g Glob) Execute(ctx context.Context, input json.RawMessage) (Result, error
 		workspaceRoot = searchRoot
 	}
 
+	walkCtx, cancel := withSearchDeadline(ctx)
+	defer cancel()
+
 	var matches []globMatch
-	err = walkSearchableFiles(ctx, workspaceRoot, searchRoot, func(workspaceRel, absPath string) error {
+	err = walkSearchableFiles(walkCtx, workspaceRoot, searchRoot, func(workspaceRel, absPath string) error {
 		matched, err := doublestar.PathMatch(pattern, workspaceRel)
 		if err != nil || !matched {
 			return nil
@@ -88,12 +92,13 @@ func (g Glob) Execute(ctx context.Context, input json.RawMessage) (Result, error
 		}
 		return nil
 	})
-	if err != nil && !errors.Is(err, fs.SkipAll) {
+	budgetExhausted := errors.Is(err, errSearchBudget) || errors.Is(err, context.DeadlineExceeded)
+	if err != nil && !errors.Is(err, fs.SkipAll) && !budgetExhausted {
 		return Result{OK: false, Output: err.Error()}, nil
 	}
 
-	truncated := len(matches) > globMaxFiles || errors.Is(err, fs.SkipAll)
-	if truncated {
+	truncated := len(matches) > globMaxFiles || errors.Is(err, fs.SkipAll) || budgetExhausted
+	if truncated && len(matches) > globMaxFiles {
 		matches = matches[:globMaxFiles]
 	}
 	sort.Slice(matches, func(i, j int) bool {

--- a/cometmind/internal/tools/grep.go
+++ b/cometmind/internal/tools/grep.go
@@ -34,12 +34,13 @@ func (Grep) Spec() ToolSpec {
 	return ToolSpec{
 		Name: "grep",
 		Description: "Search file contents for a pattern. Uses ripgrep syntax when available " +
-			"(not POSIX grep). Respects .gitignore. Results include line numbers. The path may be @runtime/wiki.",
+			"(not POSIX grep). Respects .gitignore. Results include line numbers. " +
+			"The path may be @runtime/wiki or an absolute host directory.",
 		Parameters: json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"pattern": {"type": "string", "description": "Search pattern (ripgrep regex syntax)"},
-				"path": {"type": "string", "description": "Optional relative subdirectory to scope the search (default workspace root)"},
+				"path": {"type": "string", "description": "Optional subdirectory to scope the search: workspace-relative or an absolute host directory (default workspace root)"},
 				"include": {"type": "string", "description": "Optional file glob filter, e.g. **/*.tsx"},
 				"literal_text": {"type": "boolean", "description": "Treat pattern as literal text, not regex"}
 			},
@@ -157,7 +158,9 @@ func grepNative(ctx context.Context, workspaceRoot, searchRoot, pattern, include
 	}
 
 	var lines []string
-	err := walkSearchableFiles(ctx, workspaceRoot, searchRoot, func(workspaceRel, absPath string) error {
+	walkCtx, cancel := withSearchDeadline(ctx)
+	defer cancel()
+	err := walkSearchableFiles(walkCtx, workspaceRoot, searchRoot, func(workspaceRel, absPath string) error {
 		if include != "" {
 			matched, err := doublestar.PathMatch(include, workspaceRel)
 			if err != nil || !matched {
@@ -174,8 +177,8 @@ func grepNative(ctx context.Context, workspaceRoot, searchRoot, pattern, include
 		scanner := bufio.NewScanner(f)
 		lineNum := 0
 		for scanner.Scan() {
-			if ctx.Err() != nil {
-				return ctx.Err()
+			if walkCtx.Err() != nil {
+				return walkCtx.Err()
 			}
 			lineNum++
 			line := scanner.Text()
@@ -190,7 +193,8 @@ func grepNative(ctx context.Context, workspaceRoot, searchRoot, pattern, include
 		}
 		return scanner.Err()
 	})
-	if err != nil && !errors.Is(err, fs.SkipAll) && ctx.Err() == nil {
+	budgetExhausted := errors.Is(err, errSearchBudget) || errors.Is(err, context.DeadlineExceeded)
+	if err != nil && !errors.Is(err, fs.SkipAll) && !budgetExhausted && walkCtx.Err() == nil {
 		return Result{OK: false, Output: err.Error()}, nil
 	}
 
@@ -198,7 +202,7 @@ func grepNative(ctx context.Context, workspaceRoot, searchRoot, pattern, include
 	truncated := false
 	if len([]rune(text)) > grepMaxOutputChars {
 		text, truncated = truncateOutput(text, grepMaxOutputChars)
-	} else if errors.Is(err, fs.SkipAll) {
+	} else if errors.Is(err, fs.SkipAll) || budgetExhausted {
 		truncated = true
 	}
 

--- a/cometmind/internal/tools/host_read_test.go
+++ b/cometmind/internal/tools/host_read_test.go
@@ -1,0 +1,203 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func quoteJSON(t *testing.T, v any) string {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// hostReadFixture creates a workspace plus an external fixture tree outside it.
+func hostReadFixture(t *testing.T) (workspaceRoot, externalDir string) {
+	t.Helper()
+	workspaceRoot = t.TempDir()
+	externalDir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(externalDir, "note.txt"), []byte("external content\nline two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(externalDir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(externalDir, "nested", "deep.txt"), []byte("nested external"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return workspaceRoot, externalDir
+}
+
+func TestReadFileAbsoluteExternalPath(t *testing.T) {
+	root, external := hostReadFixture(t)
+	reader := ReadFile{Workspace: Workspace{Root: root}}
+
+	res, err := reader.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, filepath.Join(external, "note.txt"))+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "external content") {
+		t.Fatalf("read result = %+v", res)
+	}
+}
+
+func TestReadFileRejectsNonRegularFiles(t *testing.T) {
+	root, external := hostReadFixture(t)
+	reader := ReadFile{Workspace: Workspace{Root: root}}
+
+	res, err := reader.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, external)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || !strings.Contains(res.Output, "not a regular file") {
+		t.Fatalf("directory read result = %+v, want regular-file rejection", res)
+	}
+
+	fifo := filepath.Join(external, "pipe")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	res, err = reader.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, fifo)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || !strings.Contains(res.Output, "not a regular file") {
+		t.Fatalf("fifo read result = %+v, want regular-file rejection", res)
+	}
+}
+
+func TestReadFileRejectsOversizedInput(t *testing.T) {
+	root, external := hostReadFixture(t)
+	big := filepath.Join(external, "big.bin")
+	if err := os.WriteFile(big, make([]byte, readFileMaxInputBytes+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reader := ReadFile{Workspace: Workspace{Root: root}}
+	res, err := reader.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, big)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || !strings.Contains(res.Output, "too large") {
+		t.Fatalf("oversized read result = %+v, want size rejection", res)
+	}
+}
+
+func TestReadFileWorkspaceSymlinkToExternal(t *testing.T) {
+	root, external := hostReadFixture(t)
+	if err := os.Symlink(filepath.Join(external, "note.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	reader := ReadFile{Workspace: Workspace{Root: root}}
+	res, err := reader.Execute(context.Background(), json.RawMessage(`{"path":"link.txt"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "external content") {
+		t.Fatalf("symlink read result = %+v", res)
+	}
+}
+
+func TestListDirAbsoluteExternalPath(t *testing.T) {
+	root, external := hostReadFixture(t)
+	tool := ListDir{Workspace: Workspace{Root: root}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, external)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "note.txt") || !strings.Contains(res.Output, "nested/") {
+		t.Fatalf("list result = %+v", res)
+	}
+}
+
+func TestGlobAbsoluteExternalPath(t *testing.T) {
+	root, external := hostReadFixture(t)
+	tool := Glob{Workspace: Workspace{Root: root}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"pattern":"**/*.txt","path":`+quoteJSON(t, external)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("glob result = %+v", res)
+	}
+	for _, want := range []string{"deep.txt", "note.txt"} {
+		if !strings.Contains(res.Output, want) {
+			t.Fatalf("glob output missing %q: %s", want, res.Output)
+		}
+	}
+	// External results must retain their absolute display path.
+	if !strings.Contains(res.Output, external) {
+		t.Fatalf("glob output missing absolute root %q: %s", external, res.Output)
+	}
+}
+
+func TestGrepAbsoluteExternalPath(t *testing.T) {
+	root, external := hostReadFixture(t)
+	tool := Grep{Workspace: Workspace{Root: root}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"pattern":"external content","path":`+quoteJSON(t, external)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "note.txt") || !strings.Contains(res.Output, "external content") {
+		t.Fatalf("grep result = %+v", res)
+	}
+	if !strings.Contains(res.Output, external) {
+		t.Fatalf("grep output missing absolute root %q: %s", external, res.Output)
+	}
+}
+
+func TestRelativePathsStillResolveFromWorkspace(t *testing.T) {
+	root, _ := hostReadFixture(t)
+	if err := os.WriteFile(filepath.Join(root, "local.txt"), []byte("local"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reader := ReadFile{Workspace: Workspace{Root: root}}
+	res, err := reader.Execute(context.Background(), json.RawMessage(`{"path":"local.txt"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "local") {
+		t.Fatalf("relative read result = %+v", res)
+	}
+}
+
+func TestWritableBoundaryStillEnforced(t *testing.T) {
+	root, external := hostReadFixture(t)
+	writer := WriteFile{Workspace: Workspace{Root: root}}
+	res, err := writer.Execute(context.Background(), json.RawMessage(`{
+		"path":`+quoteJSON(t, filepath.Join(external, "escape.txt"))+`,
+		"content":"nope"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || !strings.Contains(res.Output, "escapes workspace") {
+		t.Fatalf("external write result = %+v, want workspace escape rejection", res)
+	}
+	if _, err := os.Stat(filepath.Join(external, "escape.txt")); !os.IsNotExist(err) {
+		t.Fatalf("external file should not exist after rejected write")
+	}
+}
+
+func TestDisplayPathPreservesExternalAbsolute(t *testing.T) {
+	root, external := hostReadFixture(t)
+	ws := Workspace{Root: root}
+	abs := filepath.Join(external, "note.txt")
+	if got := ws.DisplayPath(abs, abs); got != filepath.ToSlash(filepath.Clean(abs)) {
+		t.Fatalf("DisplayPath(external) = %q, want %q", got, filepath.ToSlash(filepath.Clean(abs)))
+	}
+	local := filepath.Join(root, "local.txt")
+	if got := ws.DisplayPath(local, "local.txt"); got != "local.txt" {
+		t.Fatalf("DisplayPath(workspace) = %q, want local.txt", got)
+	}
+	if got := ws.DisplayPath("", "@runtime/wiki/x.md"); got != "@runtime/wiki/x.md" {
+		t.Fatalf("DisplayPath(runtime) = %q, want @runtime/wiki/x.md", got)
+	}
+}

--- a/cometmind/internal/tools/listdir.go
+++ b/cometmind/internal/tools/listdir.go
@@ -8,15 +8,19 @@ import (
 	"strings"
 )
 
-// ListDir lists non-hidden entries one level under a path relative to the workspace.
+// ListDir lists non-hidden entries one level under a path. Relative paths
+// resolve against the workspace; absolute paths list any readable directory.
 type ListDir struct{ Workspace Workspace }
+
+const listDirMaxEntries = 2000
 
 func (ListDir) Spec() ToolSpec {
 	return ToolSpec{
 		Name: "list_dir",
-		Description: "List files and directories at a path relative to the workspace root (non-recursive). " +
-			"Use @runtime to list managed shared mounts.",
-		Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative directory; use . for workspace root"}},"required":["path"]}`),
+		Description: "List files and directories at a path (non-recursive). " +
+			"Relative paths resolve against the workspace root; absolute paths list any readable directory. " +
+			"Hidden entries are skipped. Use @runtime to list managed shared mounts.",
+		Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative directory (use . for workspace root) or an absolute host directory"}},"required":["path"]}`),
 	}
 }
 
@@ -43,6 +47,7 @@ func (l ListDir) Execute(ctx context.Context, input json.RawMessage) (Result, er
 		return Result{OK: false, Output: err.Error()}, nil
 	}
 	var b strings.Builder
+	listed := 0
 	for _, e := range ents {
 		name := e.Name()
 		if strings.HasPrefix(name, ".") {
@@ -52,6 +57,11 @@ func (l ListDir) Execute(ctx context.Context, input json.RawMessage) (Result, er
 			fmt.Fprintf(&b, "%s/\n", name)
 		} else {
 			fmt.Fprintf(&b, "%s\n", name)
+		}
+		listed++
+		if listed >= listDirMaxEntries {
+			fmt.Fprintf(&b, "(listing truncated at %d entries)\n", listDirMaxEntries)
+			break
 		}
 	}
 	return Result{OK: true, Output: b.String()}, nil

--- a/cometmind/internal/tools/options.go
+++ b/cometmind/internal/tools/options.go
@@ -51,6 +51,10 @@ type RegistryOptions struct {
 	SessionID          string
 	JobPlatform        string
 	JobSourceChannelID string
+	// AgentMode selects the tool surface for parent-agent registries.
+	// Empty or auto keeps the full ParentSurface; plan applies the read-only
+	// PlanSurface with research-only subagent spawning.
+	AgentMode             session.AgentMode
 	BrowserSearchURL      string
 	BrowserSearchToken    string
 	ScreenCaptureURL      string

--- a/cometmind/internal/tools/plan_spawn_test.go
+++ b/cometmind/internal/tools/plan_spawn_test.go
@@ -23,6 +23,32 @@ func TestSpawnGeneralAgentPlanModeRejectsCoding(t *testing.T) {
 	}
 }
 
+func TestSpawnGeneralAgentPlanModeSpecOnlyAdvertisesResearch(t *testing.T) {
+	spec := (SpawnGeneralAgent{AgentMode: session.AgentModePlan}).Spec()
+	if strings.Contains(strings.ToLower(spec.Description), "coding") {
+		t.Fatalf("Plan description advertises coding: %q", spec.Description)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			Enum []string `json:"enum"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(spec.Parameters, &schema); err != nil {
+		t.Fatalf("decode Plan schema: %v", err)
+	}
+	kind := schema.Properties["kind"]
+	if len(kind.Enum) != 1 || kind.Enum[0] != "research" {
+		t.Fatalf("Plan kind enum = %v, want [research]", kind.Enum)
+	}
+}
+
+func TestSpawnGeneralAgentAutoModeSpecAdvertisesCoding(t *testing.T) {
+	spec := (SpawnGeneralAgent{AgentMode: session.AgentModeAuto}).Spec()
+	if !strings.Contains(strings.ToLower(spec.Description), "kind=coding") {
+		t.Fatalf("Auto description does not advertise coding: %q", spec.Description)
+	}
+}
+
 func TestSpawnGeneralAgentPlanModeAllowsResearch(t *testing.T) {
 	tool := SpawnGeneralAgent{AgentMode: session.AgentModePlan}
 

--- a/cometmind/internal/tools/plan_spawn_test.go
+++ b/cometmind/internal/tools/plan_spawn_test.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/session"
+)
+
+func TestSpawnGeneralAgentPlanModeRejectsCoding(t *testing.T) {
+	tool := SpawnGeneralAgent{AgentMode: session.AgentModePlan}
+
+	// Coding children must be rejected before any session work happens; the
+	// tool has nil deps, so reaching the "not configured" path proves the gate.
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"fix bug","kind":"coding"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.OK || !strings.Contains(res.Output, "not allowed in Plan mode") {
+		t.Fatalf("coding result = %+v, want Plan rejection", res)
+	}
+}
+
+func TestSpawnGeneralAgentPlanModeAllowsResearch(t *testing.T) {
+	tool := SpawnGeneralAgent{AgentMode: session.AgentModePlan}
+
+	// Research children pass the mode gate; with nil deps they fail later on
+	// configuration, which proves the gate did not reject them.
+	for _, kind := range []string{"", "research", "general"} {
+		body := `{"task":"explore"}`
+		if kind != "" {
+			body = `{"task":"explore","kind":"` + kind + `"}`
+		}
+		res, err := tool.Execute(context.Background(), json.RawMessage(body))
+		if err != nil {
+			t.Fatalf("Execute(kind=%q) error = %v", kind, err)
+		}
+		if strings.Contains(res.Output, "not allowed in Plan mode") {
+			t.Fatalf("kind=%q was rejected by Plan gate: %+v", kind, res)
+		}
+		if !res.OK && !strings.Contains(res.Output, "not configured") {
+			t.Fatalf("kind=%q result = %+v, want config failure after passing gate", kind, res)
+		}
+	}
+}
+
+func TestSpawnGeneralAgentAutoModeAllowsCoding(t *testing.T) {
+	tool := SpawnGeneralAgent{AgentMode: session.AgentModeAuto}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"fix bug","kind":"coding"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if strings.Contains(res.Output, "not allowed in Plan mode") {
+		t.Fatalf("auto mode should not reject coding: %+v", res)
+	}
+	if !res.OK && !strings.Contains(res.Output, "not configured") {
+		t.Fatalf("coding result = %+v, want config failure after passing gate", res)
+	}
+}

--- a/cometmind/internal/tools/plan_surface_test.go
+++ b/cometmind/internal/tools/plan_surface_test.go
@@ -75,7 +75,7 @@ func TestNewRegistryAutoKeepsFullSurface(t *testing.T) {
 	r := NewRegistry(t.TempDir(), fullPlanOptions(session.AgentModeAuto))
 	for _, name := range []string{
 		"read_file", "edit_file", "write_file", "list_dir", "glob", "grep", "run_command",
-		"spawn_general_agent", "wait_subagents", "delegate_coding_task",
+		"spawn_general_agent", "wait_subagents",
 	} {
 		if !r.Has(name) {
 			t.Errorf("auto registry missing %q", name)

--- a/cometmind/internal/tools/plan_surface_test.go
+++ b/cometmind/internal/tools/plan_surface_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/acp"
+	"github.com/cometline/cometmind/internal/event"
+	"github.com/cometline/cometmind/internal/session"
+	"github.com/cometline/cometmind/internal/skills"
+	"github.com/cometline/cometmind/internal/subagent"
+)
+
+// fullPlanOptions wires every optional capability so surface differences are
+// attributable to AgentMode, not missing dependencies.
+func fullPlanOptions(mode session.AgentMode) RegistryOptions {
+	skillReg := skills.Discover("", skills.Config{Enabled: true})
+	cfg := acp.DefaultHarnessConfig(acp.HarnessOpenCode)
+	cfg.Enabled = true
+	runnerFactory := ChildRunnerFactory(func(child session.Session, workspaceRoot string, maxSteps int, mode SubagentMode) (AgentLoopRunner, error) {
+		return nil, context.DeadlineExceeded
+	})
+	return RegistryOptions{
+		Sessions:        &session.Service{},
+		ACP:             cfg,
+		Skills:          &skillReg,
+		Orchestrator:    subagent.NewOrchestrator(5),
+		RunnerFactory:   runnerFactory,
+		AgentMode:       mode,
+		MemoryEvents:    event.NewHub(),
+		SettingsRuntime: nil,
+	}
+}
+
+func planRegistry(t *testing.T) *Registry {
+	t.Helper()
+	return NewRegistry(t.TempDir(), fullPlanOptions(session.AgentModePlan))
+}
+
+func TestNewRegistryPlanSurfaceIsReadOnlyAllowlist(t *testing.T) {
+	r := planRegistry(t)
+
+	included := []string{
+		"read_file", "list_dir", "glob", "grep",
+		"web_fetch", "web_search",
+		"present_image", "present_image_url",
+		"load_skill", "read_skill_file",
+		"spawn_general_agent", "wait_subagents",
+	}
+	for _, name := range included {
+		if !r.Has(name) {
+			t.Errorf("plan registry missing %q", name)
+		}
+	}
+
+	excluded := []string{
+		"edit_file", "write_file",
+		"run_command",
+		"delegate_coding_task",
+		"write_skill", "write_skill_draft", "promote_skill_draft",
+		"list_settings", "get_settings", "patch_settings",
+		"list_jobs", "create_job", "complete_job", "claim_job",
+		"recall_task_outcome", "list_memories", "create_memory", "update_memory", "delete_memory",
+		"leave_inbox_message",
+		"list_mcp_servers", "reconnect_mcp_server",
+	}
+	for _, name := range excluded {
+		if r.Has(name) {
+			t.Errorf("plan registry should not include %q", name)
+		}
+	}
+}
+
+func TestNewRegistryAutoKeepsFullSurface(t *testing.T) {
+	r := NewRegistry(t.TempDir(), fullPlanOptions(session.AgentModeAuto))
+	for _, name := range []string{
+		"read_file", "edit_file", "write_file", "list_dir", "glob", "grep", "run_command",
+		"spawn_general_agent", "wait_subagents", "delegate_coding_task",
+	} {
+		if !r.Has(name) {
+			t.Errorf("auto registry missing %q", name)
+		}
+	}
+}
+
+func TestNewRegistryEmptyModeDefaultsToAutoSurface(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+	for _, name := range []string{"run_command", "edit_file", "write_file", "read_file", "grep"} {
+		if !r.Has(name) {
+			t.Errorf("default registry missing %q (must preserve existing behavior)", name)
+		}
+	}
+}

--- a/cometmind/internal/tools/readfile.go
+++ b/cometmind/internal/tools/readfile.go
@@ -16,12 +16,14 @@ const (
 	readFileDefaultLimit   = 2000
 	readFileMaxLineRunes   = 2000
 	readFileMaxOutputRunes = 50000
+	readFileMaxInputBytes  = 10 << 20
 )
 
 func (ReadFile) Spec() ToolSpec {
 	return ToolSpec{
 		Name: "read_file",
-		Description: "Read a text file relative to the workspace root. You may also read " +
+		Description: "Read a text file. Relative paths resolve against the workspace root; " +
+			"absolute paths read anywhere the CometMind process may access. You may also read " +
 			"@runtime/tool-output/..., @runtime/tmp/..., and @runtime/wiki/...; other ~/.cometmind files are private. " +
 			"Each line is prefixed with its 1-based line number as \"N: content\" " +
 			"(the \"N: \" prefix is not part of the file). " +
@@ -29,7 +31,7 @@ func (ReadFile) Spec() ToolSpec {
 		Parameters: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"path":{"type":"string","description":"Relative path from workspace root"},
+				"path":{"type":"string","description":"Relative path from workspace root or an absolute host path"},
 				"offset":{"type":"integer","description":"1-based line number to start reading from (default 1)"},
 				"limit":{"type":"integer","description":"Maximum number of lines to return (default 2000)"}
 			},
@@ -54,6 +56,19 @@ func (r ReadFile) Execute(ctx context.Context, input json.RawMessage) (Result, e
 	p, err := r.Workspace.ResolveReadable(path)
 	if err != nil {
 		return Result{OK: false, Output: err.Error()}, nil
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return Result{OK: false, Output: err.Error()}, nil
+	}
+	if !info.Mode().IsRegular() {
+		return Result{OK: false, Output: "path is not a regular file"}, nil
+	}
+	if info.Size() > readFileMaxInputBytes {
+		return Result{OK: false, Output: fmt.Sprintf(
+			"file is too large to read in full (%d bytes > %d byte limit); use a path-based alternative",
+			info.Size(), readFileMaxInputBytes,
+		)}, nil
 	}
 	b, err := os.ReadFile(p)
 	if err != nil {

--- a/cometmind/internal/tools/registry.go
+++ b/cometmind/internal/tools/registry.go
@@ -32,6 +32,11 @@ func NewSubagentRegistry(workspaceRoot string, skillReg *skills.Registry, mode S
 }
 
 func newRegistryWithSurface(workspaceRoot string, surface ToolSurface, opt RegistryOptions) *Registry {
+	// Plan mode overrides the default parent surface with the read-only
+	// allowlist. Auto (and empty) registries keep the caller-provided surface.
+	if SurfaceForPlan(opt.AgentMode) {
+		surface = PlanSurface()
+	}
 	ws := Workspace{Root: workspaceRoot}
 	r := &Registry{workspace: ws, byName: make(map[string]Tool)}
 	add := func(t Tool) {
@@ -97,6 +102,7 @@ func newRegistryWithSurface(workspaceRoot string, surface ToolSurface, opt Regis
 			Orchestrator:   opt.Orchestrator,
 			RunnerFactory:  opt.RunnerFactory,
 			SubagentConfig: opt.SubagentConfig,
+			AgentMode:      opt.AgentMode,
 		})
 		add(WaitSubagents{
 			Sessions:     opt.Sessions,

--- a/cometmind/internal/tools/searchutil.go
+++ b/cometmind/internal/tools/searchutil.go
@@ -16,7 +16,19 @@ const (
 	globMaxFiles        = 100
 	grepMaxOutputChars  = 12000
 	grepTimeout         = 60 * time.Second
+	searchMaxVisited    = 250_000
+	searchWalkTimeout   = 90 * time.Second
 )
+
+// errSearchBudget stops a recursive search when the visited-entry budget is
+// exhausted so host-wide searches cannot traverse unbounded directory trees.
+var errSearchBudget = fmt.Errorf("search exceeded traversal budget")
+
+// withSearchDeadline bounds a host-wide search walk. External roots such as
+// /usr or /Library are intentionally readable but must not run forever.
+func withSearchDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, searchWalkTimeout)
+}
 
 var defaultSkippedDirs = map[string]bool{
 	"node_modules": true,
@@ -73,7 +85,8 @@ func shouldSkipFile(workspaceRel string, ignorer *gitignore.GitIgnore) bool {
 
 // walkSearchableFiles visits regular files under searchRoot, invoking fn with
 // workspace-relative paths (forward slashes). Hidden entries, common build
-// directories, and root .gitignore rules are skipped.
+// directories, and root .gitignore rules are skipped. The walk is bounded by
+// context cancellation and a visited-entry budget.
 func walkSearchableFiles(ctx context.Context, workspaceRoot, searchRoot string, fn func(workspaceRel, absPath string) error) error {
 	workspaceRoot = filepath.Clean(workspaceRoot)
 	searchRoot = filepath.Clean(searchRoot)
@@ -87,10 +100,15 @@ func walkSearchableFiles(ctx context.Context, workspaceRoot, searchRoot string, 
 	}
 
 	ignorer := loadGitignore(workspaceRoot)
+	visited := 0
 
 	return filepath.WalkDir(searchRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+		visited++
+		if visited > searchMaxVisited {
+			return errSearchBudget
 		}
 		if walkErr != nil {
 			return nil

--- a/cometmind/internal/tools/spawngeneral.go
+++ b/cometmind/internal/tools/spawngeneral.go
@@ -24,6 +24,24 @@ type SpawnGeneralAgent struct {
 }
 
 func (s SpawnGeneralAgent) Spec() ToolSpec {
+	if SurfaceForPlan(s.AgentMode) {
+		return ToolSpec{
+			Name: "spawn_general_agent",
+			Description: "Spawn a read-only in-process CometMind research subagent that runs in parallel. " +
+				"Returns immediately with a child_session_id; use wait_subagents to collect results.",
+			Parameters: json.RawMessage(`{
+				"type":"object",
+				"properties":{
+					"task":{"type":"string","description":"Task for the research subagent"},
+					"context":{"type":"string","description":"Optional extra constraints"},
+					"kind":{"type":"string","enum":["research"],"description":"research (read-only, default)"},
+					"model_id":{"type":"string","description":"Optional model override"},
+					"provider_id":{"type":"string","description":"Optional provider override"}
+				},
+				"required":["task"]
+			}`),
+		}
+	}
 	return ToolSpec{
 		Name: "spawn_general_agent",
 		Description: "Spawn an in-process CometMind subagent that runs in parallel. " +

--- a/cometmind/internal/tools/spawngeneral.go
+++ b/cometmind/internal/tools/spawngeneral.go
@@ -18,6 +18,9 @@ type SpawnGeneralAgent struct {
 	Orchestrator   *subagent.Orchestrator
 	RunnerFactory  ChildRunnerFactory
 	SubagentConfig SubagentToolConfig
+	// AgentMode is the parent agent mode. Plan mode restricts children to
+	// read-only research so spawning cannot bypass Plan restrictions.
+	AgentMode session.AgentMode
 }
 
 func (s SpawnGeneralAgent) Spec() ToolSpec {
@@ -61,6 +64,9 @@ func (s SpawnGeneralAgent) Execute(ctx context.Context, input json.RawMessage) (
 	case "", "research", "general":
 		mode = SubagentModeResearch
 	case "coding", "code":
+		if SurfaceForPlan(s.AgentMode) {
+			return Result{OK: false, Output: "kind=coding is not allowed in Plan mode (research subagents only)"}, nil
+		}
 		mode = SubagentModeCoding
 	default:
 		return Result{OK: false, Output: "kind must be research or coding"}, nil

--- a/cometmind/internal/tools/surface.go
+++ b/cometmind/internal/tools/surface.go
@@ -1,5 +1,7 @@
 package tools
 
+import "github.com/cometline/cometmind/internal/session"
+
 // ToolSurface is the capability policy for a registry: which tool families
 // are exposed. Parent, research, and coding registries share this module so
 // mode is not duplicated as stringly agentName / registry lists.
@@ -35,6 +37,22 @@ func ResearchSurface() ToolSurface {
 // CodingSurface is in-process coding subagent tools (no spawn/delegate).
 func CodingSurface() ToolSurface {
 	return ToolSurface{Read: true, Edit: true, Run: true, Skills: true}
+}
+
+// PlanSurface is the read-only parent surface for Plan mode: host/workspace
+// reads, network reads, skill reads, and research-only subagent spawning.
+// It must never include command, file-write, or mutation tool groups.
+func PlanSurface() ToolSurface {
+	return ToolSurface{
+		Read:   true,
+		Skills: true,
+		Spawn:  true,
+	}
+}
+
+// SurfaceForPlan reports whether the mode is Plan (empty/auto is not).
+func SurfaceForPlan(mode session.AgentMode) bool {
+	return mode == session.AgentModePlan
 }
 
 // SurfaceForMode maps SubagentMode to a ToolSurface.

--- a/cometmind/openapi.yaml
+++ b/cometmind/openapi.yaml
@@ -733,6 +733,7 @@ paths:
                   cache_read: 0
                   cache_write: 0
                 pinned: false
+                agent_mode: auto
                 created_at: 1746880000000
                 updated_at: 1746880000000
         '400':
@@ -794,6 +795,7 @@ paths:
                       cache_read: 0
                       cache_write: 0
                     pinned: false
+                    agent_mode: auto
                     created_at: 1746880000000
                     updated_at: 1746880200000
         '400':
@@ -2577,6 +2579,15 @@ components:
           description: Optional provider override; defaults to current config.
       description: Provide either `workspace_id` or `workspace_path`.
 
+    AgentMode:
+      type: string
+      enum: [auto, plan]
+      description: |
+        Agent capability surface for a session or turn. `auto` preserves the full
+        agent toolset; `plan` is a read-only planning mode that removes command,
+        file-write, and mutation tools while keeping host-wide reads, network
+        access, and read-only research delegation.
+
     UpdateSessionRequest:
       type: object
       additionalProperties: false
@@ -2591,6 +2602,9 @@ components:
         title:
           type: string
           description: Display name shown in the sidebar session list.
+        agent_mode:
+          $ref: '#/components/schemas/AgentMode'
+          description: Persist the preferred mode for this session. New sessions always start in `auto`.
 
     ChangeSessionWorkspaceRequest:
       type: object
@@ -2927,6 +2941,11 @@ components:
           description: |
             Optional per-turn reasoning effort override using a value advertised
             by the selected model. Empty means the provider default.
+        agent_mode:
+          $ref: '#/components/schemas/AgentMode'
+          description: |
+            Optional per-turn agent mode override. When omitted, the session's
+            persisted mode is used. New sessions always start in `auto`.
 
     WebContext:
       type: object
@@ -3009,6 +3028,7 @@ components:
         - status
         - origin
         - token_usage
+        - agent_mode
         - pinned
         - created_at
         - updated_at
@@ -3034,6 +3054,9 @@ components:
           description: Whether this session was created by a user action or an autonomous job run.
         token_usage:
           $ref: '#/components/schemas/TokenUsage'
+        agent_mode:
+          $ref: '#/components/schemas/AgentMode'
+          description: Active agent mode for the session. `auto` unless the user switched this session to `plan`.
         pinned:
           type: boolean
           description: Whether the session is pinned to the top of its workspace group.

--- a/cometmind/server/agent_mode_test.go
+++ b/cometmind/server/agent_mode_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/event"
+	"github.com/cometline/cometmind/internal/session"
+	"github.com/gin-gonic/gin"
+)
+
+// capturingRunnerFactory records the agent mode each runner was built with.
+func capturingRunnerFactory(modes *[]session.AgentMode) RunnerFactory {
+	var mu sync.Mutex
+	return func(_ session.Session, _ string, mode session.AgentMode) (Runner, error) {
+		mu.Lock()
+		*modes = append(*modes, mode)
+		mu.Unlock()
+		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
+			ch <- event.Done()
+			return nil
+		}), nil
+	}
+}
+
+func TestCreateSessionDefaultsToAuto(t *testing.T) {
+	t.Parallel()
+
+	engine, _, cleanup := newTestEngine(t, capturingRunnerFactory(new([]session.AgentMode)))
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`{"workspace_path":`+mustJSON(t.TempDir())+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var got sessionResource
+	decodeJSON(t, rec.Body.Bytes(), &got)
+	if got.AgentMode != string(session.AgentModeAuto) {
+		t.Fatalf("agent_mode = %q, want %q", got.AgentMode, session.AgentModeAuto)
+	}
+}
+
+func TestPatchSessionAgentModeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	engine, _, cleanup := newTestEngine(t, capturingRunnerFactory(new([]session.AgentMode)))
+	defer cleanup()
+
+	var created sessionResource
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`{"workspace_path":`+mustJSON(t.TempDir())+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	decodeJSON(t, rec.Body.Bytes(), &created)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+created.ID, bytes.NewBufferString(`{"agent_mode":"plan"}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var patched sessionResource
+	decodeJSON(t, rec.Body.Bytes(), &patched)
+	if patched.AgentMode != string(session.AgentModePlan) {
+		t.Fatalf("patched agent_mode = %q, want %q", patched.AgentMode, session.AgentModePlan)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+created.ID, nil)
+	engine.ServeHTTP(rec, req)
+	var fetched sessionResource
+	decodeJSON(t, rec.Body.Bytes(), &fetched)
+	if fetched.AgentMode != string(session.AgentModePlan) {
+		t.Fatalf("fetched agent_mode = %q, want %q", fetched.AgentMode, session.AgentModePlan)
+	}
+}
+
+func TestPatchSessionRejectsInvalidAgentMode(t *testing.T) {
+	t.Parallel()
+
+	engine, _, cleanup := newTestEngine(t, capturingRunnerFactory(new([]session.AgentMode)))
+	defer cleanup()
+
+	var created sessionResource
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`{"workspace_path":`+mustJSON(t.TempDir())+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	decodeJSON(t, rec.Body.Bytes(), &created)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+created.ID, bytes.NewBufferString(`{"agent_mode":"sandbox"}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("patch status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPostMessageForwardsAgentModeToRunner(t *testing.T) {
+	t.Parallel()
+
+	var modes []session.AgentMode
+	engine, svc, cleanup := newTestEngine(t, capturingRunnerFactory(&modes))
+	defer cleanup()
+
+	wsPath := t.TempDir()
+	ws, err := svc.EnsureWorkspace(context.Background(), wsPath)
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	sess, err := svc.NewSession(context.Background(), ws.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	post := func(body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/messages", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		engine.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Explicit per-turn plan mode reaches the runner.
+	rec := post(`{"text":"plan turn","agent_mode":"plan"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(modes) != 1 || modes[0] != session.AgentModePlan {
+		t.Fatalf("runner modes = %v, want [plan]", modes)
+	}
+
+	// Persisted session mode applies when the request omits agent_mode.
+	if _, err := svc.UpdateSessionAgentMode(context.Background(), sess.ID, session.AgentModePlan); err != nil {
+		t.Fatalf("UpdateSessionAgentMode() error = %v", err)
+	}
+	rec = post(`{"text":"second turn"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(modes) != 2 || modes[1] != session.AgentModePlan {
+		t.Fatalf("runner modes = %v, want [plan plan]", modes)
+	}
+}
+
+func TestPostMessageRejectsInvalidAgentMode(t *testing.T) {
+	t.Parallel()
+
+	engine, svc, cleanup := newTestEngine(t, capturingRunnerFactory(new([]session.AgentMode)))
+	defer cleanup()
+
+	ws, err := svc.EnsureWorkspace(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	sess, err := svc.NewSession(context.Background(), ws.ID, "m", "p")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/messages", bytes.NewBufferString(`{"text":"x","agent_mode":"sandbox"}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid agent mode") {
+		t.Fatalf("body = %s, want invalid agent mode error", rec.Body.String())
+	}
+}
+
+var _ = gin.Mode // keep gin import for future assertions

--- a/cometmind/server/inbox_handlers_test.go
+++ b/cometmind/server/inbox_handlers_test.go
@@ -31,7 +31,7 @@ func TestInboxHandlersReplyAndDismiss(t *testing.T) {
 		Sessions:  sessions,
 		Inbox:     inboxSvc,
 		Events:    hub,
-		NewRunner: func(session.Session, string) (Runner, error) { return nil, nil },
+		NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) { return nil, nil },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cometmind/server/job_handlers_test.go
+++ b/cometmind/server/job_handlers_test.go
@@ -28,7 +28,7 @@ func TestJobHandlersCreateListClaim(t *testing.T) {
 		Config:    config.Defaults(),
 		Sessions:  sessions,
 		Jobs:      jobSvc,
-		NewRunner: func(session.Session, string) (Runner, error) { return nil, nil },
+		NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) { return nil, nil },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestJobHandlersArchiveCompletedJob(t *testing.T) {
 		Config:    config.Defaults(),
 		Sessions:  sessions,
 		Jobs:      jobSvc,
-		NewRunner: func(session.Session, string) (Runner, error) { return nil, nil },
+		NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) { return nil, nil },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestJobHandlersRetryBlockedJob(t *testing.T) {
 		Config:    config.Defaults(),
 		Sessions:  sessions,
 		Jobs:      jobSvc,
-		NewRunner: func(session.Session, string) (Runner, error) { return nil, nil },
+		NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) { return nil, nil },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cometmind/server/memory_handlers_test.go
+++ b/cometmind/server/memory_handlers_test.go
@@ -47,7 +47,7 @@ func TestMemorySettingsGetPut(t *testing.T) {
 	}
 
 	hub := event.NewHub()
-	engine, err := New(Deps{Config: cfg, Sessions: sessions, Memory: mem, Events: hub, NewRunner: func(session.Session, string) (Runner, error) {
+	engine, err := New(Deps{Config: cfg, Sessions: sessions, Memory: mem, Events: hub, NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) {
 		return &noopRunner{}, nil
 	}, Runs: NewRunManager()})
 	if err != nil {

--- a/cometmind/server/messages.go
+++ b/cometmind/server/messages.go
@@ -47,6 +47,7 @@ type postMessageRequest struct {
 	WebContext      *webPageContextInput `json:"web_context,omitempty"`
 	WebContexts     []webContextInput    `json:"web_contexts,omitempty"`
 	ReasoningEffort string               `json:"reasoning_effort,omitempty"`
+	AgentMode       string               `json:"agent_mode,omitempty"`
 }
 
 type webPageContextInput struct {
@@ -84,6 +85,21 @@ func (a *App) handlePostMessage(c *gin.Context) {
 		return
 	}
 
+	// The per-message mode is authoritative when supplied; otherwise the
+	// session's persisted preference applies. New sessions default to auto.
+	mode, err := session.ParseAgentMode(req.AgentMode)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.AgentMode) == "" {
+		mode, err = session.ParseAgentMode(sess.AgentMode)
+		if err != nil {
+			writeError(c, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	}
+
 	blocks, contexts, err := contentBlocksFromRequest(req, wsPath)
 	if err != nil {
 		writeError(c, http.StatusBadRequest, "bad_request", err.Error())
@@ -93,10 +109,10 @@ func (a *App) handlePostMessage(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "bad_request", "text or image is required")
 		return
 	}
-	logging.L().Info("message.received", "session", sess.ID, "provider", sess.ProviderID, "model", sess.ModelID, "text_bytes", len(req.Text), "images", len(req.Images), "files", len(req.FilePaths))
+	logging.L().Info("message.received", "session", sess.ID, "provider", sess.ProviderID, "model", sess.ModelID, "text_bytes", len(req.Text), "images", len(req.Images), "files", len(req.FilePaths), "agent_mode", string(mode))
 	started := time.Now()
 
-	runner, err := a.newRunner(sess, wsPath)
+	runner, err := a.newRunner(sess, wsPath, mode)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "runner_init_failed", err.Error())
 		return

--- a/cometmind/server/scheduled_job_handlers_test.go
+++ b/cometmind/server/scheduled_job_handlers_test.go
@@ -31,7 +31,7 @@ func newScheduledJobTestServer(t *testing.T) *gin.Engine {
 		Sessions:  sessions,
 		Jobs:      jobs.NewService(sqlDB, nil, nil),
 		Scheduler: scheduler.NewService(sqlDB),
-		NewRunner: func(session.Session, string) (Runner, error) { return nil, nil },
+		NewRunner: func(session.Session, string, session.AgentMode) (Runner, error) { return nil, nil },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cometmind/server/server.go
+++ b/cometmind/server/server.go
@@ -30,7 +30,7 @@ type Runner interface {
 	Run(context.Context, session.AgentTurn, chan<- event.Event) error
 }
 
-type RunnerFactory func(sess session.Session, workspacePath string) (Runner, error)
+type RunnerFactory func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error)
 
 type RetentionResult = retention.Result
 
@@ -310,6 +310,7 @@ type sessionResource struct {
 	ProviderID       string             `json:"provider_id"`
 	Status           string             `json:"status"`
 	TokenUsage       tokenUsageResource `json:"token_usage"`
+	AgentMode        string             `json:"agent_mode"`
 	ParentSessionID  string             `json:"parent_session_id,omitempty"`
 	Purpose          string             `json:"purpose,omitempty"`
 	DelegationStatus string             `json:"delegation_status,omitempty"`
@@ -608,6 +609,7 @@ func sessionResourceFromAPISession(w apigen.Session) sessionResource {
 			CacheRead:    w.TokenUsage.CacheRead,
 			CacheWrite:   w.TokenUsage.CacheWrite,
 		},
+		AgentMode: string(w.AgentMode),
 		Pinned:    w.Pinned,
 		CreatedAt: w.CreatedAt,
 		UpdatedAt: w.UpdatedAt,

--- a/cometmind/server/server_test.go
+++ b/cometmind/server/server_test.go
@@ -37,7 +37,7 @@ func (f fakeRunner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- e
 func TestCreateSessionAutoRegistersWorkspacePath(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -77,7 +77,7 @@ func TestCreateSessionAutoRegistersWorkspacePath(t *testing.T) {
 func TestMissingSessionEndpointsReturnSessionNotFound(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -134,7 +134,7 @@ func TestMissingSessionEndpointsReturnSessionNotFound(t *testing.T) {
 func TestCreateWorkspaceRegistersPath(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -174,7 +174,7 @@ func TestCreateWorkspaceRegistersPath(t *testing.T) {
 func TestWorkspaceGitStatusAndDiff(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -279,7 +279,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 func TestListWorkspaceFiles(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -328,7 +328,7 @@ func TestListWorkspaceFiles(t *testing.T) {
 func TestListWorkspaceFileChildren(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -371,7 +371,7 @@ func TestListWorkspaceFileChildren(t *testing.T) {
 func TestReadWorkspaceFileContent(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -400,7 +400,7 @@ func TestReadWorkspaceFileContent(t *testing.T) {
 func TestWriteWorkspaceFileContent(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -447,7 +447,7 @@ func TestWriteWorkspaceFileContent(t *testing.T) {
 func TestWriteWorkspaceFileContentRejectsInvalidRequests(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -499,7 +499,7 @@ func TestWriteWorkspaceFileContentRejectsInvalidRequests(t *testing.T) {
 func TestListWorkspaceFilesFiltersByQuery(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -528,7 +528,7 @@ func TestListWorkspaceFilesFiltersByQuery(t *testing.T) {
 func TestListWorkspaceFilesMissingWorkspace(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -570,7 +570,7 @@ func assertSlice(t *testing.T, got, want []string) {
 func TestListSessionsRequiresWorkspaceScope(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -613,7 +613,7 @@ func TestListSessionsRequiresWorkspaceScope(t *testing.T) {
 func TestDeleteSessionRemovesSession(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -660,7 +660,7 @@ func TestDeleteSessionRemovesSession(t *testing.T) {
 func TestClearSessionResetsTranscript(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -710,7 +710,7 @@ func TestClearSessionResetsTranscript(t *testing.T) {
 func TestClearSessionRemovesChildSessions(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -768,7 +768,7 @@ func TestPatchSessionUpdatesModel(t *testing.T) {
 	t.Parallel()
 
 	var gotTurn session.AgentTurn
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			gotTurn = turn
 			ch <- event.Done()
@@ -820,7 +820,7 @@ func TestPatchSessionUpdatesModel(t *testing.T) {
 func TestPatchSessionUpdatesPinned(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -904,7 +904,7 @@ func TestPatchSessionUpdatesPinned(t *testing.T) {
 func TestPatchSessionUpdatesTitle(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -944,7 +944,7 @@ func TestPatchSessionUpdatesTitle(t *testing.T) {
 func TestGetMessagesReturnsTranscriptItems(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1020,7 +1020,7 @@ func TestGetMessagesReturnsTranscriptItems(t *testing.T) {
 func TestPostMessageStreamsSSEAndPersistsUserTurn(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.ReasoningStart()
 			ch <- event.TextDelta("hello")
@@ -1093,7 +1093,7 @@ func TestPostMessageStreamsSSEAndPersistsUserTurn(t *testing.T) {
 func TestPostMessageInlinesFilePaths(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1160,7 +1160,7 @@ func TestPostMessageInlinesFilePaths(t *testing.T) {
 func TestPostMessageInlinesWebContext(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1214,7 +1214,7 @@ func TestPostMessageInlinesWebContext(t *testing.T) {
 func TestPostMessageInlinesMultipleWebContexts(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1256,7 +1256,7 @@ func TestPostMessageInlinesMultipleWebContexts(t *testing.T) {
 func TestPostMessagePathOnlyFileWebContext(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1321,7 +1321,7 @@ func TestPostMessagePathOnlyFileWebContext(t *testing.T) {
 func TestPostMessageInlinesExplicitTerminalContext(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1363,7 +1363,7 @@ func TestPostMessageInlinesExplicitTerminalContext(t *testing.T) {
 func TestPostMessageInlinesAssistantResponseContext(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1428,7 +1428,7 @@ func TestFormatWebContextRejectsMalformedAssistantResponseSource(t *testing.T) {
 func TestLocalCORSAllowsCometlineRenderer(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1465,7 +1465,7 @@ func TestLocalCORSAllowsCometlineRenderer(t *testing.T) {
 func TestLocalCORSAllowsPackagedCometlineOrigin(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1502,7 +1502,7 @@ func TestLocalCORSAllowsPackagedCometlineOrigin(t *testing.T) {
 func TestLocalCORSAllowsMemorySettingsPut(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1529,7 +1529,7 @@ func TestAbortSessionCancelsRunningStream(t *testing.T) {
 
 	started := make(chan struct{})
 	cancelled := make(chan struct{})
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			close(started)
 			ch <- event.TextDelta("working")
@@ -1605,7 +1605,7 @@ func TestAbortSessionCancelsRunningStream(t *testing.T) {
 func TestPostMessageEmitsDoneAfterRunnerErrorEvent(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Errorf("provider disconnected", "llm")
 			return fmt.Errorf("provider disconnected")
@@ -1659,7 +1659,7 @@ func TestPostMessageKeepsAgentRunningAfterClientDisconnect(t *testing.T) {
 	release := make(chan struct{})
 	finished := make(chan struct{})
 	cancelled := make(chan struct{})
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			close(started)
 			select {
@@ -1738,7 +1738,7 @@ func TestSkillsDeleteAndExport(t *testing.T) {
 		t.Fatalf("WriteSkill() error = %v", err)
 	}
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1787,7 +1787,7 @@ func TestSkillDraftHandlersPromoteAndReject(t *testing.T) {
 		t.Fatalf("WriteDraft() error = %v", err)
 	}
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1879,7 +1879,7 @@ func TestSkillDraftHandlersPromoteAndReject(t *testing.T) {
 func TestListWorkspaces(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1926,7 +1926,7 @@ func TestListWorkspaces(t *testing.T) {
 func TestDeleteWorkspace(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -1965,7 +1965,7 @@ func TestDeleteWorkspace(t *testing.T) {
 func TestDeleteWorkspaceWithSessions(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2001,7 +2001,7 @@ func TestDeleteWorkspaceWithSessions(t *testing.T) {
 func TestListWorkspacesOmitsMissingPath(t *testing.T) {
 	t.Parallel()
 
-	_, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	_, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2058,7 +2058,7 @@ func TestListWorkspacesOmitsMissingPath(t *testing.T) {
 func TestPruneWorkspacesEndpoint(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2096,7 +2096,7 @@ func TestPruneWorkspacesEndpoint(t *testing.T) {
 func TestChangeSessionWorkspace(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2161,7 +2161,7 @@ func TestChangeSessionWorkspace(t *testing.T) {
 func TestChangeSessionWorkspaceRejectsMissingDirectory(t *testing.T) {
 	t.Parallel()
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2190,7 +2190,7 @@ func TestChangeSessionWorkspaceRejectsMissingDirectory(t *testing.T) {
 func TestForkSessionCopiesTranscript(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2267,7 +2267,7 @@ func TestForkSessionCopiesTranscript(t *testing.T) {
 func TestListAllSessionsAcrossWorkspaces(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2315,7 +2315,7 @@ func TestListAllSessionsAcrossWorkspaces(t *testing.T) {
 func TestListAllSessionsIncludesGatewayMetadata(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2365,7 +2365,7 @@ func TestListAllSessionsIncludesGatewayMetadata(t *testing.T) {
 func TestGetSessionIncludesGatewayMetadata(t *testing.T) {
 	t.Parallel()
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -2424,7 +2424,7 @@ func TestListModels(t *testing.T) {
 	}
 	t.Setenv("HOME", dir)
 
-	engine, _, cleanup := newTestEngine(t, func(session.Session, string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(session.Session, string, session.AgentMode) (Runner, error) {
 		return fakeRunner(func(context.Context, session.AgentTurn, chan<- event.Event) error {
 			return nil
 		}), nil
@@ -2446,7 +2446,7 @@ func TestListModels(t *testing.T) {
 }
 
 func TestLookupModelCatalogEndpoint(t *testing.T) {
-	engine, _, cleanup := newTestEngine(t, func(session.Session, string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(session.Session, string, session.AgentMode) (Runner, error) {
 		return fakeRunner(func(context.Context, session.AgentTurn, chan<- event.Event) error {
 			return nil
 		}), nil

--- a/cometmind/server/sessions.go
+++ b/cometmind/server/sessions.go
@@ -22,6 +22,7 @@ type patchSessionRequest struct {
 	ProviderID string  `json:"provider_id"`
 	Pinned     *bool   `json:"pinned"`
 	Title      *string `json:"title"`
+	AgentMode  *string `json:"agent_mode"`
 }
 
 type changeSessionWorkspaceRequest struct {
@@ -179,13 +180,24 @@ func (a *App) handlePatchSession(c *gin.Context) {
 	hasModel := strings.TrimSpace(req.ModelID) != "" || strings.TrimSpace(req.ProviderID) != ""
 	hasPinned := req.Pinned != nil
 	hasTitle := req.Title != nil
-	if !hasModel && !hasPinned && !hasTitle {
-		writeError(c, http.StatusBadRequest, "bad_request", "at least one of model_id/provider_id, pinned, or title is required")
+	hasAgentMode := req.AgentMode != nil
+	if !hasModel && !hasPinned && !hasTitle && !hasAgentMode {
+		writeError(c, http.StatusBadRequest, "bad_request", "at least one of model_id/provider_id, pinned, title, or agent_mode is required")
 		return
 	}
 	if hasModel && (strings.TrimSpace(req.ModelID) == "" || strings.TrimSpace(req.ProviderID) == "") {
 		writeError(c, http.StatusBadRequest, "bad_request", "model_id and provider_id must both be provided")
 		return
+	}
+
+	var agentMode session.AgentMode
+	if hasAgentMode {
+		mode, err := session.ParseAgentMode(*req.AgentMode)
+		if err != nil {
+			writeError(c, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		agentMode = mode
 	}
 
 	sessID := c.Param("id")
@@ -223,6 +235,18 @@ func (a *App) handlePatchSession(c *gin.Context) {
 
 	if hasTitle {
 		sess, err = a.sessions.UpdateSessionTitle(c.Request.Context(), sessID, *req.Title)
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(c, http.StatusNotFound, "session_not_found", "session was not found")
+			return
+		}
+		if err != nil {
+			writeError(c, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	}
+
+	if hasAgentMode {
+		sess, err = a.sessions.UpdateSessionAgentMode(c.Request.Context(), sessID, agentMode)
 		if errors.Is(err, session.ErrSessionNotFound) {
 			writeError(c, http.StatusNotFound, "session_not_found", "session was not found")
 			return

--- a/cometmind/server/wiki_files_test.go
+++ b/cometmind/server/wiki_files_test.go
@@ -26,7 +26,7 @@ func TestListWikiFiles(t *testing.T) {
 	mustWrite(t, filepath.Join(wikiDir, "entities", "foo.md"), "# foo")
 	mustWrite(t, filepath.Join(wikiDir, "notes.txt"), "note")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -62,7 +62,7 @@ func TestListWikiFileChildren(t *testing.T) {
 	mustWrite(t, filepath.Join(wikiDir, "entities", "foo.md"), "# foo")
 	mustWrite(t, filepath.Join(wikiDir, "entities", "nested", "bar.md"), "# bar")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -96,7 +96,7 @@ func TestReadWikiFileContent(t *testing.T) {
 	wikiDir := filepath.Join(dataDir, "wiki")
 	mustWrite(t, filepath.Join(wikiDir, "index.md"), "# wiki")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -127,7 +127,7 @@ func TestWriteWikiFileContent(t *testing.T) {
 	}
 	mustWrite(t, filepath.Join(wikiDir, "entities", "foo.md"), "old")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -162,7 +162,7 @@ func TestWriteWikiFileContentRejectsRaw(t *testing.T) {
 	}
 	mustWrite(t, filepath.Join(wikiDir, "raw", "note.md"), "immutable")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -185,7 +185,7 @@ func TestWriteWikiFileContentRejectsWikiSchema(t *testing.T) {
 	t.Setenv("COMETMIND_DATA_DIR", dataDir)
 	mustWrite(t, filepath.Join(dataDir, "wiki", "WIKI.md"), "schema")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -208,7 +208,7 @@ func TestPostMessageInlinesWikiFilePaths(t *testing.T) {
 	t.Setenv("COMETMIND_DATA_DIR", dataDir)
 	mustWrite(t, filepath.Join(dataDir, "wiki", "index.md"), "# wiki index")
 
-	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil
@@ -262,7 +262,7 @@ func TestListWikiFileBacklinks(t *testing.T) {
 	mustWrite(t, filepath.Join(wikiDir, "entities", "a.md"), "See [[b]]")
 	mustWrite(t, filepath.Join(wikiDir, "concepts", "b.md"), "target")
 
-	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string) (Runner, error) {
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
 			ch <- event.Done()
 			return nil


### PR DESCRIPTION
## Background

Users need a deliberate read-only planning mode that can research a request without editing files, running commands, mutating state, or delegating coding work. The mode is persisted per session, can be overridden per turn, and is exposed in the composer while preserving the existing auto mode.

[d2c8d3c](https://github.com/Cometline/cometline/commit/d2c8d3c6a0706a963ef8ed4e57cadfb582f04127): Persist `auto` and `plan` agent modes in the session database, API contract, and session service, including migrations and inheritance behavior.

[05d6cd0](https://github.com/Cometline/cometline/commit/05d6cd0661143625ff66e3788806ce42bbf17c31): Enforce a read-only Plan tool surface and add bounded host-wide read and search behavior.

[616e82b](https://github.com/Cometline/cometline/commit/616e82b6b94b34898ad28648294e77719126c6ea): Propagate the active agent mode through composer submissions, queued turns, jobs, conversation state, and API requests.

[1c36fb3](https://github.com/Cometline/cometline/commit/1c36fb321e2655ebeafd402694811da7eadb1980): Add Plan mode composer controls, Tab switching, read-only styling, accessibility announcements, and queued-message mode labels.

[5d5e2bf](https://github.com/Cometline/cometline/commit/5d5e2bf6f7c481f993bda0a695e92a29e259290d): Stabilize mode switching so pending session updates do not race with submissions or announcements.

[43aa13c](https://github.com/Cometline/cometline/commit/43aa13c8931eb5bb5d1398de282cb4d0b7eeefac): Advertise research-only subagents in Plan mode and prevent coding subagent requests from bypassing the restriction.

[5f26229](https://github.com/Cometline/cometline/commit/5f262296c03ff552d81973f20ce6a623e801ca30): Add mode-specific system prompts and wire the selected mode into parent runners while keeping subagent prompts mode-neutral.
