### PR TITLE
[main] feat: add right sidebar icon and improve toggle logic

### DIFF
--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -3,7 +3,12 @@
 	import { slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { PanelLeft } from '@lucide/svelte';
+	import {
+		PanelLeftClose,
+		PanelLeftOpen,
+		PanelRightClose,
+		PanelRightOpen
+	} from '@lucide/svelte';
 	import Sidebar from './Sidebar.svelte';
 	import RuntimeOverlay from './RuntimeOverlay.svelte';
 	import SettingsModal from './SettingsModal.svelte';
@@ -709,16 +714,6 @@
 					aria-label="Window title bar"
 					transition:slide={titlebarSlideParams()}
 				>
-					<Tooltip label="Show sidebar" action="toggleSidebar">
-						<button
-							type="button"
-							class="shell-titlebar-btn"
-							aria-label="Show sidebar"
-							onclick={() => shellStore.openSidebar()}
-						>
-							<PanelLeft size={16} stroke-width={1.8} />
-						</button>
-					</Tooltip>
 					{#if titlebarSessionTitle}
 						<button
 							type="button"
@@ -731,6 +726,49 @@
 						</button>
 					{/if}
 				</header>
+			{/if}
+			<!-- Fixed corner chrome: independent of the sliding shell titlebar. -->
+			{#if !shellStore.fullscreen}
+				<div class="main-corner-actions main-corner-actions-start">
+					<Tooltip
+						label={shellStore.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+						action="toggleSidebar"
+					>
+						<button
+							type="button"
+							class="shell-titlebar-btn"
+							class:active={shellStore.sidebarOpen}
+							aria-label={shellStore.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+							aria-pressed={shellStore.sidebarOpen}
+							onclick={() => shellStore.toggleSidebar()}
+						>
+							{#if shellStore.sidebarOpen}
+								<PanelLeftClose size={16} stroke-width={1.8} />
+							{:else}
+								<PanelLeftOpen size={16} stroke-width={1.8} />
+							{/if}
+						</button>
+					</Tooltip>
+				</div>
+				<div class="main-corner-actions main-corner-actions-end">
+					<Tooltip label="Toggle workspace panel" action="toggleWorkspacePanel">
+						<button
+							type="button"
+							class="shell-titlebar-btn"
+							class:active={shellStore.workspacePanelOpen}
+							aria-label="Toggle workspace panel"
+							aria-pressed={shellStore.workspacePanelOpen}
+							disabled={!activeSessionId}
+							onclick={() => shellStore.toggleWorkspacePanel()}
+						>
+							{#if shellStore.workspacePanelOpen}
+								<PanelRightClose size={16} stroke-width={1.8} />
+							{:else}
+								<PanelRightOpen size={16} stroke-width={1.8} />
+							{/if}
+						</button>
+					</Tooltip>
+				</div>
 			{/if}
 			{@render children()}
 			<RuntimeOverlay />
@@ -909,13 +947,51 @@
 		-webkit-app-region: no-drag;
 	}
 
-	.shell-titlebar-btn:hover {
+	.shell-titlebar-btn:hover:not(:disabled) {
 		background: rgba(0, 0, 0, 0.04);
 		color: var(--text-main);
 	}
 
-	.shell-titlebar-btn:active {
+	.shell-titlebar-btn:active:not(:disabled) {
 		background: rgba(0, 0, 0, 0.07);
+	}
+
+	.shell-titlebar-btn.active {
+		color: var(--text-main);
+		background: rgba(0, 0, 0, 0.05);
+	}
+
+	.shell-titlebar-btn:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	/*
+	 * Sidebar toggles stay fixed in the main pane corners so they do not
+	 * remount / slide with the shell titlebar transition.
+	 * Vertically centered against --panel-header-height (44px) with a 26px btn.
+	 */
+	.main-corner-actions {
+		position: absolute;
+		top: calc((var(--panel-header-height) - 26px) / 2);
+		z-index: 41;
+		display: flex;
+		align-items: center;
+		-webkit-app-region: no-drag;
+		pointer-events: none;
+	}
+
+	.main-corner-actions-start {
+		left: 12px;
+	}
+
+	.main-corner-actions-end {
+		right: 10px;
+	}
+
+	.main-corner-actions :global(.tooltip-wrap),
+	.main-corner-actions .shell-titlebar-btn {
+		pointer-events: auto;
 	}
 
 	.content-row {

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -25,7 +25,7 @@
 	import { startJobInSession } from '$lib/jobs/start-job-in-chat';
 	import type { JobResource } from '$lib/client/cometmind';
 	import { createChatViewController } from '$lib/conversation/chat-view-controller.svelte';
-	import { PanelLeft } from '@lucide/svelte';
+	import { PanelLeftClose, PanelLeftOpen } from '@lucide/svelte';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 
@@ -344,14 +344,22 @@
 	{#if compact}
 		<div class="mini-titlebar" aria-label="Mini window drag area">
 			<span>Mini Chat</span>
-			<Tooltip label="Show chats" action="toggleSidebar">
+			<Tooltip
+				label={miniShellStore.sidebarOpen ? 'Hide chats' : 'Show chats'}
+				action="toggleSidebar"
+			>
 				<button
 					class="mini-sidebar-toggle"
 					type="button"
-					aria-label="Show chats"
+					aria-label={miniShellStore.sidebarOpen ? 'Hide chats' : 'Show chats'}
+					aria-pressed={miniShellStore.sidebarOpen}
 					onclick={() => miniShellStore.toggleSidebar()}
 				>
-					<PanelLeft size={15} stroke-width={1.8} />
+					{#if miniShellStore.sidebarOpen}
+						<PanelLeftClose size={15} stroke-width={1.8} />
+					{:else}
+						<PanelLeftOpen size={15} stroke-width={1.8} />
+					{/if}
 				</button>
 			</Tooltip>
 			<button

--- a/cometline/src/lib/stores/shell.svelte.test.ts
+++ b/cometline/src/lib/stores/shell.svelte.test.ts
@@ -359,6 +359,65 @@ describe('shellStore workspace panel focus behavior', () => {
 
 		shellStore.clearWorkspacePanelForSession('sess-1');
 	});
+
+	it('toggleWorkspacePanel opens workspace files on first use', () => {
+		expect(shellStore.workspacePanelOpen).toBe(false);
+		expect(shellStore.hasWorkspacePanelForSession).toBe(false);
+
+		shellStore.toggleWorkspacePanel();
+
+		expect(shellStore.workspacePanelOpen).toBe(true);
+		expect(shellStore.contentSurface).toBe('workspace');
+		expect(shellStore.workspacePanelBrowseOpen).toBe(true);
+		expect(shellStore.workspacePanelSurface).toBe('web');
+		expect(shellStore.lastWorkspacePanelFocusTarget).toBe('filter');
+
+		shellStore.clearWorkspacePanelForSession('sess-1');
+	});
+
+	it('toggleWorkspacePanel soft-hides and restores last surface without content loss', () => {
+		shellStore.openFilePreviewForActive('src/app.ts');
+		expect(shellStore.workspacePanelOpen).toBe(true);
+		expect(shellStore.workspacePanelFilePath).toBe('src/app.ts');
+
+		shellStore.toggleWorkspacePanel();
+		expect(shellStore.workspacePanelOpen).toBe(false);
+		expect(shellStore.getSurfaceContent('workspace')).toEqual({
+			mode: 'file',
+			filePath: 'src/app.ts'
+		});
+
+		shellStore.toggleWorkspacePanel();
+		expect(shellStore.workspacePanelOpen).toBe(true);
+		expect(shellStore.contentSurface).toBe('workspace');
+		expect(shellStore.workspacePanelFilePath).toBe('src/app.ts');
+
+		shellStore.clearWorkspacePanelForSession('sess-1');
+	});
+
+	it('toggleWorkspacePanel soft-hides a terminal-only panel', () => {
+		expect(shellStore.openTerminalPanel()).toBe(true);
+		expect(shellStore.workspacePanelOpen).toBe(true);
+		expect(shellStore.terminalPanelOpen).toBe(true);
+
+		shellStore.toggleWorkspacePanel();
+		expect(shellStore.workspacePanelOpen).toBe(false);
+		expect(shellStore.terminalPanelOpen).toBe(false);
+
+		// No prior web session state → first web open lands on workspace files.
+		shellStore.toggleWorkspacePanel();
+		expect(shellStore.workspacePanelOpen).toBe(true);
+		expect(shellStore.contentSurface).toBe('workspace');
+		expect(shellStore.workspacePanelBrowseOpen).toBe(true);
+
+		shellStore.clearWorkspacePanelForSession('sess-1');
+	});
+
+	it('toggleWorkspacePanel no-ops without an active session', () => {
+		getActiveSessionId.mockReturnValue(null);
+		shellStore.toggleWorkspacePanel();
+		expect(shellStore.workspacePanelOpen).toBe(false);
+	});
 });
 
 describe('shellStore terminal panel visibility', () => {

--- a/cometline/src/lib/stores/shell.svelte.ts
+++ b/cometline/src/lib/stores/shell.svelte.ts
@@ -1083,28 +1083,59 @@ function createShellStore() {
 			this.setWorkspacePanelBrowseSource('changes');
 			gitChangesOpenRequestId += 1;
 		},
+		/**
+		 * Toggle the right workspace panel.
+		 * - First open for a session → workspace file tree (⌘L-like).
+		 * - Soft-hidden session → re-show last surface/content.
+		 * - Currently open → soft-hide (no content-dot walk; use closeWorkspacePanel / ⌘W for that).
+		 */
 		toggleWorkspacePanel() {
 			const sessionId = panelSessionKey();
-			if (!sessionId || !hasWorkspacePanelSession(sessionId)) return;
-			workspacePanelSurfaceBySession = {
-				...workspacePanelSurfaceBySession,
-				[sessionId]: 'web'
-			};
-			const visible = workspacePanelVisibleBySession[sessionId] !== true;
-			workspacePanelVisibleBySession = { ...workspacePanelVisibleBySession, [sessionId]: visible };
-			focusedPane = visible ? 'web' : 'chat';
-			syncWorkspacePanelOpen(visible);
-			if (!visible) return;
-			const surface = contentSurfaceFor(sessionId);
-			const content = contentFor(sessionId, surface);
-			if (surface === 'web-search' || content?.mode === 'url') {
-				this.requestAddressBarFocus();
-			} else if (
-				(surface === 'wiki' || surface === 'workspace') &&
-				content === null
-			) {
-				this.requestFileTreeFilterFocus();
+			if (!sessionId) return;
+
+			// Soft-hide the open panel without dismissing open files/pages.
+			if (workspacePanelOpenForActiveSession()) {
+				if (activeWorkspacePanelSurface() === 'terminal') {
+					const nextTerminal = { ...terminalPanelsBySession };
+					delete nextTerminal[sessionId];
+					terminalPanelsBySession = nextTerminal;
+				}
+				if (hasWorkspacePanelSession(sessionId)) {
+					workspacePanelVisibleBySession = {
+						...workspacePanelVisibleBySession,
+						[sessionId]: false
+					};
+				}
+				focusedPane = 'chat';
+				this.requestComposerFocus();
+				syncWorkspacePanelOpen(false);
+				return;
 			}
+
+			// Re-show a previously soft-hidden panel with its last surface.
+			if (hasWorkspacePanelSession(sessionId)) {
+				workspacePanelSurfaceBySession = {
+					...workspacePanelSurfaceBySession,
+					[sessionId]: 'web'
+				};
+				ensureWorkspacePanelVisible(sessionId);
+				focusedPane = 'web';
+				syncWorkspacePanelOpen(true);
+				const surface = contentSurfaceFor(sessionId);
+				const content = contentFor(sessionId, surface);
+				if (surface === 'web-search' || content?.mode === 'url') {
+					this.requestAddressBarFocus();
+				} else if (
+					(surface === 'wiki' || surface === 'workspace') &&
+					content === null
+				) {
+					this.requestFileTreeFilterFocus();
+				}
+				return;
+			}
+
+			// First open for this session: coding-first workspace file tree.
+			this.setWorkspacePanelBrowseSource('workspace');
 		},
 		openTerminalPanel() {
 			const sessionId = activeSessionId();


### PR DESCRIPTION
## Background

The main pane only had a left sidebar control, and the workspace panel toggle still flipped visibility without a clear first-open default or soft-hide path. Users need fixed corner chrome for both sidebars and a workspace toggle that opens the file tree on first use, restores the last surface after a soft hide, and soft-hides without walking content state.

[2e988c9](https://github.com/Cometline/cometline/commit/2e988c92846c972cc3a29c6aa5b9c6a6f74f31b7): Adds fixed left and right corner panel icons with open/close glyphs, keeps them outside the sliding titlebar, and reworks `toggleWorkspacePanel` so the first open shows the workspace file tree, a soft-hidden panel restores its last surface, and an open panel soft-hides without content-dot cleanup. Shell store tests cover the new toggle paths.