### PR TITLE
[main] fix: focus composer after navigation

### DIFF
--- a/cometline/src/lib/actions/navigate-to-session.test.ts
+++ b/cometline/src/lib/actions/navigate-to-session.test.ts
@@ -66,29 +66,29 @@ describe('navigateToSession sidebar order', () => {
 		vi.stubGlobal('window', { electronAPI: { setWorkspacePath: electronSetWorkspacePath } });
 	});
 
-	it('commits sidebar order for unpinned sessions by default', () => {
-		navigateToSession(session());
+	it('commits sidebar order for unpinned sessions by default', async () => {
+		await navigateToSession(session());
 
 		expect(mocks.setSidebarOrderWorkspacePath).toHaveBeenCalledWith('/ws-b');
 		expect(mocks.setSidebarOrderDiscordActive).toHaveBeenCalledWith(false);
 	});
 
-	it('does not commit sidebar order for pinned sessions by default', () => {
-		navigateToSession(session({ pinned: true }));
+	it('does not commit sidebar order for pinned sessions by default', async () => {
+		await navigateToSession(session({ pinned: true }));
 
 		expect(mocks.setSidebarOrderWorkspacePath).not.toHaveBeenCalled();
 		expect(mocks.setSidebarOrderDiscordActive).not.toHaveBeenCalled();
 	});
 
-	it('allows explicit commitSidebarOrder override for pinned sessions', () => {
-		navigateToSession(session({ pinned: true }), { commitSidebarOrder: true });
+	it('allows explicit commitSidebarOrder override for pinned sessions', async () => {
+		await navigateToSession(session({ pinned: true }), { commitSidebarOrder: true });
 
 		expect(mocks.setSidebarOrderWorkspacePath).toHaveBeenCalledWith('/ws-b');
 		expect(mocks.setSidebarOrderDiscordActive).toHaveBeenCalledWith(false);
 	});
 
-	it('still opens the session and updates active workspace when pinned', () => {
-		navigateToSession(session({ pinned: true }));
+	it('still opens the session and updates active workspace when pinned', async () => {
+		await navigateToSession(session({ pinned: true }));
 
 		expect(mocks.selectSession).toHaveBeenCalled();
 		expect(mocks.selectFromSession).toHaveBeenCalled();
@@ -97,29 +97,29 @@ describe('navigateToSession sidebar order', () => {
 		expect(mocks.goto).toHaveBeenCalledWith('/session/sess-1');
 	});
 
-	it('requests composer focus for the destination before navigation', () => {
-		navigateToSession(session());
+	it('requests composer focus for the destination after navigation', async () => {
+		await navigateToSession(session());
 
 		expect(mocks.requestComposerFocus).toHaveBeenCalledWith('sess-1');
-		expect(mocks.requestComposerFocus.mock.invocationCallOrder[0]).toBeLessThan(
-			mocks.goto.mock.invocationCallOrder[0]
+		expect(mocks.goto.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.requestComposerFocus.mock.invocationCallOrder[0]
 		);
 	});
 
-	it('does not persist workspace to Electron when switching sessions', () => {
-		navigateToSession(session());
+	it('does not persist workspace to Electron when switching sessions', async () => {
+		await navigateToSession(session());
 
 		expect(mocks.setActiveWorkspacePath).toHaveBeenCalledWith('/ws-b');
 		expect(electronSetWorkspacePath).not.toHaveBeenCalled();
 	});
 
-	it('records a visit for normal navigation', () => {
-		navigateToSession(session());
+	it('records a visit for normal navigation', async () => {
+		await navigateToSession(session());
 		expect(mocks.recordVisit).toHaveBeenCalledWith('sess-1');
 	});
 
-	it('skips visit recording when navigating from history', () => {
-		navigateToSession(session(), { fromHistory: true });
+	it('skips visit recording when navigating from history', async () => {
+		await navigateToSession(session(), { fromHistory: true });
 		expect(mocks.recordVisit).not.toHaveBeenCalled();
 	});
 });

--- a/cometline/src/lib/actions/navigate-to-session.ts
+++ b/cometline/src/lib/actions/navigate-to-session.ts
@@ -14,7 +14,7 @@ export interface NavigateToSessionOptions {
 }
 
 /** Activate a session; composer follows the session workspace immediately. */
-export function navigateToSession(session: Session, options: NavigateToSessionOptions = {}) {
+export async function navigateToSession(session: Session, options: NavigateToSessionOptions = {}) {
 	const commitSidebarOrder = options.commitSidebarOrder ?? !session.pinned;
 
 	sessionStore.selectSession(session);
@@ -35,6 +35,6 @@ export function navigateToSession(session: Session, options: NavigateToSessionOp
 		sessionVisitHistory.recordVisit(session.id);
 	}
 
+	await goto(`/session/${session.id}`);
 	shellStore.requestComposerFocus(session.id);
-	void goto(`/session/${session.id}`);
 }

--- a/cometline/src/lib/actions/new-chat.test.ts
+++ b/cometline/src/lib/actions/new-chat.test.ts
@@ -32,14 +32,14 @@ describe('startNewChat', () => {
 		mocks.createNewSession.mockResolvedValue({ id: 'new-session' });
 	});
 
-	it('targets the new session composer before navigating', async () => {
+	it('targets the new session composer after navigating', async () => {
 		await startNewChat();
 
 		expect(mocks.detachActiveSession).toHaveBeenCalledOnce();
 		expect(mocks.requestComposerFocus).toHaveBeenCalledWith('new-session');
 		expect(mocks.goto).toHaveBeenCalledWith('/session/new-session');
-		expect(mocks.requestComposerFocus.mock.invocationCallOrder[0]).toBeLessThan(
-			mocks.goto.mock.invocationCallOrder[0]
+		expect(mocks.goto.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.requestComposerFocus.mock.invocationCallOrder[0]
 		);
 	});
 });

--- a/cometline/src/lib/actions/new-chat.ts
+++ b/cometline/src/lib/actions/new-chat.ts
@@ -29,6 +29,6 @@ export async function startNewChat() {
 	// the current turn queue can keep draining without the old view staying active.
 	chatStore.detachActiveSession();
 	const session = await createNewSession();
-	shellStore.requestComposerFocus(session.id);
 	await goto(`/session/${session.id}`);
+	shellStore.requestComposerFocus(session.id);
 }

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -92,6 +92,10 @@ describe('mini window sessions', () => {
 			sessionId: 'mini-session'
 		});
 		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
+		expect(mocks.requestComposerFocus).toHaveBeenCalledWith('mini-session');
+		expect(mocks.goto.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.requestComposerFocus.mock.invocationCallOrder[0]
+		);
 	});
 
 	it('creates a default-model session and opens it in the mini route', async () => {
@@ -104,8 +108,8 @@ describe('mini window sessions', () => {
 		expect(mocks.requestNewSession).toHaveBeenCalledWith('mini-session');
 		expect(mocks.requestComposerFocus).toHaveBeenCalledWith('mini-session');
 		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session');
-		expect(mocks.requestComposerFocus.mock.invocationCallOrder[0]).toBeLessThan(
-			mocks.goto.mock.invocationCallOrder[0]
+		expect(mocks.goto.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.requestComposerFocus.mock.invocationCallOrder[0]
 		);
 	});
 

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -83,8 +83,8 @@ export async function navigateMiniToSession(session: Session) {
 	shellStore.setSidebarOrderDiscordActive(isDiscordSession(session));
 	sessionVisitHistory.recordVisit(session.id);
 	await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
-	shellStore.requestComposerFocus(session.id);
 	await goto(`/mini/session/${session.id}`);
+	shellStore.requestComposerFocus(session.id);
 }
 
 /** Create and open a persisted mini-window session using the configured default model. */
@@ -95,8 +95,8 @@ export async function createMiniWindowSession() {
 		createdSessionId = session.id;
 		await window.electronAPI?.saveMiniWindowState?.({ sessionId: session.id });
 		miniShellStore.requestNewSession(session.id);
-		shellStore.requestComposerFocus(session.id);
 		await goto(`/mini/session/${session.id}`);
+		shellStore.requestComposerFocus(session.id);
 		return session;
 	} catch (error) {
 		miniShellStore.clearNewSessionRequest(createdSessionId);


### PR DESCRIPTION
## Background

Creating or switching sessions could leave focus outside the composer because the focus request ran before SvelteKit completed navigation and applied its own focus handling. The composer focus request now runs after navigation resolves for both main and mini window session flows.

[2f731a1](https://github.com/Cometline/cometline/commit/2f731a152d4337999dd5c8bea3cd5d62232e274d): Wait for session navigation to complete before targeting the destination composer, and update the navigation tests to enforce that ordering.