### PR TITLE
[main] feat: restore last session on startup

### DIFF
--- a/cometline/src/lib/actions/bootstrap-home-session.test.ts
+++ b/cometline/src/lib/actions/bootstrap-home-session.test.ts
@@ -1,55 +1,106 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { bootstrapHomeSession } from './bootstrap-home-session';
+import type { Session } from '$lib/types';
+import { bootstrapHomeSession, type BootstrapHomeSessionDeps } from './bootstrap-home-session';
 
 describe('bootstrapHomeSession', () => {
 	const startNewChat = vi.fn();
+	const navigateToSession = vi.fn();
+	const mostRecentSessionId = vi.fn();
+
+	function session(id: string, updatedAt: number): Session {
+		return {
+			id,
+			workspace_id: 'workspace-1',
+			workspace_path: '/ws',
+			title: id,
+			model_id: 'model',
+			provider_id: 'provider',
+			status: 'active',
+			origin: 'user',
+			token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+			pinned: false,
+			agent_mode: 'auto',
+			created_at: 0,
+			updated_at: updatedAt
+		};
+	}
+
+	function deps(overrides: Partial<BootstrapHomeSessionDeps> = {}): BootstrapHomeSessionDeps {
+		return {
+			connectionStatus: () => 'ready',
+			workspacePath: () => '/ws',
+			sessionsLoaded: () => true,
+			sessions: () => [],
+			mostRecentSessionId,
+			navigateToSession,
+			startNewChat,
+			...overrides
+		};
+	}
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		startNewChat.mockResolvedValue(undefined);
+		navigateToSession.mockResolvedValue(undefined);
+		mostRecentSessionId.mockReturnValue(null);
 	});
 
 	it('skips when the sidecar is not ready', async () => {
 		await expect(
-			bootstrapHomeSession({
+			bootstrapHomeSession(deps({
 				connectionStatus: () => 'connecting',
-				workspacePath: () => '/ws',
-				startNewChat
-			})
+			}))
 		).resolves.toBe(false);
 		expect(startNewChat).not.toHaveBeenCalled();
 	});
 
 	it('skips when workspace is unset', async () => {
 		await expect(
-			bootstrapHomeSession({
-				connectionStatus: () => 'ready',
+			bootstrapHomeSession(deps({
 				workspacePath: () => '/',
-				startNewChat
-			})
+			}))
 		).resolves.toBe(false);
 		expect(startNewChat).not.toHaveBeenCalled();
 	});
 
-	it('creates a session when ready', async () => {
+	it('waits for the session list before choosing a session', async () => {
 		await expect(
-			bootstrapHomeSession({
-				connectionStatus: () => 'ready',
-				workspacePath: () => '/ws',
-				startNewChat
-			})
-		).resolves.toBe(true);
+			bootstrapHomeSession(deps({ sessionsLoaded: () => false }))
+		).resolves.toBe(false);
+		expect(startNewChat).not.toHaveBeenCalled();
+		expect(navigateToSession).not.toHaveBeenCalled();
+	});
+
+	it('creates a session when no sessions exist', async () => {
+		await expect(bootstrapHomeSession(deps())).resolves.toBe(true);
 		expect(startNewChat).toHaveBeenCalledOnce();
+	});
+
+	it('restores the persisted most recently visited session', async () => {
+		const sessions = [session('older', 1), session('last-visited', 2)];
+		mostRecentSessionId.mockImplementation((exists) =>
+			exists('last-visited') ? 'last-visited' : null
+		);
+
+		await expect(bootstrapHomeSession(deps({ sessions: () => sessions }))).resolves.toBe(true);
+
+		expect(navigateToSession).toHaveBeenCalledWith(sessions[1]);
+		expect(startNewChat).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the most recently active existing session', async () => {
+		const sessions = [session('newer', 3), session('pinned-but-older', 1)];
+
+		await expect(bootstrapHomeSession(deps({ sessions: () => sessions }))).resolves.toBe(true);
+
+		expect(navigateToSession).toHaveBeenCalledWith(sessions[0]);
+		expect(startNewChat).not.toHaveBeenCalled();
 	});
 
 	it('propagates create failures', async () => {
 		startNewChat.mockRejectedValueOnce(new Error('no model'));
 		await expect(
-			bootstrapHomeSession({
-				connectionStatus: () => 'ready',
-				workspacePath: () => '/ws',
-				startNewChat
-			})
+			bootstrapHomeSession(deps())
 		).rejects.toThrow('no model');
 	});
 });

