### PR TITLE
[main] fix: polish mini window loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,7 +377,7 @@ Cometline can improve itself using the same agent runtime:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (13415 symbols, 37616 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (13650 symbols, 38598 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,7 @@ Cometline can improve itself using the same agent runtime:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cometline-release** (13415 symbols, 37616 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cometline-release** (13650 symbols, 38598 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/cometline/src/lib/components/MiniSessionSidebar.svelte
+++ b/cometline/src/lib/components/MiniSessionSidebar.svelte
@@ -10,6 +10,8 @@
 	} from '$lib/actions/activate-after-session-deleted';
 	import { sessionStore } from '$lib/stores/session.svelte';
 	import { shellStore } from '$lib/stores/shell.svelte';
+	import { settingsStore } from '$lib/stores/settings.svelte';
+	import { terminalStore } from '$lib/stores/terminal.svelte';
 	import { sessionDisplayTitle } from '$lib/sessions/session-title';
 	import {
 		layoutSessionsForSidebar,
@@ -19,6 +21,7 @@
 	} from '$lib/sessions/group-by-workspace';
 	import SidebarSearch from '$lib/components/sidebar/SidebarSearch.svelte';
 	import SessionRow from '$lib/components/sidebar/SessionRow.svelte';
+	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 
 	const WORKSPACE_GROUP_FLIP = { duration: 240 };
@@ -38,6 +41,8 @@
 	let collapsedGroups = $state<Record<string, boolean>>({});
 	let deletingID = $state<string | null>(null);
 	let pinningID = $state<string | null>(null);
+	let pendingDelete = $state<Session | null>(null);
+	let terminalDeleteSession = $state<Session | null>(null);
 	let filteredSessions = $derived.by(() => {
 		const query = searchQuery.trim().toLowerCase();
 		if (!query) return sessionStore.sessions;
@@ -84,12 +89,45 @@
 	}
 
 	async function removeSession(session: Session) {
-		if (!window.confirm(`Delete ${session.title || 'this chat'}?`)) return;
+		if (terminalStore.isRunning(session.id)) {
+			terminalDeleteSession = session;
+			return;
+		}
+		if (terminalStore.hasTerminal(session.id)) await terminalStore.remove(session.id);
+		if (settingsStore.settings.app.confirmBeforeDeletingChats) {
+			pendingDelete = session;
+			return;
+		}
+		await deleteSelectedSession(session);
+	}
+
+	async function confirmTerminalDelete() {
+		const session = terminalDeleteSession;
+		if (!session) return;
+		terminalDeleteSession = null;
+		await terminalStore.remove(session.id);
+		await deleteSelectedSession(session);
+	}
+
+	async function confirmDelete() {
+		if (!pendingDelete) return;
+		const session = pendingDelete;
+		pendingDelete = null;
+		await deleteSelectedSession(session);
+	}
+
+	async function alwaysDeleteWithoutConfirm() {
+		void settingsStore.saveConfirmBeforeDeletingChats(false).catch(() => {});
+		await confirmDelete();
+	}
+
+	async function deleteSelectedSession(session: Session) {
 		deletingID = session.id;
 		try {
 			const wasCurrent = sessionStore.current?.id === session.id;
 			const before = sessionsSnapshot();
 			await deleteSession(session.id);
+			shellStore.clearWorkspacePanelForSession(session.id);
 			sessionStore.removeSession(session.id);
 			if (wasCurrent) {
 				onClose();
@@ -160,6 +198,26 @@
 			<p class="session-empty">{searchQuery.trim() ? 'No chats match your search' : 'No chats yet'}</p>
 		{/if}
 	</div>
+
+	<ConfirmActionModal
+		open={Boolean(pendingDelete)}
+		title={`Delete "${pendingDelete ? sessionDisplayTitle(pendingDelete.title) : ''}"?`}
+		description="This cannot be undone."
+		confirmLabel="Delete"
+		secondaryLabel="Don't ask again"
+		onSecondary={() => void alwaysDeleteWithoutConfirm()}
+		onCancel={() => (pendingDelete = null)}
+		onConfirm={() => void confirmDelete()}
+	/>
+
+	<ConfirmActionModal
+		open={Boolean(terminalDeleteSession)}
+		title="Delete chat?"
+		description="This will terminate this chat's terminal and every program started from it. This cannot be undone."
+		confirmLabel="Delete chat"
+		onCancel={() => (terminalDeleteSession = null)}
+		onConfirm={() => void confirmTerminalDelete()}
+	/>
 </aside>
 
 <style>

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 	setActiveWorkspacePath: vi.fn(),
 	setSidebarOrderWorkspacePath: vi.fn(),
 	setSidebarOrderDiscordActive: vi.fn(),
-	recordVisit: vi.fn()
+	recordVisit: vi.fn(),
+	requestNewSession: vi.fn(),
+	clearNewSessionRequest: vi.fn()
 }));
 
 vi.mock('$app/navigation', () => ({ goto: mocks.goto }));
@@ -36,6 +38,12 @@ vi.mock('$lib/stores/shell.svelte', () => ({
 }));
 vi.mock('$lib/stores/session-visit-history.svelte', () => ({
 	sessionVisitHistory: { recordVisit: mocks.recordVisit }
+}));
+vi.mock('$lib/stores/mini-shell.svelte', () => ({
+	miniShellStore: {
+		requestNewSession: mocks.requestNewSession,
+		clearNewSessionRequest: mocks.clearNewSessionRequest
+	}
 }));
 
 import {
@@ -91,13 +99,32 @@ describe('mini window sessions', () => {
 		expect(window.electronAPI?.saveMiniWindowState).toHaveBeenCalledWith({
 			sessionId: 'mini-session'
 		});
+		expect(mocks.requestNewSession).toHaveBeenCalledWith('mini-session');
 		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
+	});
+
+	it('clears the matching loading request when navigation fails', async () => {
+		mocks.goto.mockRejectedValueOnce(new Error('navigation failed'));
+
+		await expect(createMiniWindowSession()).rejects.toThrow('navigation failed');
+
+		expect(mocks.clearNewSessionRequest).toHaveBeenCalledWith('mini-session');
 	});
 
 	it('reuses a preferred session from another workspace', async () => {
 		await expect(ensureMiniWindowSession('mini-session')).resolves.toBe('mini-session');
 
 		expect(mocks.listAllSessions).toHaveBeenCalledOnce();
+		expect(mocks.createNewSession).not.toHaveBeenCalled();
+	});
+
+	it('does not create a replacement for a missing preferred session', async () => {
+		mocks.listAllSessions.mockResolvedValue({ sessions: [] });
+
+		await expect(ensureMiniWindowSession('missing-session')).rejects.toThrow(
+			'This chat no longer exists.'
+		);
+
 		expect(mocks.createNewSession).not.toHaveBeenCalled();
 	});
 });

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -2,6 +2,7 @@ import { goto } from '$app/navigation';
 import { createSession, listAllSessions } from '$lib/client/cometmind';
 import { createNewSession } from '$lib/actions/create-new-session';
 import { modelStore } from '$lib/stores/model.svelte';
+import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
 import { shellStore } from '$lib/stores/shell.svelte';
@@ -53,6 +54,9 @@ export async function ensureMiniWindowSession(preferredSessionId = '') {
 			}
 			return session.id;
 		}
+		if (preferredSessionId) {
+			throw new Error('This chat no longer exists.');
+		}
 	}
 
 	const selected = await resolveSelectedModel();
@@ -84,8 +88,16 @@ export async function navigateMiniToSession(session: Session) {
 
 /** Create and open a persisted mini-window session using the configured default model. */
 export async function createMiniWindowSession() {
-	const session = await createNewSession();
-	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
-	await goto(`/mini/session/${session.id}`);
-	return session;
+	let createdSessionId = '';
+	try {
+		const session = await createNewSession();
+		createdSessionId = session.id;
+		await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
+		miniShellStore.requestNewSession(session.id);
+		await goto(`/mini/session/${session.id}`);
+		return session;
+	} catch (error) {
+		miniShellStore.clearNewSessionRequest(createdSessionId);
+		throw error;
+	}
 }

--- a/cometline/src/lib/stores/mini-shell.svelte.test.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { miniShellStore } from './mini-shell.svelte';
+
+describe('mini shell new-session requests', () => {
+	beforeEach(() => {
+		miniShellStore.clearNewSessionRequest();
+	});
+
+	it('only consumes the request for the matching session', () => {
+		miniShellStore.requestNewSession('new-session');
+
+		expect(miniShellStore.consumeNewSessionRequest('existing-session')).toBe(false);
+		expect(miniShellStore.consumeNewSessionRequest('new-session')).toBe(true);
+		expect(miniShellStore.consumeNewSessionRequest('new-session')).toBe(false);
+	});
+
+	it('does not clear a newer request for another session', () => {
+		miniShellStore.requestNewSession('new-session');
+		miniShellStore.clearNewSessionRequest('other-session');
+
+		expect(miniShellStore.consumeNewSessionRequest('new-session')).toBe(true);
+	});
+});

--- a/cometline/src/lib/stores/mini-shell.svelte.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.ts
@@ -1,5 +1,6 @@
 function createMiniShellStore() {
 	let sidebarOpen = $state(false);
+	let requestedNewSessionId = '';
 
 	return {
 		get sidebarOpen() {
@@ -13,6 +14,17 @@ function createMiniShellStore() {
 		},
 		closeSidebar() {
 			sidebarOpen = false;
+		},
+		requestNewSession(sessionId: string) {
+			requestedNewSessionId = sessionId;
+		},
+		consumeNewSessionRequest(sessionId: string) {
+			const requested = requestedNewSessionId === sessionId;
+			if (requested) requestedNewSessionId = '';
+			return requested;
+		},
+		clearNewSessionRequest(sessionId?: string) {
+			if (!sessionId || requestedNewSessionId === sessionId) requestedNewSessionId = '';
 		}
 	};
 }

--- a/cometline/src/routes/mini/+page.svelte
+++ b/cometline/src/routes/mini/+page.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
+	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
+
+	const MIN_LOADING_MS = 320;
+	const LOADING_FADE_MS = 160;
 
 	let error = $state('');
 
 	onMount(() => {
+		const startedAt = performance.now();
 		void (async () => {
 			try {
 				const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
 				const sessionId = await ensureMiniWindowSession();
+				const remaining = Math.max(0, MIN_LOADING_MS - (performance.now() - startedAt));
+				if (remaining > 0) await new Promise((resolve) => setTimeout(resolve, remaining));
 				await goto(`/mini/session/${sessionId}`, { replaceState: true });
 			} catch (err) {
 				error = err instanceof Error ? err.message : 'Failed to open mini chat';
@@ -17,35 +25,36 @@
 	});
 </script>
 
-<div class="mini-loading-shell">
-	<div class="mini-loading-card">
-		<p>{error || 'Opening mini chat...'}</p>
+{#if error}
+	<div class="mini-loading-error" role="alert">{error}</div>
+{:else}
+	<div class="mini-loading-overlay" transition:fade={{ duration: LOADING_FADE_MS }}>
+		<ThinkingIndicator size={28} label="Opening mini chat" />
 	</div>
-</div>
+{/if}
 
 <style>
-	.mini-loading-shell {
+	.mini-loading-overlay {
+		position: absolute;
+		inset: 0;
 		display: grid;
 		place-items: center;
-		min-height: 100vh;
 		padding: 24px;
-		background: var(--app-bg);
-		color: var(--text-main);
-		-webkit-app-region: drag;
+		z-index: 90;
+		background: color-mix(in srgb, var(--app-bg) 38%, transparent);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		-webkit-app-region: no-drag;
 	}
 
-	.mini-loading-card {
-		width: min(100%, 320px);
-		padding: 18px 20px;
-		border-radius: 16px;
-		background: color-mix(in srgb, var(--panel-bg) 90%, transparent);
-		border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
-		box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
-	}
-
-	p {
-		margin: 0;
-		font-size: 14px;
-		line-height: 1.5;
+	.mini-loading-error {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		color: var(--status-error);
+		text-align: center;
+		-webkit-app-region: no-drag;
 	}
 </style>

--- a/cometline/src/routes/mini/session/[id]/+page.svelte
+++ b/cometline/src/routes/mini/session/[id]/+page.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
+	import { untrack } from 'svelte';
 	import ChatView from '$lib/components/ChatView.svelte';
+	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
+	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
+
+	const MIN_LOADING_MS = 320;
 
 	let sessionId = $derived(page.params.id ?? '');
 	let resolvedSessionId = $state('');
 	let resolvingRun = 0;
+	let resolving = $state(true);
+	let showLoading = $state(true);
 	let error = $state('');
 
 	async function resolveSession(id: string, run: number) {
+		const startedAt = performance.now();
 		try {
 			const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
 			const ensuredSessionId = await ensureMiniWindowSession(id);
@@ -17,19 +25,27 @@
 				await goto(`/mini/session/${ensuredSessionId}`, { replaceState: true });
 				return;
 			}
+			const remaining = Math.max(0, MIN_LOADING_MS - (performance.now() - startedAt));
+			if (remaining > 0) await new Promise((resolve) => setTimeout(resolve, remaining));
+			if (run !== resolvingRun) return;
 			resolvedSessionId = ensuredSessionId;
 			error = '';
+			resolving = false;
 		} catch (err) {
 			if (run !== resolvingRun) return;
 			error = err instanceof Error ? err.message : 'Failed to open mini chat';
 			resolvedSessionId = '';
+			resolving = false;
 		}
 	}
 
 	$effect(() => {
 		if (!sessionId) return;
-		resolvedSessionId = '';
+		const existingSession = untrack(() => Boolean(resolvedSessionId));
+		showLoading = !existingSession || miniShellStore.consumeNewSessionRequest(sessionId);
+		resolvedSessionId = sessionId;
 		error = '';
+		resolving = true;
 		const run = ++resolvingRun;
 		void resolveSession(sessionId, run);
 	});
@@ -37,26 +53,38 @@
 
 {#if resolvedSessionId}
 	<ChatView sessionId={resolvedSessionId} compact />
-{:else}
-	<div class="mini-session-loading">
-		<p>{error || 'Opening mini chat...'}</p>
+{:else if error}
+	<div class="mini-session-error" role="alert">{error}</div>
+{/if}
+
+{#if showLoading && resolving && !error}
+	<div class="mini-loading-overlay">
+		<ThinkingIndicator size={28} label="Opening mini chat" />
 	</div>
 {/if}
 
 <style>
-	.mini-session-loading {
+	.mini-loading-overlay {
+		position: absolute;
+		inset: 0;
 		display: grid;
 		place-items: center;
-		min-height: 100vh;
 		padding: 24px;
-		background: var(--app-bg);
-		color: var(--text-main);
-		-webkit-app-region: drag;
+		z-index: 90;
+		background: color-mix(in srgb, var(--app-bg) 38%, transparent);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		-webkit-app-region: no-drag;
 	}
 
-	p {
-		margin: 0;
-		font-size: 14px;
-		line-height: 1.5;
+	.mini-session-error {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		color: var(--status-error);
+		text-align: center;
+		-webkit-app-region: no-drag;
 	}
 </style>


### PR DESCRIPTION
## Background

Mini-window session loading needed a less intrusive indicator without delaying existing chats, while deletion needed to match the main window confirmation behavior.

[222f77c](https://github.com/Cometline/cometline/commit/222f77c3ff9553bdf7d607b69867af2f00be818f): Replaces the mini-window loading card with a blurred indicator overlay, keeps existing chats visible during validation, aligns deletion confirmation with the main sidebar, and prevents stale-session and new-session loading races.