### PR TITLE
[main] feat: prune unused sessions on startup

### DIFF
--- a/cometmind/cmd/serve.go
+++ b/cometmind/cmd/serve.go
@@ -62,6 +62,14 @@ func runServe(_ *cobra.Command, _ []string) error {
 		return rt.Reload(reloadCtx)
 	})
 
+	// Remove unused New Chat rows before serving requests so the initial session
+	// list cannot include a conversation that was never started.
+	if pruned, err := rt.Sessions.PruneUnusedUserSessions(ctx); err != nil {
+		logging.L().Warn("session.unused_prune_failed", "error", err)
+	} else if pruned > 0 {
+		logging.L().Info("session.unused_pruned", "count", pruned)
+	}
+
 	// Prune workspaces whose filesystem path no longer exists. This stats every
 	// workspace path (slow on network mounts), so run it in the background to
 	// keep it off the startup critical path.

--- a/cometmind/internal/db/migrate.go
+++ b/cometmind/internal/db/migrate.go
@@ -466,6 +466,13 @@ var alterStatements = [][]string{
 	{
 		"ALTER TABLE sessions ADD COLUMN agent_mode TEXT NOT NULL DEFAULT 'auto' CHECK (agent_mode IN ('auto', 'plan'))",
 	},
+	// v27 -> v28: preserve sessions whose transcript was cleared or configured,
+	// while allowing startup cleanup to remove never-used new chats. Existing
+	// sessions are conservatively marked as non-disposable.
+	{
+		"ALTER TABLE sessions ADD COLUMN is_disposable INTEGER NOT NULL DEFAULT 1",
+		"UPDATE sessions SET is_disposable = 0",
+	},
 }
 
 // execAlter runs one incremental DDL statement, tolerating idempotent failures
@@ -504,7 +511,7 @@ func splitStatements(sql string) []string {
 	return out
 }
 
-const schemaVersion = 27
+const schemaVersion = 28
 
 // EnsureSchema runs [Migrate] once per database file using PRAGMA user_version.
 // For existing databases, it applies incremental ALTER statements to upgrade

--- a/cometmind/internal/db/migrate_test.go
+++ b/cometmind/internal/db/migrate_test.go
@@ -175,3 +175,32 @@ func TestEnsureSchemaUpgradesContextSummaryColumns(t *testing.T) {
 		}
 	}
 }
+
+func TestEnsureSchemaPreservesExistingSessionsForDisposableSessionCleanup(t *testing.T) {
+	ctx := context.Background()
+	conn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "migrate-v27.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE sessions (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(ctx, `INSERT INTO sessions (id) VALUES ('existing')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA user_version = 27"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	var isDisposable int
+	if err := conn.QueryRowContext(ctx, `SELECT is_disposable FROM sessions WHERE id = 'existing'`).Scan(&isDisposable); err != nil {
+		t.Fatal(err)
+	}
+	if isDisposable != 0 {
+		t.Fatalf("is_disposable = %d, want 0", isDisposable)
+	}
+}

--- a/cometmind/internal/db/models.go
+++ b/cometmind/internal/db/models.go
@@ -177,6 +177,7 @@ type Session struct {
 	ProviderID              string         `json:"provider_id"`
 	Status                  string         `json:"status"`
 	Origin                  string         `json:"origin"`
+	IsDisposable            int64          `json:"is_disposable"`
 	TokenUsage              string         `json:"token_usage"`
 	ParentSessionID         sql.NullString `json:"parent_session_id"`
 	Purpose                 string         `json:"purpose"`

--- a/cometmind/internal/db/queries/sessions.sql
+++ b/cometmind/internal/db/queries/sessions.sql
@@ -76,6 +76,26 @@ LIMIT 1;
 DELETE FROM sessions
 WHERE id = ?;
 
+-- name: MarkSessionNonDisposable :exec
+UPDATE sessions
+SET is_disposable = 0
+WHERE id = ?;
+
+-- name: ListUnusedUserSessionIDs :many
+-- A session is unused only if it is still disposable and has no messages.
+-- This deliberately preserves sessions that were configured or later cleared.
+SELECT s.id
+FROM sessions s
+WHERE s.origin = 'user'
+  AND s.parent_session_id IS NULL
+  AND s.is_disposable = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM messages m
+      WHERE m.session_id = s.id
+  )
+ORDER BY s.created_at ASC;
+
 -- name: ListSessionsByWorkspaceAsc :many
 SELECT id, updated_at, delegation_status, parent_session_id
 FROM sessions
