### PR TITLE
[main] fix: dismiss selection popup on outside click

### DIFF
--- a/cometline/src/lib/components/FilePreview.svelte
+++ b/cometline/src/lib/components/FilePreview.svelte
@@ -3,7 +3,7 @@
 	import { untrack } from 'svelte';
 	import AssistantMarkdown from '$lib/components/AssistantMarkdown.svelte';
 	import FileEditor from '$lib/components/FileEditor.svelte';
-	import { portal } from '$lib/components/portal';
+	import SelectionAddToChat from '$lib/components/SelectionAddToChat.svelte';
 	import {
 		listWikiFileBacklinks,
 		readWikiFileContent,
@@ -389,14 +389,6 @@
 		};
 	});
 
-	$effect(() => {
-		document.addEventListener('scroll', clearSelectionPopup, true);
-		window.addEventListener('resize', clearSelectionPopup);
-		return () => {
-			document.removeEventListener('scroll', clearSelectionPopup, true);
-			window.removeEventListener('resize', clearSelectionPopup);
-		};
-	});
 </script>
 
 {#snippet backlinksSection()}
@@ -547,17 +539,11 @@
 	{/if}
 
 	{#if selectionPopup}
-		<button
-			use:portal
-			type="button"
-			class="selection-add-chat"
-			style:top="{selectionPopup.top}px"
-			style:left="{selectionPopup.left}px"
-			onmousedown={(event) => event.preventDefault()}
-			onclick={addSelectionToChat}
-		>
-			Add to chat
-		</button>
+		<SelectionAddToChat
+			position={{ top: selectionPopup.top, left: selectionPopup.left }}
+			onAdd={addSelectionToChat}
+			onDismiss={clearSelectionPopup}
+		/>
 	{/if}
 </div>
 
@@ -570,23 +556,6 @@
 		background: #fff;
 	}
 
-	.selection-add-chat {
-		position: fixed;
-		z-index: 10000;
-		padding: 6px 10px;
-		border: 1px solid var(--border-soft);
-		border-radius: 8px;
-		background: #fff;
-		color: var(--text-main);
-		font-size: 12px;
-		font-weight: 600;
-		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
-		cursor: pointer;
-	}
-
-	.selection-add-chat:hover {
-		border-color: var(--text-soft);
-	}
 
 	.file-preview-state {
 		display: flex;

--- a/cometline/src/lib/components/GitDiffView.svelte
+++ b/cometline/src/lib/components/GitDiffView.svelte
@@ -9,7 +9,7 @@
 		type GitScope
 	} from '$lib/client/cometmind';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
-	import { portal } from '$lib/components/portal';
+	import SelectionAddToChat from '$lib/components/SelectionAddToChat.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import {
 		highlightGitDiffLines,
@@ -233,15 +233,6 @@
 		void [workspacePath, filePath, scope, workspaceChangeVersion(workspacePath)];
 		void load();
 	});
-
-	$effect(() => {
-		document.addEventListener('scroll', clearSelectionPopup, true);
-		window.addEventListener('resize', clearSelectionPopup);
-		return () => {
-			document.removeEventListener('scroll', clearSelectionPopup, true);
-			window.removeEventListener('resize', clearSelectionPopup);
-		};
-	});
 </script>
 
 <div class="git-diff-view">
