### PR TITLE
[main] feat: add unread session indicators

### DIFF
--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -126,6 +126,7 @@
 
 	/* Sidebar session rows — tints derive from --session-group-color (set by parent group) */
 	--session-group-color: var(--workspace-group-color);
+	--session-unread-color: #d97706;
 	--session-row-bg-hover: color-mix(in srgb, var(--session-group-color) 11%, transparent);
 	--session-row-bg-streaming: color-mix(in srgb, var(--session-group-color) 9%, transparent);
 	--session-row-bg-active: color-mix(in srgb, var(--session-group-color) 26%, transparent);

--- a/cometline/src/lib/components/sidebar/SessionRow.svelte
+++ b/cometline/src/lib/components/sidebar/SessionRow.svelte
@@ -5,6 +5,7 @@
 	import { sessionDisplayTitle } from '$lib/sessions/session-title';
 	import { chatStore } from '$lib/stores/chat.svelte';
 	import { terminalStore } from '$lib/stores/terminal.svelte';
+	import { unreadSessionOutputStore } from '$lib/stores/unread-session-output.svelte';
 
 	let {
 		session,
@@ -40,6 +41,24 @@
 		chatStore.isStreamingFor(session.id) || chatStore.hasInFlightTurn(session.id)
 	);
 	let terminalRunning = $derived(terminalStore.isRunning(session.id));