--- a/cometline/src/lib/actions/bootstrap-home-session.ts
+++ b/cometline/src/lib/actions/bootstrap-home-session.ts
@@ -1,22 +1,34 @@
 import { startNewChat } from '$lib/actions/new-chat';
+import { navigateToSession } from '$lib/actions/navigate-to-session';
 import { connectionState } from '$lib/stores/runtime.svelte';
+import { sessionStore } from '$lib/stores/session.svelte';
+import { sessionVisitHistory } from '$lib/stores/session-visit-history.svelte';
 import { shellStore } from '$lib/stores/shell.svelte';
+import type { Session } from '$lib/types';
 
 export type BootstrapHomeSessionDeps = {
 	connectionStatus: () => typeof connectionState.status;
 	workspacePath: () => string;
+	sessionsLoaded: () => boolean;
+	sessions: () => readonly Session[];
+	mostRecentSessionId: (exists: (sessionId: string) => boolean) => string | null;
+	navigateToSession: (session: Session) => Promise<unknown>;
 	startNewChat: () => Promise<unknown>;
 };
 
 const defaultDeps: BootstrapHomeSessionDeps = {
 	connectionStatus: () => connectionState.status,
 	workspacePath: () => shellStore.defaultWorkspacePath || shellStore.workspacePath,
+	sessionsLoaded: () => sessionStore.loaded,
+	sessions: () => sessionStore.sessions,
+	mostRecentSessionId: (exists) => sessionVisitHistory.mostRecent(exists),
+	navigateToSession,
 	startNewChat
 };
 
 /**
- * When the home route is ready (sidecar up + workspace set), create a persisted
- * session and navigate to it — same as New Chat. Returns false when skipped.
+ * When the home route is ready, restore the most recently visited session. If
+ * no sessions exist, create and navigate to one — same as New Chat.
  */
 export async function bootstrapHomeSession(
 	deps: BootstrapHomeSessionDeps = defaultDeps
@@ -24,6 +36,24 @@ export async function bootstrapHomeSession(
 	if (deps.connectionStatus() !== 'ready') return false;
 	const workspace = deps.workspacePath().trim();
 	if (!workspace || workspace === '/') return false;
+	if (!deps.sessionsLoaded()) return false;
+
+	const sessions = deps.sessions();
+	const sessionExists = (sessionId: string) => sessions.some((session) => session.id === sessionId);
+	const recentSessionId = deps.mostRecentSessionId(sessionExists);
+	const recentSession = recentSessionId
+		? sessions.find((session) => session.id === recentSessionId)
+		: undefined;
+	const fallbackSession = sessions.reduce<Session | undefined>((latest, session) => {
+		if (!latest || session.updated_at > latest.updated_at) return session;
+		return latest;
+	}, undefined);
+
+	if (recentSession ?? fallbackSession) {
+		await deps.navigateToSession(recentSession ?? fallbackSession!);
+		return true;
+	}
+
 	await deps.startNewChat();
 	return true;
 }

--- a/cometline/src/lib/actions/navigate-to-session.test.ts
+++ b/cometline/src/lib/actions/navigate-to-session.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
 	setSidebarOrderWorkspacePath: vi.fn(),
 	setSidebarOrderDiscordActive: vi.fn(),
 	requestComposerFocus: vi.fn(),
+	markActive: vi.fn(),
 	recordVisit: vi.fn()
 }));
 
