### PR TITLE
[main] feat: add response complete sound toggle

### DIFF
--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -49,10 +49,18 @@ declare global {
 		theme: TerminalThemeId;
 	}
 
+	/** Chime when an agent response finishes successfully. */
+	interface ResponseCompleteSoundSettings {
+		enabled: boolean;
+		/** 0–1 linear gain applied to the HTMLAudioElement volume. */
+		volume: number;
+	}
+
 	interface AppearanceSettings {
 		heroComposer: HeroComposerAppearance;
 		caretTrail: CaretTrailSettings;
 		terminal: TerminalAppearanceSettings;
+		responseCompleteSound: ResponseCompleteSoundSettings;
 	}
 
 	type ShortcutAction =

--- a/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsAppearancePanel.svelte
@@ -2,6 +2,7 @@
 	import type {
 		CaretTrailSettings,
 		HeroComposerAppearance,
+		ResponseCompleteSoundSettings,
 		TerminalAppearanceSettings
 	} from '$lib/types';
 	import {
@@ -16,15 +17,19 @@
 		normalizeTerminalFontSize,
 		TERMINAL_THEME_PRESETS
 	} from '$lib/terminal-appearance';
+	import { defaultResponseCompleteSoundSettings } from '$lib/settings/schema';
+	import { playResponseCompleteSound } from '$lib/sound/response-complete';
 
 	let {
 		appearance = $bindable({ ...DEFAULT_HERO_COMPOSER_APPEARANCE }),
 		caretTrail = $bindable({ enabled: true, intensity: 0.72, speed: 0.68 }),
-		terminal = $bindable({ ...DEFAULT_TERMINAL_APPEARANCE })
+		terminal = $bindable({ ...DEFAULT_TERMINAL_APPEARANCE }),
+		responseCompleteSound = $bindable(defaultResponseCompleteSoundSettings())
 	}: {
 		appearance: HeroComposerAppearance;
 		caretTrail: CaretTrailSettings;
 		terminal: TerminalAppearanceSettings;
+		responseCompleteSound: ResponseCompleteSoundSettings;
 	} = $props();
 
 	let previewStyle = $derived(heroComposerCssVarStyle(appearance));
@@ -32,6 +37,7 @@
 	let hasCustomPreset = $derived(Boolean(appearance.customPreset));
 	let customControlsDisabled = $derived(activePreset !== 'custom');
 	let terminalTheme = $derived(TERMINAL_THEME_PRESETS[terminal.theme]);