@@ -349,17 +340,11 @@
 	{/if}
 
 	{#if selectionPopup}
-		<button
-			use:portal
-			type="button"
-			class="selection-add-chat"
-			style:top="{selectionPopup.top}px"
-			style:left="{selectionPopup.left}px"
-			onmousedown={(event) => event.preventDefault()}
-			onclick={addSelectionToChat}
-		>
-			Add to chat
-		</button>
+		<SelectionAddToChat
+			position={{ top: selectionPopup.top, left: selectionPopup.left }}
+			onAdd={addSelectionToChat}
+			onDismiss={clearSelectionPopup}
+		/>
 	{/if}
 </div>
 
@@ -578,23 +563,5 @@
 		padding: 8px 12px 12px;
 		font-size: 12px;
 		color: var(--text-muted);
-	}
-
-	.selection-add-chat {
-		position: fixed;
-		z-index: 10000;
-		padding: 6px 10px;
-		border: 1px solid var(--border-soft);
-		border-radius: 8px;
-		background: #fff;
-		color: var(--text-main);
-		font-size: 12px;
-		font-weight: 600;
-		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
-		cursor: pointer;
-	}
-
-	.selection-add-chat:hover {
-		border-color: var(--text-soft);
 	}
 </style>

--- a/cometline/src/lib/components/SelectionAddToChat.svelte
+++ b/cometline/src/lib/components/SelectionAddToChat.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { portal } from '$lib/components/portal';
+
+	let {
+		position,
+		onAdd,
+		onDismiss
+	}: {
+		position: { top: number; left: number };
+		onAdd: () => void;
+		onDismiss: () => void;
+	} = $props();
+
+	let button = $state<HTMLButtonElement | null>(null);
+
+	function handlePointerDown(event: PointerEvent) {
+		if (button?.contains(event.target as Node)) return;
+		onDismiss();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') onDismiss();
+	}
+
+	onMount(() => {
+		window.addEventListener('pointerdown', handlePointerDown, true);
+		window.addEventListener('keydown', handleKeydown);
+		document.addEventListener('scroll', onDismiss, true);
+		window.addEventListener('resize', onDismiss);
+		return () => {
+			window.removeEventListener('pointerdown', handlePointerDown, true);
+			window.removeEventListener('keydown', handleKeydown);
+			document.removeEventListener('scroll', onDismiss, true);
+			window.removeEventListener('resize', onDismiss);
+		};
+	});
+</script>
+
+<button
+	bind:this={button}
+	use:portal
+	type="button"
+	class="selection-add-chat"
+	style:top="{position.top}px"
+	style:left="{position.left}px"
+	onmousedown={(event) => event.preventDefault()}
+	onclick={onAdd}
+>
+	Add to chat
+</button>
+
+<style>
+	.selection-add-chat {
+		position: fixed;
+		z-index: 10000;
+		padding: 6px 10px;
+		border: 1px solid var(--border-soft);
+		border-radius: 8px;
+		background: #fff;
+		color: var(--text-main);
+		font-size: 12px;
+		font-weight: 600;
+		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+		cursor: pointer;
+	}
+
+	.selection-add-chat:hover {
+		border-color: var(--text-soft);
+	}
+</style>