@@ -29,7 +30,7 @@ vi.mock('$lib/stores/shell.svelte', () => ({
 	}
 }));
 vi.mock('$lib/stores/session-visit-history.svelte', () => ({
-	sessionVisitHistory: { recordVisit: mocks.recordVisit }
+	sessionVisitHistory: { markActive: mocks.markActive, recordVisit: mocks.recordVisit }
 }));
 
 import { navigateToSession } from './navigate-to-session';
@@ -121,5 +122,6 @@ describe('navigateToSession sidebar order', () => {
 	it('skips visit recording when navigating from history', async () => {
 		await navigateToSession(session(), { fromHistory: true });
 		expect(mocks.recordVisit).not.toHaveBeenCalled();
+		expect(mocks.markActive).toHaveBeenCalledWith('sess-1');
 	});
 });

--- a/cometline/src/lib/actions/navigate-to-session.ts
+++ b/cometline/src/lib/actions/navigate-to-session.ts
@@ -33,6 +33,9 @@ export async function navigateToSession(session: Session, options: NavigateToSes
 
 	if (!options.fromHistory) {
 		sessionVisitHistory.recordVisit(session.id);
+	} else {
+		// Keep the back/forward stack intact while restoring this session on relaunch.
+		sessionVisitHistory.markActive(session.id);
 	}
 
 	await goto(`/session/${session.id}`);

--- a/cometline/src/lib/stores/session-visit-history.svelte.test.ts
+++ b/cometline/src/lib/stores/session-visit-history.svelte.test.ts
@@ -1,9 +1,30 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { sessionVisitHistory } from './session-visit-history.svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	LAST_VISITED_SESSION_STORAGE_KEY,
+	sessionVisitHistory
+} from './session-visit-history.svelte';
 
 describe('sessionVisitHistory', () => {
+	let stored: Record<string, string>;
+
 	beforeEach(() => {
+		stored = {};
+		vi.stubGlobal('window', {
+			localStorage: {
+				getItem: (key: string) => stored[key] ?? null,
+				setItem: (key: string, value: string) => {
+					stored[key] = value;
+				},
+				removeItem: (key: string) => {
+					delete stored[key];
+				}
+			}
+		});
 		sessionVisitHistory.reset();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it('records visits and truncates the forward stack', () => {
@@ -61,5 +82,31 @@ describe('sessionVisitHistory', () => {
 		expect(sessionVisitHistory.mostRecent(exists)).toBe('a');
 		expect(sessionVisitHistory.stack).toEqual(['a', 'gone']);
 		expect(sessionVisitHistory.index).toBe(1);
+	});
+
+	it('restores the last visit from browser storage after a restart', () => {
+		sessionVisitHistory.recordVisit('persisted');
+		expect(stored[LAST_VISITED_SESSION_STORAGE_KEY]).toBe('persisted');
+
+		sessionVisitHistory.reset();
+		expect(sessionVisitHistory.mostRecent((id) => id === 'persisted')).toBe('persisted');
+	});
+
+	it('persists history navigation without changing the visit stack', () => {
+		sessionVisitHistory.recordVisit('a');
+		sessionVisitHistory.recordVisit('b');
+		expect(sessionVisitHistory.goBack(() => true)).toBe('a');
+
+		sessionVisitHistory.markActive('a');
+		expect(sessionVisitHistory.stack).toEqual(['a', 'b']);
+		expect(sessionVisitHistory.index).toBe(0);
+		expect(stored[LAST_VISITED_SESSION_STORAGE_KEY]).toBe('a');
+	});
+
+	it('clears a stale persisted visit', () => {
+		stored[LAST_VISITED_SESSION_STORAGE_KEY] = 'gone';
+
+		expect(sessionVisitHistory.mostRecent(() => false)).toBeNull();
+		expect(stored[LAST_VISITED_SESSION_STORAGE_KEY]).toBeUndefined();
 	});
 });

--- a/cometline/src/lib/stores/session-visit-history.svelte.ts
+++ b/cometline/src/lib/stores/session-visit-history.svelte.ts
@@ -1,11 +1,53 @@
 const MAX_VISIT_HISTORY = 50;
+export const LAST_VISITED_SESSION_STORAGE_KEY = 'cometline:last-active-session-id';
+
+function browserStorage(): Storage | null {
+	if (typeof window === 'undefined') return null;
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function readPersistedSessionId(): string | null {
+	try {
+		const sessionId = browserStorage()?.getItem(LAST_VISITED_SESSION_STORAGE_KEY)?.trim();
+		return sessionId || null;
+	} catch {
+		return null;
+	}
+}
+
+function persistSessionId(sessionId: string) {
+	try {
+		browserStorage()?.setItem(LAST_VISITED_SESSION_STORAGE_KEY, sessionId);
+	} catch {
+		// Session navigation must still work when browser storage is unavailable.
+	}
+}
+
+function clearPersistedSessionId() {
+	try {
+		browserStorage()?.removeItem(LAST_VISITED_SESSION_STORAGE_KEY);
+	} catch {
+		// A stale value is harmless when browser storage is unavailable.
+	}
+}
 
 function createSessionVisitHistoryStore() {
 	let stack = $state<string[]>([]);
 	let index = $state(-1);
 
-	function recordVisit(sessionId: string) {
+	function markActive(sessionId: string): string | null {
 		const id = sessionId.trim();
+		if (!id) return null;
+		persistSessionId(id);
+		return id;
+	}
+
+	function recordVisit(sessionId: string) {
+		const id = markActive(sessionId);
 		if (!id) return;
 		if (stack[index] === id) return;
 
@@ -43,6 +85,11 @@ function createSessionVisitHistoryStore() {
 
 	/** Peek the current visit pointer (or older entries) without moving history. */
 	function mostRecent(exists: (sessionId: string) => boolean): string | null {
+		if (stack.length === 0) {
+			const persisted = readPersistedSessionId();
+			if (persisted && exists(persisted)) return persisted;
+			if (persisted) clearPersistedSessionId();
+		}
 		for (let i = index; i >= 0; i -= 1) {
 			const id = stack[i];
 			if (exists(id)) return id;
@@ -68,6 +115,7 @@ function createSessionVisitHistoryStore() {
 		get canGoForward() {
 			return index >= 0 && index < stack.length - 1;
 		},
+		markActive,
 		recordVisit,
 		goBack,
 		goForward,

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -16,6 +16,7 @@ export interface PendingMessage {
 
 function createSessionStore() {
 	let sessions = $state<Session[]>([]);
+	let loaded = $state(false);
 	let current = $state<Session | null>(null);
 	let pendingMessages = $state.raw(new Map<string, Omit<PendingMessage, 'sessionId'>>());
 
@@ -44,6 +45,7 @@ function createSessionStore() {
 
 	function setSessions(list: Session[]) {
 		sessions = list;
+		loaded = true;
 		unreadSessionOutputStore.prune(list.map((session) => session.id));
 		if (current && !list.some((session) => session.id === current?.id)) {
 			current = null;
@@ -124,6 +126,9 @@ function createSessionStore() {
 	return {
 		get sessions() {
 			return sessions;
+		},
+		get loaded() {
+			return loaded;
 		},
 		get current() {
 			return current;

--- a/cometline/src/routes/+page.svelte
+++ b/cometline/src/routes/+page.svelte
@@ -41,6 +41,7 @@
 		const tryBootstrap = () => {
 			if (cancelled || attempted || bootstrapping) return;
 			if (connectionState.status !== 'ready') return;
+			if (!sessionStore.loaded) return;
 			const workspace = shellStore.defaultWorkspacePath || shellStore.workspacePath;
 			if (!workspace || workspace === '/') return;
 


### PR DESCRIPTION
## Background

Cometline currently creates a new session whenever the desktop restarts, even when the user already has existing conversations. The startup flow now returns to the last interacted session and only creates a new session when no sessions exist.

[49e88a0](https://github.com/Cometline/cometline/commit/49e88a0a3b146f3c940119d020885894fe7d0434): Persist the last active session ID, wait for the session list before bootstrapping, restore the saved session when available, and fall back to the most recently active session or a new session.