+	let unread = $derived(unreadSessionOutputStore.isUnread(session.id));
+	let activityLabel = $derived(
+		terminalRunning
+			? streaming
+				? unread
+					? 'Terminal running, responding with unread output'
+					: 'Terminal running and responding'
+				: unread
+					? 'Terminal running with unread output'
+					: 'Terminal running'
+			: streaming
+				? unread
+					? 'Responding with unread output'
+					: 'Responding'
+				: unread
+					? 'Unread output'
+					: undefined
+	);
 
 	function handleContextMenu(event: MouseEvent) {
 		event.preventDefault();
@@ -65,19 +84,14 @@
 		<span class="session-title-row">
 			<span
 				class="session-activity"
-				aria-label={terminalRunning
-					? streaming
-						? 'Terminal running and responding'
-						: 'Terminal running'
-					: streaming
-						? 'Responding'
-						: undefined}
+				aria-label={activityLabel}
 			>
 				<span
 					class:active={streaming}
 					class:terminal={terminalRunning}
+					class:unread
 					class="session-streaming"
-					title={terminalRunning ? 'Terminal running' : streaming ? 'Responding' : undefined}
+					title={activityLabel}
 				>{#if terminalRunning}<span class="terminal-marker">t</span>{/if}</span>
 			</span>
 			<span class="session-title">{sessionDisplayTitle(session.title)}</span>
@@ -216,6 +230,25 @@
 		animation: session-streaming-pulse 1.2s ease-in-out infinite;
 	}
 
+	.session-streaming.unread {
+		background: var(--session-unread-color);
+		opacity: 1;
+	}
+
+	.session-streaming.active.unread {
+		animation: none;
+		position: relative;
+	}
+
+	.session-streaming.active.unread::after {
+		content: '';
+		position: absolute;
+		inset: -3px;
+		border: 1px solid var(--session-unread-color);
+		border-radius: inherit;
+		animation: session-unread-ring 1.2s ease-in-out infinite;
+	}
+
 	.session-streaming.terminal {
 		display: inline-grid;
 		place-items: center;
@@ -231,6 +264,18 @@
 		100% {
 			opacity: 0.35;
 			transform: scale(0.85);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	@keyframes session-unread-ring {
+		0%,
+		100% {
+			opacity: 0.25;
+			transform: scale(0.82);
 		}
 		50% {
 			opacity: 1;

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -25,6 +25,7 @@ vi.mock('$lib/actions/create-new-session', () => ({ createNewSession }));
 import { getSessionMessages, listChildSessions, streamMessage } from '$lib/client/cometmind';
 import { chatStore, revealRemoteUserItems } from './chat.svelte';
 import { sessionStore } from './session.svelte';
+import { unreadSessionOutputStore } from './unread-session-output.svelte';
 import { startNewChat } from '$lib/actions/new-chat';
 
 async function flushAnimationFrames() {
@@ -175,6 +176,34 @@ describe('chatStore session switching', () => {
 
 		releaseA!();
 		await vi.waitFor(() => expect(chatStore.isStreamingFor('sess-a')).toBe(false));
+	});
+
+	it('marks background stream output unread until its session is opened', async () => {
+		let releaseA: (() => void) | undefined;
+		const aGate = new Promise<void>((resolve) => {
+			releaseA = resolve;
+		});
+
+		vi.mocked(streamMessage).mockImplementation(async function* (sessionId) {
+			if (sessionId === 'sess-a') {
+				await aGate;
+				yield { type: 'text_delta', delta: 'background answer' };
+				yield { type: 'done' };
+			}
+		});
+
+		chatStore.bindSession('sess-a');
+		const sendA = chatStore.send('sess-a', 'question A');
+		await vi.waitFor(() => expect(chatStore.isStreamingFor('sess-a')).toBe(true));
+
+		chatStore.bindSession('sess-b');
+		releaseA!();
+		await sendA;
+
+		expect(unreadSessionOutputStore.isUnread('sess-a')).toBe(true);
+
+		chatStore.bindSession('sess-a');
+		expect(unreadSessionOutputStore.isUnread('sess-a')).toBe(false);
 	});
 
 	it('allows concurrent sends in different sessions', async () => {

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -19,6 +19,7 @@ import { playResponseCompleteSound } from '$lib/sound/response-complete';
 import { settingsStore } from '$lib/stores/settings.svelte';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 import { homeRouteFor } from '$lib/routes/session-route';
+import { unreadSessionOutputStore } from '$lib/stores/unread-session-output.svelte';
 
 import { itemsFromTranscript, localID, mergeSubagents } from '$lib/stores/chat-transcript';
 import {
@@ -252,7 +253,10 @@ function createChatStore() {
 	}
 
 	function bindSession(nextSessionID: string) {
-		if (sessionID === nextSessionID) return;
+		if (sessionID === nextSessionID) {
+			unreadSessionOutputStore.markRead(nextSessionID);
+			return;
+		}
 
 		if (sessionID) {
 			const handle = streamHandles.get(sessionID);
@@ -270,6 +274,7 @@ function createChatStore() {
 		error = sessionErrors.get(nextSessionID) ?? '';
 		contextBudget = sessionContextBudgets.get(nextSessionID) ?? null;
 		isLoading = false;
+		unreadSessionOutputStore.markRead(nextSessionID);
 	}
 
 	async function loadTranscript(nextSessionID: string) {
@@ -473,6 +478,9 @@ function createChatStore() {
 			contextBudget = reduced.contextBudget;
 		}
 		writeSessionItems(targetSessionID, reduced.items);
+		if (event.type !== 'done' && sessionID !== targetSessionID) {
+			unreadSessionOutputStore.markUnread(targetSessionID);
+		}
 	}
 
 	function flushBatchForSession(targetSessionID: string, ctx: StreamCtx, handle: SessionStream) {
@@ -798,6 +806,12 @@ function createChatStore() {
 			}
 			if (message.type === 'chat-streaming') {
 				setRemoteStreamingState(message.sessionId, message.streaming);
+				return;
+			}
+			if (message.type === 'session-output-unread' && message.unread && sessionID === message.sessionId) {
+				// Another window generated output while this window is already showing
+				// the session, so keep the shared marker cleared.
+				unreadSessionOutputStore.markRead(message.sessionId);
 			}
 		});
 	}

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { AgentMode, ImageAttachment, Session } from '$lib/types';
 import type { WebContext } from '$lib/actions/start-chat';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
+import { unreadSessionOutputStore } from '$lib/stores/unread-session-output.svelte';
 
 export interface PendingMessage {
 	sessionId: string;
@@ -43,6 +44,7 @@ function createSessionStore() {
 
 	function setSessions(list: Session[]) {
 		sessions = list;
+		unreadSessionOutputStore.prune(list.map((session) => session.id));
 		if (current && !list.some((session) => session.id === current?.id)) {
 			current = null;
 		}
@@ -59,6 +61,7 @@ function createSessionStore() {
 	function removeSession(id: string, options: { broadcast?: boolean } = {}) {
 		const { broadcast = true } = options;
 		sessions = sessions.filter((item) => item.id !== id);
+		unreadSessionOutputStore.remove(id, broadcast);
 		if (current?.id === id) current = null;
 		if (broadcast) {
 			publishWindowSync({ type: 'session-remove', sessionId: id });

--- a/cometline/src/lib/stores/unread-session-output.svelte.test.ts
+++ b/cometline/src/lib/stores/unread-session-output.svelte.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+const STORAGE_KEY = 'cometline.unread-session-output.v1';
+
+function installLocalStorageMock() {
+	const store = new Map<string, string>();
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: {
+			getItem: (key: string) => store.get(key) ?? null,
+			setItem: (key: string, value: string) => store.set(key, value),
+			removeItem: (key: string) => store.delete(key),
+			clear: () => store.clear()
+		}
+	});
+}
+
+describe('unreadSessionOutputStore', () => {
+	beforeEach(() => {
+		installLocalStorageMock();
+		localStorage.clear();
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it('persists unread session IDs and clears them when read', async () => {
+		const { unreadSessionOutputStore } = await import('./unread-session-output.svelte');
+
+		unreadSessionOutputStore.markUnread('session-a');
+
+		expect(unreadSessionOutputStore.isUnread('session-a')).toBe(true);
+		expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['session-a']));
+
+		unreadSessionOutputStore.markRead('session-a');
+
+		expect(unreadSessionOutputStore.isUnread('session-a')).toBe(false);
+		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+
+	it('restores valid IDs and ignores malformed persisted values', async () => {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(['session-a', '', 42]));
+		let module = await import('./unread-session-output.svelte');
+
+		expect(module.unreadSessionOutputStore.isUnread('session-a')).toBe(true);
+		expect(module.unreadSessionOutputStore.isUnread('42')).toBe(false);
+
+		vi.resetModules();
+		localStorage.setItem(STORAGE_KEY, '{not json');
+		module = await import('./unread-session-output.svelte');
+
+		expect(module.unreadSessionOutputStore.unreadSessionIds.size).toBe(0);
+	});
+
+	it('prunes IDs for deleted sessions', async () => {
+		const { unreadSessionOutputStore } = await import('./unread-session-output.svelte');
+		unreadSessionOutputStore.markUnread('session-a');
+		unreadSessionOutputStore.markUnread('session-b');
+
+		unreadSessionOutputStore.prune(['session-b']);
+
+		expect(unreadSessionOutputStore.isUnread('session-a')).toBe(false);
+		expect(unreadSessionOutputStore.isUnread('session-b')).toBe(true);
+	});
+});

--- a/cometline/src/lib/stores/unread-session-output.svelte.ts
+++ b/cometline/src/lib/stores/unread-session-output.svelte.ts
@@ -1,0 +1,96 @@
+import { browser } from '$app/environment';
+import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
+
+const STORAGE_KEY = 'cometline.unread-session-output.v1';
+
+function storageAvailable() {
+	return typeof localStorage !== 'undefined';
+}
+
+function readUnreadSessionIds(): Set<string> {
+	if (!storageAvailable()) return new Set();
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return new Set();
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((id): id is string => typeof id === 'string' && id.trim() !== ''));
+	} catch {
+		return new Set();
+	}
+}
+
+function writeUnreadSessionIds(ids: Set<string>) {
+	if (!storageAvailable()) return;
+	if (ids.size === 0) {
+		localStorage.removeItem(STORAGE_KEY);
+		return;
+	}
+	localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+}
+
+function createUnreadSessionOutputStore() {
+	let unreadSessionIds = $state.raw(readUnreadSessionIds());
+
+	function setUnread(sessionId: string, unread: boolean, broadcast = true) {
+		const id = sessionId.trim();
+		if (!id) return;
+		const next = new Set(unreadSessionIds);
+		if (unread) {
+			next.add(id);
+		} else {
+			next.delete(id);
+		}
+		if (next.size !== unreadSessionIds.size || next.has(id) !== unreadSessionIds.has(id)) {
+			unreadSessionIds = next;
+			writeUnreadSessionIds(next);
+		}
+		if (broadcast) {
+			publishWindowSync({ type: 'session-output-unread', sessionId: id, unread });
+		}
+	}
+
+	function isUnread(sessionId: string) {
+		return unreadSessionIds.has(sessionId);
+	}
+
+	function markUnread(sessionId: string) {
+		setUnread(sessionId, true);
+	}
+
+	function markRead(sessionId: string) {
+		setUnread(sessionId, false);
+	}
+
+	function remove(sessionId: string, broadcast = true) {
+		setUnread(sessionId, false, broadcast);
+	}
+
+	function prune(sessionIds: Iterable<string>) {
+		const valid = new Set(sessionIds);
+		for (const id of unreadSessionIds) {
+			if (!valid.has(id)) remove(id);
+		}
+	}
+
+	if (browser) {
+		subscribeWindowSync((message) => {
+			if (message.type === 'session-output-unread') {
+				setUnread(message.sessionId, message.unread, false);
+			}
+		});
+	}
+
+	return {
+		get unreadSessionIds() {
+			return unreadSessionIds;
+		},
+		isUnread,
+		markUnread,
+		markRead,
+		remove,
+		prune
+	};
+}
+
+export const unreadSessionOutputStore = createUnreadSessionOutputStore();

--- a/cometline/src/lib/window-sync.ts
+++ b/cometline/src/lib/window-sync.ts
@@ -5,7 +5,8 @@ type SyncPayload =
 	| { type: 'session-upsert'; session: Session }
 	| { type: 'session-remove'; sessionId: string }
 	| { type: 'chat-items'; sessionId: string; items: ChatItem[] }
-	| { type: 'chat-streaming'; sessionId: string; streaming: boolean };
+	| { type: 'chat-streaming'; sessionId: string; streaming: boolean }
+	| { type: 'session-output-unread'; sessionId: string; unread: boolean };
 
 type SyncMessage = SyncPayload & { source: string };
 


### PR DESCRIPTION
## Background

Sessions can continue producing output after a user navigates away, leaving no durable way to distinguish finished background work from idle sessions. The sidebar now retains an orange unread marker across reloads and synchronizes it between the desktop and mini windows.

[40c2708](https://github.com/Cometline/cometline/commit/40c2708f78d9fc0c761f59a62f90163149e932ab): Adds persistent unread state for streamed session activity, clears it when a session is opened or deleted, and renders separate idle and running unread indicators. Includes chat and storage tests.