--- a/cometline/src/lib/components/SelectionAddToChat.svelte.test.ts
+++ b/cometline/src/lib/components/SelectionAddToChat.svelte.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import SelectionAddToChat from './SelectionAddToChat.svelte';
+
+describe('SelectionAddToChat', () => {
+	function renderPopup() {
+		const onAdd = vi.fn();
+		const onDismiss = vi.fn();
+		render(SelectionAddToChat, {
+			props: { position: { top: 20, left: 30 }, onAdd, onDismiss }
+		});
+		return { onAdd, onDismiss };
+	}
+
+	it('dismisses on the first pointer down outside the popup', async () => {
+		const { onDismiss } = renderPopup();
+
+		await fireEvent.pointerDown(document.body);
+
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it('keeps the popup open through its own pointer down and adds context on click', async () => {
+		const { onAdd, onDismiss } = renderPopup();
+		const button = screen.getByRole('button', { name: 'Add to chat' });
+
+		await fireEvent.pointerDown(button);
+		await fireEvent.click(button);
+
+		expect(onDismiss).not.toHaveBeenCalled();
+		expect(onAdd).toHaveBeenCalledOnce();
+	});
+
+	it('dismisses on Escape, scroll, and resize', async () => {
+		const { onDismiss } = renderPopup();
+
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		await fireEvent.scroll(document);
+		await fireEvent.resize(window);
+
+		expect(onDismiss).toHaveBeenCalledTimes(3);
+	});
+});

--- a/cometline/src/lib/components/chat/AssistantStack.svelte
+++ b/cometline/src/lib/components/chat/AssistantStack.svelte
@@ -17,7 +17,7 @@
 	import type { ChatItem } from '$lib/stores/chat.svelte';
 	import { resolveImageSrc } from '$lib/files/images';
 	import ImageLightbox from '$lib/components/chat/ImageLightbox.svelte';
-	import { portal } from '$lib/components/portal';
+	import SelectionAddToChat from '$lib/components/SelectionAddToChat.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
 	import {
 		assistantResponseSource,
@@ -57,7 +57,7 @@
 	const thinkingWait = $derived(assistantThinkingWait(item, context.now));
 	const showThinkingSpinner = $derived(
 		!item.text.trim() &&
-			!(item.images?.length) &&
+			!item.images?.length &&
 			!(item.id === context.streamingAssistantId && context.sessionStreaming)
 	);
 	const responseSource = $derived(
@@ -123,15 +123,6 @@
 		clearSelectionPopup();
 		window.getSelection()?.removeAllRanges();
 	}
-
-	$effect(() => {
-		document.addEventListener('scroll', clearSelectionPopup, true);
-		window.addEventListener('resize', clearSelectionPopup);
-		return () => {
-			document.removeEventListener('scroll', clearSelectionPopup, true);
-			window.removeEventListener('resize', clearSelectionPopup);
-		};
-	});
 </script>
 
 <div class="assistant-stack" data-assistant-response-source={responseSource ?? undefined}>
@@ -231,26 +222,15 @@
 </div>
 
 {#if selectionPopup}
-	<button
-		use:portal
-		type="button"
-		class="selection-add-chat"
-		style:top="{selectionPopup.top}px"
-		style:left="{selectionPopup.left}px"
-		onmousedown={(event) => event.preventDefault()}
-		onclick={addSelectionToChat}
-	>
-		Add to chat
-	</button>
+	<SelectionAddToChat
+		position={{ top: selectionPopup.top, left: selectionPopup.left }}
+		onAdd={addSelectionToChat}
+		onDismiss={clearSelectionPopup}
+	/>
 {/if}
 
 {#if lightbox}
-	<ImageLightbox
-		open
-		src={lightbox.src}
-		alt={lightbox.alt}
-		onClose={() => (lightbox = null)}
-	/>
+	<ImageLightbox open src={lightbox.src} alt={lightbox.alt} onClose={() => (lightbox = null)} />
 {/if}
 
 <style>
@@ -283,24 +263,6 @@
 			box-shadow: 0 0 0 3px
 				color-mix(in srgb, var(--hero-composer-glow-color, #72c0ff) 45%, transparent);
 		}
-	}
-
-	.selection-add-chat {
-		position: fixed;
-		z-index: 10000;
-		padding: 6px 10px;
-		border: 1px solid var(--border-soft);
-		border-radius: 8px;
-		background: #fff;
-		color: var(--text-main);
-		font-size: 12px;
-		font-weight: 600;
-		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
-		cursor: pointer;
-	}
-
-	.selection-add-chat:hover {
-		border-color: var(--text-soft);
 	}
 
 	.assistant-stack > :global(.memory-panel),


### PR DESCRIPTION
## Background

Text selection actions in File Preview, Git Diff, and assistant responses remained visible after one outside click because each surface owned a separate popup lifecycle.

[de34e15](https://github.com/Cometline/cometline/commit/de34e1561776ea967b4139aba3c7dbab9d2f1f92): Extracts the action into a shared portal component that dismisses on capture-phase outside pointerdown, Escape, scrolling, and resizing while preserving the add action. Covers the shared lifecycle with interaction tests.