@@ -143,6 +163,7 @@ ORDER BY s.pinned DESC, s.updated_at DESC;
 UPDATE sessions
 SET
     title = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?;
 
@@ -153,6 +174,7 @@ WHERE id = ?;
 UPDATE sessions
 SET
     title = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
   AND trim(title) = '';
@@ -169,6 +191,7 @@ UPDATE sessions
 SET
     model_id = ?,
     provider_id = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?;
 
@@ -176,6 +199,7 @@ WHERE id = ?;
 UPDATE sessions
 SET
     pinned = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?;
 
@@ -183,6 +207,7 @@ WHERE id = ?;
 UPDATE sessions
 SET
     agent_mode = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
 RETURNING *;
@@ -191,6 +216,7 @@ RETURNING *;
 UPDATE sessions
 SET
     workspace_id = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?;
 

--- a/cometmind/internal/db/schema.sql
+++ b/cometmind/internal/db/schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE sessions (
                        CHECK (status IN ('active', 'archived')),
     origin             TEXT NOT NULL DEFAULT 'user'
                        CHECK (origin IN ('user', 'autonomy', 'inbox')),
+    is_disposable      INTEGER NOT NULL DEFAULT 1,
     token_usage        TEXT NOT NULL DEFAULT '{}',
     parent_session_id  TEXT REFERENCES sessions (id) ON DELETE SET NULL,
     purpose            TEXT NOT NULL DEFAULT '',

--- a/cometmind/internal/db/sessions.sql.go
+++ b/cometmind/internal/db/sessions.sql.go
@@ -42,7 +42,7 @@ INSERT INTO sessions (
     agent_mode
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 `
 
 type CreateChildSessionParams struct {
@@ -84,6 +84,7 @@ func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSession
 		&i.ProviderID,
 		&i.Status,
 		&i.Origin,
+		&i.IsDisposable,
 		&i.TokenUsage,
 		&i.ParentSessionID,
 		&i.Purpose,
@@ -106,7 +107,7 @@ func (q *Queries) CreateChildSession(ctx context.Context, arg CreateChildSession
 const createSession = `-- name: CreateSession :one
 INSERT INTO sessions (id, workspace_id, title, model_id, provider_id, status, origin, agent_mode)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 `
 
 type CreateSessionParams struct {
@@ -140,6 +141,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.ProviderID,
 		&i.Status,
 		&i.Origin,
+		&i.IsDisposable,
 		&i.TokenUsage,
 		&i.ParentSessionID,
 		&i.Purpose,
@@ -170,7 +172,7 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 }
 
 const getActiveChildForParent = `-- name: GetActiveChildForParent :one
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE
     parent_session_id = ?
@@ -190,6 +192,7 @@ func (q *Queries) GetActiveChildForParent(ctx context.Context, parentSessionID s
 		&i.ProviderID,
 		&i.Status,
 		&i.Origin,
+		&i.IsDisposable,
 		&i.TokenUsage,
 		&i.ParentSessionID,
 		&i.Purpose,
@@ -211,7 +214,7 @@ func (q *Queries) GetActiveChildForParent(ctx context.Context, parentSessionID s
 
 const getSession = `-- name: GetSession :one
 SELECT
-    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
+    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.is_disposable, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
     COALESCE(g.platform, '') AS gateway_platform,
     COALESCE(g.platform_channel_id, '') AS gateway_channel_id,
     COALESCE(g.thread_id, '') AS gateway_thread_id
@@ -240,6 +243,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, err
 		&i.Session.ProviderID,
 		&i.Session.Status,
 		&i.Session.Origin,
+		&i.Session.IsDisposable,
 		&i.Session.TokenUsage,
 		&i.Session.ParentSessionID,
 		&i.Session.Purpose,
@@ -264,7 +268,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, err
 
 const listAllSessions = `-- name: ListAllSessions :many
 SELECT
-    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
+    s.id, s.workspace_id, s.title, s.model_id, s.provider_id, s.status, s.origin, s.is_disposable, s.token_usage, s.parent_session_id, s.purpose, s.delegation_status, s.output_summary, s.acp_session_id, s.pending_question, s.subagent_kind, s.agent_mode, s.pinned, s.context_summary, s.compacted_until_message_id, s.context_summary_updated_at, s.created_at, s.updated_at,
     COALESCE(g.platform, '') AS gateway_platform,
     COALESCE(g.platform_channel_id, '') AS gateway_channel_id,
     COALESCE(g.thread_id, '') AS gateway_thread_id
@@ -300,6 +304,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 			&i.Session.ProviderID,
 			&i.Session.Status,
 			&i.Session.Origin,
+			&i.Session.IsDisposable,
 			&i.Session.TokenUsage,
 			&i.Session.ParentSessionID,
 			&i.Session.Purpose,
@@ -333,7 +338,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 }
 
 const listChildSessions = `-- name: ListChildSessions :many
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE parent_session_id = ?
 ORDER BY created_at ASC
@@ -356,6 +361,7 @@ func (q *Queries) ListChildSessions(ctx context.Context, parentSessionID sql.Nul
 			&i.ProviderID,
 			&i.Status,
 			&i.Origin,
+			&i.IsDisposable,
 			&i.TokenUsage,
 			&i.ParentSessionID,
 			&i.Purpose,
@@ -386,7 +392,7 @@ func (q *Queries) ListChildSessions(ctx context.Context, parentSessionID sql.Nul
 }
 
 const listSessionsByWorkspace = `-- name: ListSessionsByWorkspace :many
-SELECT id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+SELECT id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 FROM sessions
 WHERE workspace_id = ?
 ORDER BY pinned DESC, updated_at DESC
@@ -409,6 +415,7 @@ func (q *Queries) ListSessionsByWorkspace(ctx context.Context, workspaceID strin
 			&i.ProviderID,
 			&i.Status,
 			&i.Origin,
+			&i.IsDisposable,
 			&i.TokenUsage,
 			&i.ParentSessionID,
 			&i.Purpose,
@@ -554,6 +561,56 @@ func (q *Queries) ListStaleSessionIDs(ctx context.Context, arg ListStaleSessionI
 	return items, nil
 }
 
+const listUnusedUserSessionIDs = `-- name: ListUnusedUserSessionIDs :many
+SELECT s.id
+FROM sessions s
+WHERE s.origin = 'user'
+  AND s.parent_session_id IS NULL
+  AND s.is_disposable = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM messages m
+      WHERE m.session_id = s.id
+  )
+ORDER BY s.created_at ASC
+`
+
+// A session is unused only if it is still disposable and has no messages.
+// This deliberately preserves sessions that were configured or later cleared.
+func (q *Queries) ListUnusedUserSessionIDs(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listUnusedUserSessionIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const markSessionNonDisposable = `-- name: MarkSessionNonDisposable :exec
+UPDATE sessions
+SET is_disposable = 0
+WHERE id = ?
+`
+
+func (q *Queries) MarkSessionNonDisposable(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, markSessionNonDisposable, id)
+	return err
+}
+
 const resetSessionTranscriptState = `-- name: ResetSessionTranscriptState :exec
 UPDATE sessions
 SET
@@ -581,6 +638,7 @@ const setTitleIfEmpty = `-- name: SetTitleIfEmpty :exec
 UPDATE sessions
 SET
     title = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
   AND trim(title) = ''
@@ -632,9 +690,10 @@ const updateSessionAgentMode = `-- name: UpdateSessionAgentMode :one
 UPDATE sessions
 SET
     agent_mode = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
-RETURNING id, workspace_id, title, model_id, provider_id, status, origin, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
+RETURNING id, workspace_id, title, model_id, provider_id, status, origin, is_disposable, token_usage, parent_session_id, purpose, delegation_status, output_summary, acp_session_id, pending_question, subagent_kind, agent_mode, pinned, context_summary, compacted_until_message_id, context_summary_updated_at, created_at, updated_at
 `
 
 type UpdateSessionAgentModeParams struct {
@@ -653,6 +712,7 @@ func (q *Queries) UpdateSessionAgentMode(ctx context.Context, arg UpdateSessionA
 		&i.ProviderID,
 		&i.Status,
 		&i.Origin,
+		&i.IsDisposable,
 		&i.TokenUsage,
 		&i.ParentSessionID,
 		&i.Purpose,
@@ -751,6 +811,7 @@ UPDATE sessions
 SET
     model_id = ?,
     provider_id = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
 `
@@ -770,6 +831,7 @@ const updateSessionPinned = `-- name: UpdateSessionPinned :exec
 UPDATE sessions
 SET
     pinned = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
 `
@@ -806,6 +868,7 @@ const updateSessionTitle = `-- name: UpdateSessionTitle :exec
 UPDATE sessions
 SET
     title = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
 `
@@ -842,6 +905,7 @@ const updateSessionWorkspace = `-- name: UpdateSessionWorkspace :exec
 UPDATE sessions
 SET
     workspace_id = ?,
+    is_disposable = 0,
     updated_at = unixepoch ('now', 'subsec') * 1000
 WHERE id = ?
 `

--- a/cometmind/internal/session/service.go
+++ b/cometmind/internal/session/service.go
@@ -299,7 +299,7 @@ func (s *Service) ForkSession(ctx context.Context, sessionID, absPath string) (S
 			}
 			content = remapped
 		}
-		newMsg, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+		newMsg, err := s.createMessage(ctx, db.CreateMessageParams{
 			ID:               id.New(),
 			SessionID:        forked.ID,
 			Role:             msg.Role,
@@ -366,7 +366,7 @@ func remapToolResultContent(content string, idMap map[string]string) (string, er
 
 // AppendSystemMessage persists a system notice in the transcript.
 func (s *Service) AppendSystemMessage(ctx context.Context, sessionID, text string) (Message, error) {
-	msg, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+	msg, err := s.createMessage(ctx, db.CreateMessageParams{
 		ID:         id.New(),
 		SessionID:  sessionID,
 		Role:       "system",
@@ -380,6 +380,13 @@ func (s *Service) AppendSystemMessage(ctx context.Context, sessionID, text strin
 		return Message{}, err
 	}
 	return messageFromDB(msg), nil
+}
+
+func (s *Service) createMessage(ctx context.Context, params db.CreateMessageParams) (db.Message, error) {
+	if err := s.q.MarkSessionNonDisposable(ctx, params.SessionID); err != nil {
+		return db.Message{}, err
+	}
+	return s.q.CreateMessage(ctx, params)
 }
 
 // AppendErrorMessage persists a turn-level error notice for transcript replay.
@@ -505,6 +512,21 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	}
 	_ = media.DeleteSession(sessionID)
 	return s.q.DeleteSession(ctx, sessionID)
+}
+
+// PruneUnusedUserSessions removes top-level user sessions that were created
+// but never changed or given a transcript. Cleared conversations are retained.
+func (s *Service) PruneUnusedUserSessions(ctx context.Context) (int, error) {
+	ids, err := s.q.ListUnusedUserSessionIDs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if err := s.DeleteSession(ctx, id); err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
 }
 
 // ClearSessionTranscript deletes all transcript rows for a session and resets
@@ -661,7 +683,7 @@ func (s *Service) AppendUserMessageContent(ctx context.Context, sessionID string
 	if err != nil {
 		return Message{}, err
 	}
-	msg, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+	msg, err := s.createMessage(ctx, db.CreateMessageParams{
 		ID:         id.New(),
 		SessionID:  sessionID,
 		Role:       "user",
@@ -886,7 +908,7 @@ func (s *Service) AppendAssistantStep(ctx context.Context, sessionID string, tex
 	if err != nil {
 		return Message{}, nil, fmt.Errorf("marshal injected memories: %w", err)
 	}
-	assistant, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+	assistant, err := s.createMessage(ctx, db.CreateMessageParams{
 		ID:               id.New(),
 		SessionID:        sessionID,
 		Role:             "assistant",
@@ -955,7 +977,7 @@ func (s *Service) AppendAssistantMedia(ctx context.Context, sessionID string, im
 	if err != nil {
 		return Message{}, err
 	}
-	assistant, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+	assistant, err := s.createMessage(ctx, db.CreateMessageParams{
 		ID:         id.New(),
 		SessionID:  sessionID,
 		Role:       "assistant",
@@ -1020,7 +1042,7 @@ func (s *Service) AppendToolResultMessage(ctx context.Context, sessionID, toolCa
 	if err != nil {
 		return Message{}, err
 	}
-	msg, err := s.q.CreateMessage(ctx, db.CreateMessageParams{
+	msg, err := s.createMessage(ctx, db.CreateMessageParams{
 		ID:         id.New(),
 		SessionID:  sessionID,
 		Role:       "tool_result",

--- a/cometmind/internal/session/unused_session_test.go
+++ b/cometmind/internal/session/unused_session_test.go
@@ -1,0 +1,116 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/db"
+	_ "modernc.org/sqlite"
+)
+
+func TestPruneUnusedUserSessions(t *testing.T) {
+	ctx := context.Background()
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := db.EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := New(conn)
+	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unused, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	used, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.AppendUserMessage(ctx, used.ID, "hello"); err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.AppendUserMessage(ctx, cleared.ID, "clear me"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.ClearSessionTranscript(ctx, cleared.ID); err != nil {
+		t.Fatal(err)
+	}
+	configuredModel, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateSessionModel(ctx, configuredModel.ID, "other-model", "other-provider"); err != nil {
+		t.Fatal(err)
+	}
+	configuredMode, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateSessionAgentMode(ctx, configuredMode.ID, AgentModePlan); err != nil {
+		t.Fatal(err)
+	}
+	configuredPinned, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateSessionPinned(ctx, configuredPinned.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	configuredTitle, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateSessionTitle(ctx, configuredTitle.ID, "planned chat"); err != nil {
+		t.Fatal(err)
+	}
+	child, err := svc.NewChildSession(ctx, used, "task", "general")
+	if err != nil {
+		t.Fatal(err)
+	}
+	autonomous, err := svc.NewAutonomySession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := svc.NewInboxSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := svc.PruneUnusedUserSessions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != 1 {
+		t.Fatalf("PruneUnusedUserSessions() = %d, want 1", pruned)
+	}
+	if _, err := svc.GetSession(ctx, unused.ID); err == nil {
+		t.Fatal("expected unused session to be deleted")
+	}
+	for _, id := range []string{
+		used.ID,
+		cleared.ID,
+		configuredModel.ID,
+		configuredMode.ID,
+		configuredPinned.ID,
+		configuredTitle.ID,
+		child.ID,
+		autonomous.ID,
+		inbox.ID,
+	} {
+		if _, err := svc.GetSession(ctx, id); err != nil {
+			t.Fatalf("expected session %q to be preserved: %v", id, err)
+		}
+	}
+}


### PR DESCRIPTION
## Background

Empty New Chat sessions accumulate when users leave them without sending a message. The sidecar now removes only disposable sessions before serving its initial session list.

[2bda075](https://github.com/Cometline/cometline/commit/2bda075850ee79c34ff304a7e4243e7b51048c72): Adds a migration-backed disposable-session marker, removes unused user sessions at sidecar startup, and keeps sessions after a transcript or persisted configuration change. Includes migration and lifecycle coverage.