+	let volumePercent = $derived(Math.round(responseCompleteSound.volume * 100));
 
 	function applyPreset(preset: (typeof HERO_COMPOSER_PRESETS)[number]) {
 		appearance = {
@@ -70,6 +76,7 @@
 		appearance = { ...DEFAULT_HERO_COMPOSER_APPEARANCE };
 		caretTrail = { enabled: true, intensity: 0.72, speed: 0.68 };
 		terminal = { ...DEFAULT_TERMINAL_APPEARANCE };
+		responseCompleteSound = defaultResponseCompleteSoundSettings();
 	}
 
 	function updateTerminal<K extends keyof TerminalAppearanceSettings>(
@@ -77,6 +84,13 @@
 		value: TerminalAppearanceSettings[K]
 	) {
 		terminal = { ...terminal, [key]: value };
+	}
+
+	function previewResponseSound() {
+		playResponseCompleteSound({
+			...responseCompleteSound,
+			force: true
+		});
 	}
 </script>
 
@@ -300,6 +314,62 @@
 				</label>
 			</div>
 		</div>
+
+		<div class="settings-section">
+			<div class="settings-section-heading">
+				<div>
+					<h3>Response complete sound</h3>
+					<p>Play a short chime when the agent finishes a successful reply.</p>
+				</div>
+				<button
+					class="switch"
+					class:on={responseCompleteSound.enabled}
+					role="switch"
+					aria-checked={responseCompleteSound.enabled}
+					aria-label="Toggle response complete sound"
+					type="button"
+					onclick={() =>
+						(responseCompleteSound = {
+							...responseCompleteSound,
+							enabled: !responseCompleteSound.enabled
+						})}
+				>
+					<span></span>
+				</button>
+			</div>
+
+			<div class="sound-settings-row">
+				<label class="sound-volume-field">
+					<span class="sound-volume-label">
+						<span>Volume</span>
+						<span class="sound-volume-value" aria-live="polite">{volumePercent}%</span>
+					</span>
+					<input
+						type="range"
+						min="0"
+						max="1"
+						step="0.01"
+						value={responseCompleteSound.volume}
+						disabled={!responseCompleteSound.enabled}
+						aria-label="Response complete sound volume"
+						aria-valuetext={`${volumePercent}%`}
+						oninput={(e) =>
+							(responseCompleteSound = {
+								...responseCompleteSound,
+								volume: Number(e.currentTarget.value)
+							})}
+					/>
+				</label>
+				<button
+					class="secondary preview-sound-button"
+					type="button"
+					disabled={responseCompleteSound.volume <= 0}
+					onclick={previewResponseSound}
+				>
+					Preview
+				</button>
+			</div>
+		</div>
 	</div>
 </section>
 
@@ -361,6 +431,35 @@
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 		gap: 14px;
+	}
+
+	.sound-settings-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 14px;
+		align-items: end;
+	}
+
+	.sound-volume-field {
+		min-width: 0;
+	}
+
+	.sound-volume-label {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 12px;
+	}
+
+	.sound-volume-value {
+		font-variant-numeric: tabular-nums;
+		color: var(--text-main);
+	}
+
+	.preview-sound-button {
+		height: 38px;
+		padding: 0 14px;
+		white-space: nowrap;
 	}
 
 	.appearance-grid {
@@ -586,6 +685,14 @@
 
 		.slider-grid {
 			grid-template-columns: 1fr;
+		}
+
+		.sound-settings-row {
+			grid-template-columns: 1fr;
+		}
+
+		.preview-sound-button {
+			width: 100%;
 		}
 
 		.terminal-settings-grid,

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -426,6 +426,7 @@
 							bind:appearance={draft.appearance.heroComposer}
 							bind:caretTrail={draft.appearance.caretTrail}
 							bind:terminal={draft.appearance.terminal}
+							bind:responseCompleteSound={draft.appearance.responseCompleteSound}
 						/>
 						<section class="settings-panel-frame">
 							<div class="settings-section">

--- a/cometline/src/lib/settings/pending-settings.test.ts
+++ b/cometline/src/lib/settings/pending-settings.test.ts
@@ -59,6 +59,23 @@ describe('pending-settings', () => {
 		expect(sectionPendingDirty('appearance', draft, base)).toBe(true);
 	});
 
+	it('detects pending response complete sound edits in the Appearance section', () => {
+		const base = normalizeSettings(defaultSettings());
+		const draft = normalizeSettings({
+			...base,
+			appearance: {
+				...base.appearance,
+				responseCompleteSound: {
+					...base.appearance.responseCompleteSound,
+					volume: 0.25
+				}
+			}
+		});
+
+		expect(settingsPendingDirty(draft, base)).toBe(true);
+		expect(sectionPendingDirty('appearance', draft, base)).toBe(true);
+	});
+
 	it('produces stable snapshots', () => {
 		const settings = normalizeSettings(defaultSettings());
 		expect(pendingSettingsSnapshot(settings)).toBe(pendingSettingsSnapshot(settings));

--- a/cometline/src/lib/settings/pending-settings.ts
+++ b/cometline/src/lib/settings/pending-settings.ts
@@ -23,7 +23,8 @@ export function pendingSettingsSnapshot(settings: ProviderSettings): string {
 		appearance: {
 			heroComposer: { ...settings.appearance.heroComposer },
 			caretTrail: { ...settings.appearance.caretTrail },
-			terminal: { ...settings.appearance.terminal }
+			terminal: { ...settings.appearance.terminal },
+			responseCompleteSound: { ...settings.appearance.responseCompleteSound }
 		},
 		app: {
 			personaId: settings.app?.personaId ?? 'minako',
@@ -77,7 +78,8 @@ function appearanceSectionSnapshot(settings: ProviderSettings): string {
 		appearance: {
 			heroComposer: { ...settings.appearance.heroComposer },
 			caretTrail: { ...settings.appearance.caretTrail },
-			terminal: { ...settings.appearance.terminal }
+			terminal: { ...settings.appearance.terminal },
+			responseCompleteSound: { ...settings.appearance.responseCompleteSound }
 		},
 		personaId: settings.app?.personaId ?? 'minako',
 		personas: settings.app?.personas?.custom ?? []
@@ -134,7 +136,7 @@ export const SECTION_PERSISTENCE_HINTS: Record<
 		action: 'Refresh skills, sync symlinks, MCP test'
 	},
 	appearance: {
-		pending: 'Hero composer, terminal appearance, caret trail, and persona'
+		pending: 'Hero composer, terminal, caret trail, response sound, and persona'
 	},
 	shortcuts: {
 		instant: 'Every shortcut binding'

--- a/cometline/src/lib/settings/schema.test.ts
+++ b/cometline/src/lib/settings/schema.test.ts
@@ -148,6 +148,36 @@ describe('settings schema', () => {
 		});
 	});
 
+	it('normalizes response complete sound for settings created before that preference', () => {
+		const settings = normalizeSettings({
+			...defaultSettings(),
+			appearance: {
+				...defaultSettings().appearance,
+				responseCompleteSound: undefined as never
+			}
+		});
+
+		expect(settings.appearance.responseCompleteSound).toEqual({
+			enabled: true,
+			volume: 0.7
+		});
+	});
+
+	it('clamps response complete sound volume to 0–1', () => {
+		const settings = normalizeSettings({
+			...defaultSettings(),
+			appearance: {
+				...defaultSettings().appearance,
+				responseCompleteSound: { enabled: false, volume: 1.8 }
+			}
+		});
+
+		expect(settings.appearance.responseCompleteSound).toEqual({
+			enabled: false,
+			volume: 1
+		});
+	});
+
 	it('normalizes workspacePanelWidth: floors, clamps negatives, falls back on invalid', () => {
 		const base = defaultSettings();
 		expect(

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -11,7 +11,8 @@ import type {
 	CaretTrailSettings,
 	ProviderConfig,
 	ProviderMethod,
-	ProviderSettings
+	ProviderSettings,
+	ResponseCompleteSoundSettings
 } from '../types';
 import {
 	DEFAULT_CONTEXT_WINDOW_LIMIT,
@@ -965,6 +966,10 @@ function defaultCaretTrailSettings(): CaretTrailSettings {
 	return { enabled: true, intensity: 0.72, speed: 0.68 };
 }
 
+export function defaultResponseCompleteSoundSettings(): ResponseCompleteSoundSettings {
+	return { enabled: true, volume: 0.7 };
+}
+
 function normalizeUnit(value: unknown, fallback: number): number {
 	if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
 	return Math.min(1, Math.max(0, value));
@@ -981,11 +986,22 @@ function normalizeCaretTrailSettings(
 	};
 }
 
+export function normalizeResponseCompleteSoundSettings(
+	settings: Partial<ResponseCompleteSoundSettings> | undefined
+): ResponseCompleteSoundSettings {
+	const defaults = defaultResponseCompleteSoundSettings();
+	return {
+		enabled: typeof settings?.enabled === 'boolean' ? settings.enabled : defaults.enabled,
+		volume: normalizeUnit(settings?.volume, defaults.volume)
+	};
+}
+
 function defaultAppearance(): AppearanceSettings {
 	return {
 		heroComposer: { ...DEFAULT_HERO_COMPOSER_APPEARANCE },
 		caretTrail: defaultCaretTrailSettings(),
-		terminal: { ...DEFAULT_TERMINAL_APPEARANCE }
+		terminal: { ...DEFAULT_TERMINAL_APPEARANCE },
+		responseCompleteSound: defaultResponseCompleteSoundSettings()
 	};
 }
 
@@ -1226,7 +1242,10 @@ export function normalizeSettings(
 		appearance: {
 			heroComposer: normalizeHeroComposerAppearance(next.appearance?.heroComposer),
 			caretTrail: normalizeCaretTrailSettings(next.appearance?.caretTrail),
-			terminal: normalizeTerminalAppearance(next.appearance?.terminal)
+			terminal: normalizeTerminalAppearance(next.appearance?.terminal),
+			responseCompleteSound: normalizeResponseCompleteSoundSettings(
+				next.appearance?.responseCompleteSound
+			)
 		},
 		shortcuts: normalizeKeyboardShortcuts(next.shortcuts),
 		app: {
@@ -1426,6 +1445,10 @@ const providerSettingsSchema = z.object({
 		terminal: z.object({
 			fontSize: z.number().int().min(8).max(32),
 			theme: z.enum(['cometline-dark', 'dracula', 'gruvbox-dark', 'solarized-dark'])
+		}),
+		responseCompleteSound: z.object({
+			enabled: z.boolean(),
+			volume: z.number().min(0).max(1)
 		})
 	}),
 	shortcuts: z.record(z.string(), z.unknown()),

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -34,7 +34,8 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 					: undefined
 			},
 			caretTrail: { ...settings.appearance.caretTrail },
-			terminal: { ...settings.appearance.terminal }
+			terminal: { ...settings.appearance.terminal },
+			responseCompleteSound: { ...settings.appearance.responseCompleteSound }
 		},
 		shortcuts: cloneShortcuts(settings),
 		app: {
@@ -77,7 +78,8 @@ export function providerPayloadFromDraft(draft: ProviderSettings): ProviderSetti
 					: undefined
 			},
 			caretTrail: { ...draft.appearance.caretTrail },
-			terminal: { ...draft.appearance.terminal }
+			terminal: { ...draft.appearance.terminal },
+			responseCompleteSound: { ...draft.appearance.responseCompleteSound }
 		},
 		shortcuts: cloneShortcuts(draft),
 		app: { ...draft.app },

--- a/cometline/src/lib/sound/response-complete.test.ts
+++ b/cometline/src/lib/sound/response-complete.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const play = vi.fn(() => Promise.resolve());
+const audioInstances: Array<{ volume: number; currentTime: number; play: typeof play }> = [];
+
+class MockAudio {
+	volume = 1;
+	currentTime = 0;
+	play = play;
+
+	constructor(_src?: string) {
+		audioInstances.push(this);
+	}
+}
+
+describe('playResponseCompleteSound', () => {
+	beforeEach(() => {
+		audioInstances.length = 0;
+		play.mockClear();
+		vi.stubGlobal('Audio', MockAudio);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.resetModules();
+	});
+
+	it('plays at the given volume when enabled', async () => {
+		const { playResponseCompleteSound } = await import('./response-complete');
+		playResponseCompleteSound({ enabled: true, volume: 0.4 });
+
+		expect(audioInstances).toHaveLength(1);
+		expect(audioInstances[0]?.volume).toBe(0.4);
+		expect(audioInstances[0]?.currentTime).toBe(0);
+		expect(play).toHaveBeenCalledTimes(1);
+	});
+
+	it('no-ops when disabled', async () => {
+		const { playResponseCompleteSound } = await import('./response-complete');
+		playResponseCompleteSound({ enabled: false, volume: 0.9 });
+
+		expect(audioInstances).toHaveLength(0);
+		expect(play).not.toHaveBeenCalled();
+	});
+
+	it('no-ops when volume is 0', async () => {
+		const { playResponseCompleteSound } = await import('./response-complete');
+		playResponseCompleteSound({ enabled: true, volume: 0 });
+
+		expect(audioInstances).toHaveLength(0);
+		expect(play).not.toHaveBeenCalled();
+	});
+
+	it('ignores enabled when force is true', async () => {
+		const { playResponseCompleteSound } = await import('./response-complete');
+		playResponseCompleteSound({ enabled: false, volume: 0.55, force: true });
+
+		expect(audioInstances).toHaveLength(1);
+		expect(audioInstances[0]?.volume).toBe(0.55);
+		expect(play).toHaveBeenCalledTimes(1);
+	});
+});

--- a/cometline/src/lib/sound/response-complete.ts
+++ b/cometline/src/lib/sound/response-complete.ts
@@ -1,14 +1,35 @@
 import { browser } from '$app/environment';
+import type { ResponseCompleteSoundSettings } from '$lib/types';
 
 const RESPONSE_COMPLETE_SOUND_URL = '/sound/response_complete.mp3';
 
 let audio: HTMLAudioElement | null = null;
 
-export function playResponseCompleteSound() {
+function clampVolume(volume: number): number {
+	if (!Number.isFinite(volume)) return 0;
+	return Math.min(1, Math.max(0, volume));
+}
+
+/**
+ * Play the response-complete chime.
+ * @param options.enabled when false, no-op. Defaults to true when omitted.
+ * @param options.volume 0–1 gain (HTMLAudioElement.volume). Defaults to 1 when omitted.
+ * @param options.force when true, ignore `enabled` (used by settings preview).
+ */
+export function playResponseCompleteSound(
+	options?: Partial<ResponseCompleteSoundSettings> & { force?: boolean }
+) {
 	if (!browser) return;
+
+	const enabled = options?.enabled !== false;
+	if (!options?.force && !enabled) return;
+
+	const volume = clampVolume(options?.volume ?? 1);
+	if (volume <= 0) return;
 
 	try {
 		audio ??= new Audio(RESPONSE_COMPLETE_SOUND_URL);
+		audio.volume = volume;
 		audio.currentTime = 0;
 		void audio.play().catch(() => {});
 	} catch {

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -16,6 +16,7 @@ import { anyReasoningPending, hasReasoning } from '$lib/conversation/reasoning';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { chatDebug, summarizeChatItems, summarizeStreamEvent } from '../debug/chat';
 import { playResponseCompleteSound } from '$lib/sound/response-complete';
+import { settingsStore } from '$lib/stores/settings.svelte';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 import { homeRouteFor } from '$lib/routes/session-route';
 
@@ -657,7 +658,9 @@ function createChatStore() {
 						applyEventToSession(nextSessionID, event, ctx);
 						unmarkStreaming(nextSessionID);
 						if (streamOutcome === 'success' && !sessionErrors.get(nextSessionID)) {
-							playResponseCompleteSound();
+							playResponseCompleteSound(
+								settingsStore.settings.appearance.responseCompleteSound
+							);
 						}
 					}
 					chatDebug('store:stream-event', {
@@ -718,7 +721,9 @@ function createChatStore() {
 					applyEventToSession(nextSessionID, { type: 'done' }, ctx);
 					unmarkStreaming(nextSessionID);
 					if (streamOutcome === 'success' && !sessionErrors.get(nextSessionID)) {
-						playResponseCompleteSound();
+						playResponseCompleteSound(
+							settingsStore.settings.appearance.responseCompleteSound
+						);
 					}
 				}
 				// Mini models / aborted streams can settle with no visible assistant

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -86,10 +86,18 @@ export interface TerminalAppearanceSettings {
 	theme: TerminalThemeId;
 }
 
+/** Chime when an agent response finishes successfully. */
+export interface ResponseCompleteSoundSettings {
+	enabled: boolean;
+	/** 0–1 linear gain applied to the HTMLAudioElement volume. */
+	volume: number;
+}
+
 export interface AppearanceSettings {
 	heroComposer: HeroComposerAppearance;
 	caretTrail: CaretTrailSettings;
 	terminal: TerminalAppearanceSettings;
+	responseCompleteSound: ResponseCompleteSoundSettings;
 }
 
 export type ShortcutAction =


### PR DESCRIPTION
## Background

The response-complete chime always played at full volume with no user control. Appearance settings need an enable toggle, volume control, and a preview button so users can mute or soften the sound without digging into desktop config files.

[21ae1b4](https://github.com/Cometline/cometline/commit/21ae1b481a3fba426ddb8f949ac3f0892613b17c): Persists `appearance.responseCompleteSound` (`enabled`, `volume`) through the settings schema, draft, and pending-dirty paths, wires those preferences into `playResponseCompleteSound` (including a forced preview path), and adds Appearance panel controls for toggle, volume, and Preview.

[2f206f6](https://github.com/Cometline/cometline/commit/2f206f6d7b6e9e1930fd7c8083787441b46f17b3): Adds unit coverage for sound play/no-op/force behavior, schema normalization and volume clamping for older settings files, and pending-dirty detection when the Appearance sound section changes.

### Reference

[#81 sidebar icon PR](https://github.com/Cometline/cometline/pull/81)