### PR TITLE
[main] feat: preview workspace PDF documents

### DIFF
--- a/cometline/electron/src/domains/ipc.ts
+++ b/cometline/electron/src/domains/ipc.ts
@@ -25,6 +25,8 @@ export interface IpcHandlers {
 	filterExistingWorkspacePaths: Invoker;
 	pruneWorkspaceStore: Invoker;
 	readWorkspaceFile: Invoker;
+	createPdfPreview: Invoker;
+	revokePdfPreview: Invoker;
 	terminalList: Invoker;
 	terminalCreate: Invoker;
 	terminalWrite: Invoker;
@@ -92,9 +94,14 @@ export function registerIpcHandlers(handlers: IpcHandlers) {
 	ipcMain.handle('cometline:watch-workspace', handlers.watchWorkspace);
 	ipcMain.handle('cometline:list-recent-workspaces', handlers.listRecentWorkspaces);
 	ipcMain.handle('cometline:remove-recent-workspace-path', handlers.removeRecentWorkspacePath);
-	ipcMain.handle('cometline:filter-existing-workspace-paths', handlers.filterExistingWorkspacePaths);
+	ipcMain.handle(
+		'cometline:filter-existing-workspace-paths',
+		handlers.filterExistingWorkspacePaths
+	);
 	ipcMain.handle('cometline:prune-workspace-store', handlers.pruneWorkspaceStore);
 	ipcMain.handle('cometline:read-workspace-file', handlers.readWorkspaceFile);
+	ipcMain.handle('cometline:create-pdf-preview', handlers.createPdfPreview);
+	ipcMain.handle('cometline:revoke-pdf-preview', handlers.revokePdfPreview);
 	ipcMain.handle('cometline:terminal-list', handlers.terminalList);
 	ipcMain.handle('cometline:terminal-create', handlers.terminalCreate);
 	ipcMain.handle('cometline:terminal-write', handlers.terminalWrite);

--- a/cometline/electron/src/domains/pdf-preview.test.ts
+++ b/cometline/electron/src/domains/pdf-preview.test.ts
@@ -1,0 +1,214 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	PDF_PREVIEW_MAX_BYTES,
+	PDF_PREVIEW_SCHEME,
+	createPdfPreviewRegistry,
+	registerPdfPreviewProtocol
+} from './pdf-preview.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0))
+		fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function fixture() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-pdf-preview-'));
+	const workspace = path.join(root, 'workspace');
+	const wiki = path.join(root, 'wiki');
+	fs.mkdirSync(workspace);
+	fs.mkdirSync(wiki);
+	fs.writeFileSync(path.join(workspace, 'report.pdf'), '%PDF-1.7');
+	fs.writeFileSync(path.join(workspace, 'notes.txt'), 'nope');
+	fs.writeFileSync(path.join(wiki, 'paper.pdf'), '%PDF-1.7');
+	temporaryDirectories.push(root);
+	return { root, workspace, wiki };
+}
+
+describe('PDF preview registry', () => {
+	it('creates exact-file workspace and wiki grants without exposing local paths', async () => {
+		const { workspace, wiki } = fixture();
+		const registry = createPdfPreviewRegistry({
+			fs,
+			path,
+			wikiRoot: wiki,
+			randomUUID: () => 'token'
+		});
+
+		const workspaceResult = await registry.create({
+			scope: 'workspace',
+			workspacePath: workspace,
+			relativePath: 'report.pdf'
+		});
+		expect(workspaceResult).toEqual({
+			ok: true,
+			token: 'token',
+			url: `${PDF_PREVIEW_SCHEME}://pdf/token/report.pdf`
+		});
+		expect(JSON.stringify(workspaceResult)).not.toContain(workspace);
+
+		const wikiResult = await registry.create({ scope: 'wiki', relativePath: 'paper.pdf' });
+		expect(wikiResult.ok).toBe(true);
+	});
+
+	it('rejects non-PDF files, traversal, symlink escapes, and oversized PDFs', async () => {
+		const { root, workspace, wiki } = fixture();
+		const outside = path.join(root, 'outside.pdf');
+		fs.writeFileSync(outside, '%PDF');
+		fs.symlinkSync(outside, path.join(workspace, 'link.pdf'));
+		fs.writeFileSync(path.join(workspace, 'large.pdf'), '');
+		fs.truncateSync(path.join(workspace, 'large.pdf'), PDF_PREVIEW_MAX_BYTES + 1);
+		const registry = createPdfPreviewRegistry({ fs, path, wikiRoot: wiki });
+
+		await expect(
+			registry.create({
+				scope: 'workspace',
+				workspacePath: 'relative/workspace',
+				relativePath: 'report.pdf'
+			})
+		).resolves.toEqual({ ok: false, error: 'Invalid preview root' });
+		await expect(
+			registry.create({
+				scope: 'workspace',
+				workspacePath: workspace,
+				relativePath: 'notes.txt'
+			})
+		).resolves.toEqual({ ok: false, error: 'Only PDF files can use PDF preview' });
+		await expect(
+			registry.create({
+				scope: 'workspace',
+				workspacePath: workspace,
+				relativePath: '../outside.pdf'
+			})
+		).resolves.toEqual({ ok: false, error: 'Path escapes workspace' });
+		await expect(
+			registry.create({
+				scope: 'workspace',
+				workspacePath: workspace,
+				relativePath: 'link.pdf'
+			})
+		).resolves.toEqual({ ok: false, error: 'Path escapes workspace' });
+		await expect(
+			registry.create({
+				scope: 'workspace',
+				workspacePath: workspace,
+				relativePath: 'large.pdf'
+			})
+		).resolves.toEqual({ ok: false, error: 'PDF exceeds 50 MB preview limit' });
+	});
+
+	it('expires and revokes grants', async () => {
+		const { workspace, wiki } = fixture();
+		let now = 100;
+		const registry = createPdfPreviewRegistry({
+			fs,
+			path,
+			wikiRoot: wiki,
+			now: () => now,
+			randomUUID: () => 'token'
+		});
+		await registry.create({
+			scope: 'workspace',
+			workspacePath: workspace,
+			relativePath: 'report.pdf'
+		});
+		expect(registry.resolve('token')?.absolutePath).toBe(
+			fs.realpathSync(path.join(workspace, 'report.pdf'))
+		);
+		registry.revoke('token');
+		expect(registry.resolve('token')).toBeNull();
+		await registry.create({
+			scope: 'workspace',
+			workspacePath: workspace,
+			relativePath: 'report.pdf'
+		});
+		now += 31 * 60 * 1000;
+		expect(registry.resolve('token')).toBeNull();
+	});
+});
+
+describe('PDF preview protocol', () => {
+	it('serves a granted file and rejects altered paths and methods', async () => {
+		const { workspace, wiki } = fixture();
+		const registry = createPdfPreviewRegistry({
+			fs,
+			path,
+			wikiRoot: wiki,
+			randomUUID: () => 'token'
+		});
+		const result = await registry.create({
+			scope: 'workspace',
+			workspacePath: workspace,
+			relativePath: 'report.pdf'
+		});
+		if (!result.ok) throw new Error(result.error);
+
+		let handler: ((request: Request) => Response | Promise<Response>) | undefined;
+		const fetch = vi.fn(
+			async () => new Response('%PDF', { headers: { 'content-type': 'application/pdf' } })
+		);
+		registerPdfPreviewProtocol({
+			registry,
+			fs,
+			path,
+			net: { fetch },
+			protocol: {
+				handle: (_scheme, next) => {
+					handler = next as typeof handler;
+				}
+			}
+		});
+
+		const response = await handler!(new Request(result.url));
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toBe('application/pdf');
+		expect(fetch).toHaveBeenCalledWith(
+			pathToFileURL(fs.realpathSync(path.join(workspace, 'report.pdf'))).toString(),
+			expect.any(Object)
+		);
+		expect(
+			(await handler!(new Request(`${PDF_PREVIEW_SCHEME}://pdf/token/other.pdf`))).status
+		).toBe(404);
+		expect((await handler!(new Request(result.url, { method: 'POST' }))).status).toBe(405);
+	});
+
+	it('returns 404 when a granted file is removed before serving', async () => {
+		const { workspace, wiki } = fixture();
+		const registry = createPdfPreviewRegistry({
+			fs,
+			path,
+			wikiRoot: wiki,
+			randomUUID: () => 'token'
+		});
+		const result = await registry.create({
+			scope: 'workspace',
+			workspacePath: workspace,
+			relativePath: 'report.pdf'
+		});
+		if (!result.ok) throw new Error(result.error);
+		fs.rmSync(path.join(workspace, 'report.pdf'));
+
+		let handler: ((request: Request) => Response | Promise<Response>) | undefined;
+		registerPdfPreviewProtocol({
+			registry,
+			fs,
+			path,
+			net: { fetch: vi.fn() },
+			protocol: {
+				handle: (_scheme, next) => {
+					handler = next as typeof handler;
+				}
+			}
+		});
+
+		const response = await handler!(new Request(result.url));
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe('PDF preview file unavailable');
+	});
+});

--- a/cometline/electron/src/domains/pdf-preview.ts
+++ b/cometline/electron/src/domains/pdf-preview.ts
@@ -1,0 +1,200 @@
+import type { Net, Protocol } from 'electron';
+import crypto from 'node:crypto';
+import type fs from 'node:fs';
+import type path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const PDF_PREVIEW_SCHEME = 'cometline-preview';
+export const PDF_PREVIEW_HOST = 'pdf';
+export const PDF_PREVIEW_MAX_BYTES = 50 * 1024 * 1024;
+const PDF_PREVIEW_TOKEN_TTL_MS = 30 * 60 * 1000;
+const PDF_PREVIEW_MAX_TOKENS = 100;
+
+type FileSystem = Pick<typeof fs, 'promises'>;
+type PathService = Pick<typeof path, 'extname' | 'isAbsolute' | 'resolve' | 'sep'>;
+
+type PreviewEntry = {
+	absolutePath: string;
+	root: string;
+	publicName: string;
+	expiresAt: number;
+};
+
+export type PdfPreviewRequest =
+	| { scope: 'workspace'; workspacePath: string; relativePath: string }
+	| { scope: 'wiki'; relativePath: string };
+
+export type PdfPreviewResult =
+	| { ok: true; token: string; url: string }
+	| { ok: false; error: string };
+
+export interface PdfPreviewDependencies {
+	fs: FileSystem;
+	path: PathService;
+	wikiRoot: string;
+	now?: () => number;
+	randomUUID?: () => string;
+}
+
+function withinRoot(root: string, target: string, pathService: PathService) {
+	return target === root || target.startsWith(`${root}${pathService.sep}`);
+}
+
+/** Owns short-lived, exact-file grants used by the PDF protocol. */
+export function createPdfPreviewRegistry(dependencies: PdfPreviewDependencies) {
+	const entries = new Map<string, PreviewEntry>();
+	const now = dependencies.now ?? Date.now;
+	const randomUUID = dependencies.randomUUID ?? crypto.randomUUID;
+
+	function prune() {
+		const timestamp = now();
+		for (const [token, entry] of entries) {
+			if (entry.expiresAt <= timestamp) entries.delete(token);
+		}
+		while (entries.size >= PDF_PREVIEW_MAX_TOKENS) {
+			const oldest = entries.keys().next().value;
+			if (!oldest) break;
+			entries.delete(oldest);
+		}
+	}
+
+	async function create(request: unknown): Promise<PdfPreviewResult> {
+		if (!request || typeof request !== 'object')
+			return { ok: false, error: 'Invalid PDF preview request' };
+		const input = request as Partial<PdfPreviewRequest> & {
+			relativePath?: unknown;
+			workspacePath?: unknown;
+		};
+		const relativePath = String(input.relativePath || '').replace(/^[/\\]+/, '');
+		if (!relativePath || !['workspace', 'wiki'].includes(String(input.scope))) {
+			return { ok: false, error: 'Invalid PDF preview request' };
+		}
+		if (dependencies.path.extname(relativePath).toLowerCase() !== '.pdf') {
+			return { ok: false, error: 'Only PDF files can use PDF preview' };
+		}
+
+		const rootInput =
+			input.scope === 'wiki' ? dependencies.wikiRoot : String(input.workspacePath || '');
+		if (!rootInput || !dependencies.path.isAbsolute(rootInput)) {
+			return { ok: false, error: 'Invalid preview root' };
+		}
+		const resolvedRoot = dependencies.path.resolve(rootInput);
+		if (resolvedRoot === dependencies.path.sep) {
+			return { ok: false, error: 'Invalid preview root' };
+		}
+
+		try {
+			const root = await dependencies.fs.promises.realpath(resolvedRoot);
+			const candidate = dependencies.path.resolve(root, relativePath);
+			if (!withinRoot(root, candidate, dependencies.path)) {
+				return { ok: false, error: `Path escapes ${input.scope}` };
+			}
+			const absolutePath = await dependencies.fs.promises.realpath(candidate);
+			if (!withinRoot(root, absolutePath, dependencies.path)) {
+				return { ok: false, error: `Path escapes ${input.scope}` };
+			}
+			const stat = await dependencies.fs.promises.stat(absolutePath);
+			if (!stat.isFile()) return { ok: false, error: 'PDF file not found' };
+			if (stat.size > PDF_PREVIEW_MAX_BYTES) {
+				return { ok: false, error: 'PDF exceeds 50 MB preview limit' };
+			}
+
+			prune();
+			const token = randomUUID();
+			const publicName = absolutePath.split(dependencies.path.sep).pop() || 'document.pdf';
+			entries.set(token, {
+				absolutePath,
+				root,
+				publicName,
+				expiresAt: now() + PDF_PREVIEW_TOKEN_TTL_MS
+			});
+			const fileName = encodeURIComponent(publicName);
+			return {
+				ok: true,
+				token,
+				url: `${PDF_PREVIEW_SCHEME}://${PDF_PREVIEW_HOST}/${token}/${fileName}`
+			};
+		} catch {
+			return { ok: false, error: 'PDF file not found' };
+		}
+	}
+
+	function resolve(token: string): PreviewEntry | null {
+		const entry = entries.get(token);
+		if (!entry) return null;
+		if (entry.expiresAt <= now()) {
+			entries.delete(token);
+			return null;
+		}
+		return entry;
+	}
+
+	function revoke(token: unknown) {
+		entries.delete(String(token || ''));
+	}
+
+	return { create, resolve, revoke, clear: () => entries.clear() };
+}
+
+export type PdfPreviewRegistry = ReturnType<typeof createPdfPreviewRegistry>;
+
+/** Serves only files granted by the registry, without exposing their real paths. */
+export function registerPdfPreviewProtocol(dependencies: {
+	protocol: Pick<Protocol, 'handle'>;
+	net: Pick<Net, 'fetch'>;
+	fs: FileSystem;
+	path: PathService;
+	registry: PdfPreviewRegistry;
+}) {
+	dependencies.protocol.handle(PDF_PREVIEW_SCHEME, async (request) => {
+		if (request.method !== 'GET' && request.method !== 'HEAD') {
+			return new Response('Method not allowed', { status: 405 });
+		}
+		const url = new URL(request.url);
+		if (url.host !== PDF_PREVIEW_HOST) return new Response('Not found', { status: 404 });
+		const parts = url.pathname.split('/').filter(Boolean);
+		if (parts.length !== 2) return new Response('Not found', { status: 404 });
+		const entry = dependencies.registry.resolve(parts[0]);
+		if (!entry) return new Response('PDF preview token expired', { status: 404 });
+		try {
+			if (decodeURIComponent(parts[1]) !== entry.publicName)
+				return new Response('Not found', { status: 404 });
+		} catch {
+			return new Response('Not found', { status: 404 });
+		}
+		let upstream: Response;
+		try {
+			const currentPath = await dependencies.fs.promises.realpath(entry.absolutePath);
+			if (
+				currentPath !== entry.absolutePath ||
+				!withinRoot(entry.root, currentPath, dependencies.path)
+			) {
+				return new Response('PDF preview file changed', { status: 404 });
+			}
+			const stat = await dependencies.fs.promises.stat(currentPath);
+			if (!stat.isFile() || stat.size > PDF_PREVIEW_MAX_BYTES) {
+				return new Response('PDF preview file unavailable', { status: 404 });
+			}
+			upstream = await dependencies.net.fetch(pathToFileURL(currentPath).toString(), {
+				method: request.method,
+				headers: request.headers
+			});
+		} catch {
+			return new Response('PDF preview file unavailable', { status: 404 });
+		}
+		if (!upstream.ok && upstream.status !== 206) {
+			return new Response('Failed to load PDF preview', { status: upstream.status || 500 });
+		}
+		const headers = new Headers(upstream.headers);
+		headers.set('content-type', 'application/pdf');
+		headers.set(
+			'content-disposition',
+			`inline; filename="${entry.publicName.replace(/["\\]/g, '_')}"`
+		);
+		return new Response(request.method === 'HEAD' ? null : upstream.body, {
+			status: upstream.status,
+			statusText: upstream.statusText,
+			headers
+		});
+	});
+}

--- a/cometline/electron/src/domains/runtime-ipc.ts
+++ b/cometline/electron/src/domains/runtime-ipc.ts
@@ -11,6 +11,7 @@ import {
 	requestScreenCaptureAccess
 } from './media-permissions.js';
 import type { createPersonas } from './personas.js';
+import type { createPdfPreviewRegistry } from './pdf-preview.js';
 import type { createProviderAuth } from './provider-auth.js';
 import type { ShellWindowContext } from './runtime-context.js';
 import type { createSettingsDomain } from './settings.js';
@@ -32,6 +33,7 @@ type AutoUpdater = ReturnType<typeof createAutoUpdater>;
 type Shortcuts = ReturnType<typeof createShortcutCoordinator>;
 type WindowChrome = ReturnType<typeof createWindowChrome>;
 type WorkspaceWatcher = ReturnType<typeof createWorkspaceWatcher>;
+type PdfPreviewRegistry = ReturnType<typeof createPdfPreviewRegistry>;
 
 interface NotificationService {
 	isSupported(): boolean;
@@ -43,6 +45,7 @@ export interface RuntimeIpcDependencies {
 	Notification: NotificationService;
 	shell: Pick<Shell, 'openExternal'>;
 	workspacePreview: Parameters<typeof readWorkspaceFileForPreview>[0];
+	pdfPreview: PdfPreviewRegistry;
 	selectBackupFolder(): Promise<{ canceled: boolean; path?: string }>;
 	context: ShellWindowContext;
 	windows: Windows;
@@ -159,6 +162,11 @@ export function registerRuntimeIpcHandlers(dependencies: RuntimeIpcDependencies)
 			relativePath: unknown
 		) =>
 			readWorkspaceFileForPreview(dependencies.workspacePreview, workspacePath, relativePath),
+		createPdfPreview: (_event: IpcMainInvokeEvent, request: unknown) =>
+			dependencies.pdfPreview.create(request),
+		revokePdfPreview: (_event: IpcMainInvokeEvent, token: unknown) => {
+			dependencies.pdfPreview.revoke(token);
+		},
 		terminalList: (event: IpcMainInvokeEvent) =>
 			dependencies.terminals.isMainWindowSender(event) ? dependencies.terminals.list() : [],
 		terminalCreate: (event: IpcMainInvokeEvent, payload: unknown = {}) => {

--- a/cometline/electron/src/domains/runtime.ts
+++ b/cometline/electron/src/domains/runtime.ts
@@ -26,6 +26,11 @@ import { createAutoUpdater } from './auto-updater.js';
 import { createBrowserSearchBridge } from './browser-search.js';
 import { createCometMindLifecycle } from './cometmind-lifecycle.js';
 import { createPersonas } from './personas.js';
+import {
+	PDF_PREVIEW_SCHEME,
+	createPdfPreviewRegistry,
+	registerPdfPreviewProtocol
+} from './pdf-preview.js';
 import { createProviderAuth } from './provider-auth.js';
 import { createRouteSignals } from './route-signals.js';
 import { registerRuntimeIpcHandlers } from './runtime-ipc.js';
@@ -84,6 +89,15 @@ export function initializeRuntime() {
 				supportFetchAPI: true,
 				stream: true,
 				codeCache: true
+			}
+		},
+		{
+			scheme: PDF_PREVIEW_SCHEME,
+			privileges: {
+				standard: true,
+				secure: true,
+				supportFetchAPI: true,
+				stream: true
 			}
 		}
 	]);
@@ -146,7 +160,8 @@ export function initializeRuntime() {
 	});
 	const browserSearch = createBrowserSearchBridge();
 	const screenCapture = createScreenCaptureBridge({
-		isPreferred: () => Boolean(settingsDomain.readProviderSettings().app?.screenCapturePreferred)
+		isPreferred: () =>
+			Boolean(settingsDomain.readProviderSettings().app?.screenCapturePreferred)
 	});
 	const terminals = createTerminalManager(() => windows?.getMainWindow() ?? null);
 	const workspaceWatcher = createWorkspaceWatcher({
@@ -154,7 +169,8 @@ export function initializeRuntime() {
 		path,
 		onChange: (change) => {
 			for (const window of BrowserWindow.getAllWindows()) {
-				if (!window.isDestroyed()) window.webContents.send('cometline:workspace-changed', change);
+				if (!window.isDestroyed())
+					window.webContents.send('cometline:workspace-changed', change);
 			}
 		},
 		setTimeout,
@@ -341,6 +357,11 @@ export function initializeRuntime() {
 		windowChrome,
 		writeMiniWindowState: settingsDomain.writeMiniWindowState
 	});
+	const pdfPreview = createPdfPreviewRegistry({
+		fs,
+		path,
+		wikiRoot: path.join(os.homedir(), '.cometmind', 'wiki')
+	});
 	const updater = createAutoUpdater({
 		context: shellContext,
 		beforeInstall: async () => {
@@ -358,6 +379,7 @@ export function initializeRuntime() {
 		Notification: ElectronNotification,
 		shell,
 		workspacePreview: { fs, path },
+		pdfPreview,
 		selectBackupFolder,
 		context: shellContext,
 		windows,
@@ -376,6 +398,7 @@ export function initializeRuntime() {
 	});
 
 	app.whenReady().then(async () => {
+		registerPdfPreviewProtocol({ protocol, net, fs, path, registry: pdfPreview });
 		if (app.isPackaged) {
 			registerAppProtocol({
 				bundleDirectory: path.join(runtimeDirectory, '..', 'build'),

--- a/cometline/electron/src/preload.ts
+++ b/cometline/electron/src/preload.ts
@@ -22,7 +22,8 @@ const electronAPI: ElectronAPI = {
 	selectBackupFolder: () => ipcRenderer.invoke('cometline:select-backup-folder'),
 	setWorkspacePath: (workspacePath) =>
 		ipcRenderer.invoke('cometline:set-workspace-path', workspacePath),
-	watchWorkspace: (workspacePath) => ipcRenderer.invoke('cometline:watch-workspace', workspacePath),
+	watchWorkspace: (workspacePath) =>
+		ipcRenderer.invoke('cometline:watch-workspace', workspacePath),
 	listRecentWorkspaces: () => ipcRenderer.invoke('cometline:list-recent-workspaces'),
 	removeRecentWorkspacePath: (workspacePath) =>
 		ipcRenderer.invoke('cometline:remove-recent-workspace-path', workspacePath),
@@ -31,6 +32,8 @@ const electronAPI: ElectronAPI = {
 	pruneWorkspaceStore: () => ipcRenderer.invoke('cometline:prune-workspace-store'),
 	readWorkspaceFile: (workspacePath, relativePath) =>
 		ipcRenderer.invoke('cometline:read-workspace-file', workspacePath, relativePath),
+	createPdfPreview: (request) => ipcRenderer.invoke('cometline:create-pdf-preview', request),
+	revokePdfPreview: (token) => ipcRenderer.invoke('cometline:revoke-pdf-preview', token),
 	listTerminals: () => ipcRenderer.invoke('cometline:terminal-list'),
 	createTerminal: (payload) => ipcRenderer.invoke('cometline:terminal-create', payload),
 	writeTerminal: (payload) => ipcRenderer.invoke('cometline:terminal-write', payload),
@@ -93,14 +96,17 @@ const electronAPI: ElectronAPI = {
 		ipcRenderer.send('cometline:shortcut-capture-active', Boolean(active)),
 	setSessionNavigationSuspended: (suspended) =>
 		ipcRenderer.send('cometline:session-navigation-suspended', Boolean(suspended)),
-	setWorkspacePanelOpen: (open) => ipcRenderer.send('cometline:workspace-panel-open', Boolean(open)),
+	setWorkspacePanelOpen: (open) =>
+		ipcRenderer.send('cometline:workspace-panel-open', Boolean(open)),
 	setInboxOpen: (open) => ipcRenderer.send('cometline:inbox-open', Boolean(open)),
 	confirmCloseWindow: () => ipcRenderer.send('cometline:confirm-close-window'),
-	onCloseWorkspacePanel: (callback) => subscribeSignal('cometline:close-workspace-panel', callback),
+	onCloseWorkspacePanel: (callback) =>
+		subscribeSignal('cometline:close-workspace-panel', callback),
 	onCloseInbox: (callback) => subscribeSignal('cometline:close-inbox', callback),
 	onRequestCloseWindow: (callback) => subscribeSignal('cometline:request-close-window', callback),
 	onRequestReload: (callback) => subscribeSignal('cometline:request-reload', callback),
-	onToggleWorkspacePanel: (callback) => subscribeSignal('cometline:toggle-workspace-panel', callback),
+	onToggleWorkspacePanel: (callback) =>
+		subscribeSignal('cometline:toggle-workspace-panel', callback),
 	onOpenWebSearch: (callback) => subscribeSignal('cometline:open-web-search', callback),
 	onNavigateSession: (callback) =>
 		subscribe('cometline:navigate-session', (direction) => {

--- a/cometline/electron/src/shared/api.ts
+++ b/cometline/electron/src/shared/api.ts
@@ -91,6 +91,8 @@ export interface ElectronAPI {
 		workspacePath: string,
 		relativePath: string
 	): Promise<ReadWorkspaceFileResult>;
+	createPdfPreview(request: PdfPreviewRequest): Promise<PdfPreviewResult>;
+	revokePdfPreview(token: string): Promise<void>;
 	listTerminals(): Promise<TerminalSnapshot[]>;
 	createTerminal(payload: TerminalCreatePayload): Promise<TerminalSnapshot>;
 	writeTerminal(payload: { sessionId: string; data: string }): Promise<boolean>;

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -363,6 +363,11 @@ declare global {
 		| { ok: true; kind: 'image'; mimeType: string; dataUrl: string }
 		| { ok: false; error: string };
 
+	type PdfPreviewRequest =
+		| { scope: 'workspace'; workspacePath: string; relativePath: string }
+		| { scope: 'wiki'; relativePath: string };
+	type PdfPreviewResult = { ok: true; token: string; url: string } | { ok: false; error: string };
+
 	type ReadPersonaSoulResult = { ok: true; content: string } | { ok: false; error: string };
 
 	type ReadPersonaAvatarResult = { ok: true; dataUrl: string } | { ok: false; error: string };
@@ -497,7 +502,11 @@ declare global {
 		getFullScreen?: () => Promise<boolean>;
 		onFullScreenChange?: (callback: (isFullScreen: boolean) => void) => () => void;
 		onWorkspaceChanged?: (
-			callback: (change: { workspacePath: string; paths: string[]; gitChanged: boolean }) => void
+			callback: (change: {
+				workspacePath: string;
+				paths: string[];
+				gitChanged: boolean;
+			}) => void
 		) => () => void;
 		getWorkspacePath?: () => Promise<string>;
 		selectWorkspacePath?: () => Promise<string | null>;
@@ -513,6 +522,8 @@ declare global {
 			workspacePath: string,
 			relativePath: string
 		) => Promise<ReadWorkspaceFileResult>;
+		createPdfPreview?: (request: PdfPreviewRequest) => Promise<PdfPreviewResult>;
+		revokePdfPreview?: (token: string) => Promise<void>;
 		listTerminals?: () => Promise<TerminalSnapshot[]>;
 		createTerminal?: (payload: {
 			sessionId: string;

--- a/cometline/src/lib/components/FilePreview.svelte
+++ b/cometline/src/lib/components/FilePreview.svelte
@@ -3,6 +3,7 @@
 	import { untrack } from 'svelte';
 	import AssistantMarkdown from '$lib/components/AssistantMarkdown.svelte';
 	import FileEditor from '$lib/components/FileEditor.svelte';
+	import PdfPreview from '$lib/components/PdfPreview.svelte';
 	import SelectionAddToChat from '$lib/components/SelectionAddToChat.svelte';
 	import {
 		listWikiFileBacklinks,
@@ -15,6 +16,7 @@
 	import { openWorkspaceFilePreview } from '$lib/workspace/open-file-preview';
 	import {
 		isMarkdownPath,
+		isPdfPath,
 		languageFromExtension,
 		languageFromPath
 	} from '$lib/workspace/file-preview';
@@ -36,7 +38,10 @@
 	import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
 	import { workspaceFileChangeVersion } from '$lib/workspace/workspace-change.svelte';
 	import { createFileDiff } from '$lib/workspace/file-diff';
-	import { highlightGitDiffLines, type HighlightedDiffLine } from '$lib/workspace/git-diff-highlight';
+	import {
+		highlightGitDiffLines,
+		type HighlightedDiffLine
+	} from '$lib/workspace/git-diff-highlight';
 	import { parseGitDiffLines } from '$lib/workspace/git-diff-lines';
 	import {
 		isWikiReadOnlyPath,
@@ -72,7 +77,7 @@
 	let savedContent = $state('');
 	let draftContent = $state('');
 	let language = $state<string | null>(null);
-	let previewKind = $state<'text' | 'image' | null>(null);
+	let previewKind = $state<'text' | 'image' | 'pdf' | null>(null);
 	let saving = $state(false);
 	let saveError = $state<string | null>(null);
 	let loadVersion = 0;
@@ -99,10 +104,12 @@
 	let externalComparisonError = $state<string | null>(null);
 	let externalComparisonOpen = $state(false);
 	let lastObservedFileChangeVersion = 0;
+	let pdfReloadVersion = $state(0);
 
 	const readOnly = $derived(isWikiUiPath(filePath) && isWikiReadOnlyPath(filePath));
 	const dirty = $derived(previewKind === 'text' && draftContent !== savedContent && !readOnly);
 	const isMarkdown = $derived(isMarkdownPath(filePath));
+	const isPdf = $derived(isPdfPath(filePath));
 	const showMarkdownToggle = $derived(previewKind === 'text' && isMarkdown);
 	const effectiveViewMode = $derived(
 		showMarkdownToggle ? viewMode : ('source' satisfies MarkdownFileViewMode)
@@ -306,6 +313,10 @@
 		selectionPopup = null;
 
 		try {
+			if (isPdf) {
+				previewKind = 'pdf';
+				return;
+			}
 			const wikiIndexPromise = refreshWikiFileIndex(true);
 			const result = isWikiUiPath(filePath)
 				? await readWikiFileContent(toWikiRelative(filePath))
@@ -351,6 +362,10 @@
 		const changeVersion = workspaceFileChangeVersion(workspacePath, filePath);
 		if (changeVersion === lastObservedFileChangeVersion) return;
 		lastObservedFileChangeVersion = changeVersion;
+		if (isPdf) {
+			pdfReloadVersion += 1;
+			return;
+		}
 		if (dirty) {
 			externalChangePending = true;
 			externalComparisonLines = null;
@@ -388,7 +403,6 @@
 			onEditorState?.(null);
 		};
 	});
-
 </script>
 
 {#snippet backlinksSection()}
@@ -429,6 +443,8 @@
 		<div class="file-preview-image-wrap">
 			<img src={imageDataUrl} alt={filePath} class="file-preview-image" />
 		</div>
+	{:else if previewKind === 'pdf'}
+		<PdfPreview {workspacePath} {filePath} wiki={isWikiFile} reloadVersion={pdfReloadVersion} />
 	{:else if previewKind === 'text'}
 		<div class="file-preview-editor-wrap">
 			{#if externalComparisonOpen && externalComparisonLines !== null}
@@ -436,8 +452,11 @@
 					<header class="external-diff-toolbar">
 						<span>External change diff</span>
 						<div class="external-change-actions">
-							<button type="button" onclick={reloadAfterExternalChange}>Reload</button>
-							<button type="button" onclick={keepEditingAfterExternalChange}>Keep editing</button>
+							<button type="button" onclick={reloadAfterExternalChange}>Reload</button
+							>
+							<button type="button" onclick={keepEditingAfterExternalChange}
+								>Keep editing</button
+							>
 							<button type="button" onclick={() => void compareExternalChange()}>
 								Close diff
 							</button>
@@ -454,85 +473,90 @@
 				</div>
 			{:else}
 				{#if showMarkdownToggle}
-				<div class="md-view-toggle" role="group" aria-label="Markdown view mode">
-					<button
-						type="button"
-						class="md-view-toggle-btn"
-						class:active={effectiveViewMode === 'preview'}
-						onclick={() => setViewMode('preview')}
-					>
-						Preview
-					</button>
-					<button
-						type="button"
-						class="md-view-toggle-btn"
-						class:active={effectiveViewMode === 'source'}
-						onclick={() => setViewMode('source')}
-					>
-						Source
-					</button>
-				</div>
+					<div class="md-view-toggle" role="group" aria-label="Markdown view mode">
+						<button
+							type="button"
+							class="md-view-toggle-btn"
+							class:active={effectiveViewMode === 'preview'}
+							onclick={() => setViewMode('preview')}
+						>
+							Preview
+						</button>
+						<button
+							type="button"
+							class="md-view-toggle-btn"
+							class:active={effectiveViewMode === 'source'}
+							onclick={() => setViewMode('source')}
+						>
+							Source
+						</button>
+					</div>
 				{/if}
 				{#if saveError}
-				<div class="file-preview-save-error">{saveError}</div>
+					<div class="file-preview-save-error">{saveError}</div>
 				{/if}
 				{#if externalChangePending}
-				<div class="external-change-notice" role="status">
-					<span>This file changed outside Cometline.</span>
-					<div class="external-change-actions">
-						<button type="button" onclick={reloadAfterExternalChange}>Reload</button>
-						<button type="button" onclick={keepEditingAfterExternalChange}>Keep editing</button>
-						<button type="button" onclick={() => void compareExternalChange()}>Compare</button>
+					<div class="external-change-notice" role="status">
+						<span>This file changed outside Cometline.</span>
+						<div class="external-change-actions">
+							<button type="button" onclick={reloadAfterExternalChange}>Reload</button
+							>
+							<button type="button" onclick={keepEditingAfterExternalChange}
+								>Keep editing</button
+							>
+							<button type="button" onclick={() => void compareExternalChange()}
+								>Compare</button
+							>
+						</div>
 					</div>
-				</div>
-				{#if externalComparisonError}
-					<div class="file-preview-save-error">{externalComparisonError}</div>
-				{/if}
+					{#if externalComparisonError}
+						<div class="file-preview-save-error">{externalComparisonError}</div>
+					{/if}
 				{/if}
 				{#if effectiveViewMode === 'preview'}
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div class="file-preview-markdown scrollbar-none" onmouseup={onPreviewMouseUp}>
-					<AssistantMarkdown
-						source={draftContent}
-						mode="assistant"
-						annotateSourceLines
-						{wikiFiles}
-						workspaceResources={{
-							kind: isWikiFile ? 'wiki' : 'workspace',
-							workspacePath,
-							filePath: isWikiFile ? toWikiRelative(filePath) : filePath,
-							readFile: (relativePath) =>
-								isWikiFile
-									? readWikiFileContent(relativePath)
-									: readWorkspaceFileContent(workspacePath, relativePath)
-						}}
-					/>
-					{#if showBacklinks}
-						{@render backlinksSection()}
-					{/if}
-				</div>
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div class="file-preview-markdown scrollbar-none" onmouseup={onPreviewMouseUp}>
+						<AssistantMarkdown
+							source={draftContent}
+							mode="assistant"
+							annotateSourceLines
+							{wikiFiles}
+							workspaceResources={{
+								kind: isWikiFile ? 'wiki' : 'workspace',
+								workspacePath,
+								filePath: isWikiFile ? toWikiRelative(filePath) : filePath,
+								readFile: (relativePath) =>
+									isWikiFile
+										? readWikiFileContent(relativePath)
+										: readWorkspaceFileContent(workspacePath, relativePath)
+							}}
+						/>
+						{#if showBacklinks}
+							{@render backlinksSection()}
+						{/if}
+					</div>
 				{:else}
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div class="file-preview-source-wrap" onmouseup={onSourceMouseUp}>
-					<FileEditor
-						bind:this={fileEditor}
-						value={draftContent}
-						{language}
-						readOnly={saving || readOnly}
-						{revealRange}
-						onChange={(value) => {
-							draftContent = value;
-							if (saveError) saveError = null;
-						}}
-						onSave={() => {
-							void save();
-						}}
-						onRevealApplied={() => shellStore.clearFileRevealForActive()}
-					/>
-					{#if showBacklinks && !showMarkdownToggle}
-						{@render backlinksSection()}
-					{/if}
-				</div>
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div class="file-preview-source-wrap" onmouseup={onSourceMouseUp}>
+						<FileEditor
+							bind:this={fileEditor}
+							value={draftContent}
+							{language}
+							readOnly={saving || readOnly}
+							{revealRange}
+							onChange={(value) => {
+								draftContent = value;
+								if (saveError) saveError = null;
+							}}
+							onSave={() => {
+								void save();
+							}}
+							onRevealApplied={() => shellStore.clearFileRevealForActive()}
+						/>
+						{#if showBacklinks && !showMarkdownToggle}
+							{@render backlinksSection()}
+						{/if}
+					</div>
 				{/if}
 			{/if}
 		</div>
@@ -555,7 +579,6 @@
 		overflow: auto;
 		background: #fff;
 	}
-
 
 	.file-preview-state {
 		display: flex;

--- a/cometline/src/lib/components/PdfPreview.svelte
+++ b/cometline/src/lib/components/PdfPreview.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import { Loader } from '@lucide/svelte';
+	import { toWikiRelative } from '$lib/wiki/paths';
+
+	let {
+		workspacePath,
+		filePath,
+		wiki,
+		reloadVersion = 0
+	}: {
+		workspacePath: string;
+		filePath: string;
+		wiki: boolean;
+		reloadVersion?: number;
+	} = $props();
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let previewUrl = $state<string | null>(null);
+	let activeToken: string | null = null;
+	let loadVersion = 0;
+
+	async function revoke(token: string | null) {
+		if (!token) return;
+		try {
+			await window.electronAPI?.revokePdfPreview?.(token);
+		} catch {
+			// A revoked or shutting-down main process needs no renderer recovery.
+		}
+	}
+
+	async function load() {
+		const version = ++loadVersion;
+		const previousToken = activeToken;
+		activeToken = null;
+		previewUrl = null;
+		loading = true;
+		error = null;
+		void revoke(previousToken);
+
+		const createPreview = window.electronAPI?.createPdfPreview;
+		if (!createPreview) {
+			error = 'PDF preview is available in the Cometline desktop app.';
+			loading = false;
+			return;
+		}
+
+		try {
+			const result = await createPreview(
+				wiki
+					? { scope: 'wiki', relativePath: toWikiRelative(filePath) }
+					: { scope: 'workspace', workspacePath, relativePath: filePath }
+			);
+			if (version !== loadVersion) {
+				if (result.ok) void revoke(result.token);
+				return;
+			}
+			if (!result.ok) {
+				error = result.error;
+				return;
+			}
+			activeToken = result.token;
+			previewUrl = result.url;
+		} catch (cause) {
+			if (version === loadVersion) {
+				error = cause instanceof Error ? cause.message : 'Failed to load PDF preview';
+			}
+		} finally {
+			if (version === loadVersion) loading = false;
+		}
+	}
+
+	$effect(() => {
+		void [workspacePath, filePath, wiki, reloadVersion];
+		void load();
+	});
+
+	$effect(() => () => {
+		loadVersion += 1;
+		void revoke(activeToken);
+	});
+</script>
+
+<div class="pdf-preview">
+	{#if loading}
+		<div class="pdf-preview-state">
+			<Loader size={16} stroke-width={2} class="pdf-preview-spinner" />
+			<span>Loading PDF…</span>
+		</div>
+	{:else if error}
+		<div class="pdf-preview-state pdf-preview-error">{error}</div>
+	{:else if previewUrl}
+		<iframe title={filePath} src={previewUrl} class="pdf-preview-frame"></iframe>
+	{/if}
+</div>
+
+<style>
+	.pdf-preview {
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		background: #fff;
+	}
+
+	.pdf-preview-frame {
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+
+	.pdf-preview-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		height: 100%;
+		padding: 24px;
+		color: #737373;
+		font-size: 13px;
+		text-align: center;
+	}
+
+	.pdf-preview-error {
+		color: #b91c1c;
+	}
+
+	.pdf-preview-state :global(.pdf-preview-spinner) {
+		animation: pdf-preview-spin 0.7s linear infinite;
+	}
+
+	@keyframes pdf-preview-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/cometline/src/lib/workspace/file-preview.test.ts
+++ b/cometline/src/lib/workspace/file-preview.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { extensionFromPath, isImagePath, isMarkdownPath, languageFromPath } from './file-preview';
+import {
+	extensionFromPath,
+	isImagePath,
+	isMarkdownPath,
+	isPdfPath,
+	languageFromPath
+} from './file-preview';
 
 describe('file-preview helpers', () => {
 	it('detects language from extension', () => {
@@ -11,6 +17,13 @@ describe('file-preview helpers', () => {
 		expect(isMarkdownPath('docs/guide.md')).toBe(true);
 		expect(isImagePath('static/logo.png')).toBe(true);
 		expect(isImagePath('src/main.go')).toBe(false);
+	});
+
+	it('detects PDF paths case-insensitively', () => {
+		expect(isPdfPath('docs/report.pdf')).toBe(true);
+		expect(isPdfPath('docs/REPORT.PDF')).toBe(true);
+		expect(isPdfPath('docs/report.pdf.txt')).toBe(false);
+		expect(isPdfPath('report')).toBe(false);
 	});
 
 	it('extracts extension from nested paths', () => {

--- a/cometline/src/lib/workspace/file-preview.ts
+++ b/cometline/src/lib/workspace/file-preview.ts
@@ -53,3 +53,7 @@ export function isMarkdownPath(filePath: string): boolean {
 export function isImagePath(filePath: string): boolean {
 	return IMAGE_EXTENSIONS.has(extensionFromPath(filePath));
 }
+
+export function isPdfPath(filePath: string): boolean {
+	return extensionFromPath(filePath) === '.pdf';
+}

--- a/cometmind/internal/filelist/filelist.go
+++ b/cometmind/internal/filelist/filelist.go
@@ -20,6 +20,7 @@ type Options struct {
 	Query              string
 	Limit              int
 	SkipDirectoryNames map[string]bool
+	IncludeFile        func(relativePath string) bool
 }
 
 // Result is the outcome of an entry listing.
@@ -84,6 +85,8 @@ func List(ctx context.Context, root string, opts Options) (Result, error) {
 			if isDir {
 				directories = append(directories, filepath.Join(dir, entry.Name()))
 				rel += "/"
+			} else if opts.IncludeFile != nil && !opts.IncludeFile(rel) {
+				continue
 			}
 			if query != "" && !strings.Contains(strings.ToLower(rel), query) {
 				continue
@@ -178,6 +181,8 @@ func ListDirectory(ctx context.Context, root, directory string, opts Options) (R
 		}
 		if isDir {
 			path += "/"
+		} else if opts.IncludeFile != nil && !opts.IncludeFile(path) {
+			continue
 		}
 		if query != "" && !strings.Contains(strings.ToLower(path), query) {
 			continue

--- a/cometmind/internal/wiki/files/files.go
+++ b/cometmind/internal/wiki/files/files.go
@@ -19,9 +19,19 @@ type ListOptions = filelist.Options
 
 type Result = filelist.Result
 
-// ListMarkdownFiles returns wiki-root-relative file and directory paths, sorted.
+func includeWikiDocument(relativePath string) bool {
+	switch strings.ToLower(filepath.Ext(relativePath)) {
+	case ".md", ".markdown", ".html", ".htm", ".pdf":
+		return true
+	default:
+		return false
+	}
+}
+
+// ListDocumentFiles returns wiki document files and directories, sorted.
 // Directories have a trailing slash so clients can distinguish them from files.
-func ListMarkdownFiles(ctx context.Context, root string, opts ListOptions) (Result, error) {
+func ListDocumentFiles(ctx context.Context, root string, opts ListOptions) (Result, error) {
+	opts.IncludeFile = includeWikiDocument
 	result, err := filelist.List(ctx, root, opts)
 	if errors.Is(err, os.ErrNotExist) {
 		return Result{Files: []string{}}, nil
@@ -31,6 +41,7 @@ func ListMarkdownFiles(ctx context.Context, root string, opts ListOptions) (Resu
 
 // ListDirectory returns direct children of a wiki-root-relative directory.
 func ListDirectory(ctx context.Context, root, directory string, opts ListOptions) (Result, error) {
+	opts.IncludeFile = includeWikiDocument
 	result, err := filelist.ListDirectory(ctx, root, directory, opts)
 	if errors.Is(err, os.ErrNotExist) {
 		return Result{Files: []string{}}, nil

--- a/cometmind/internal/wiki/files/files_test.go
+++ b/cometmind/internal/wiki/files/files_test.go
@@ -7,13 +7,15 @@ import (
 	"testing"
 )
 
-func TestListMarkdownFiles(t *testing.T) {
+func TestListDocumentFiles(t *testing.T) {
 	dir := t.TempDir()
 	for _, p := range []string{
 		"index.md",
 		"entities/foo.md",
 		"raw/2026-01-01-note.md",
 		"raw/2026-01-01-paper.html",
+		"paper.pdf",
+		"draft.markdown",
 		"notes.txt",
 		".hidden.md",
 		".private/draft.txt",
@@ -27,18 +29,18 @@ func TestListMarkdownFiles(t *testing.T) {
 		}
 	}
 
-	result, err := ListMarkdownFiles(context.Background(), dir, ListOptions{Limit: 50})
+	result, err := ListDocumentFiles(context.Background(), dir, ListOptions{Limit: 50})
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
 		".hidden.md",
 		".private/",
-		".private/draft.txt",
+		"draft.markdown",
 		"entities/",
 		"entities/foo.md",
 		"index.md",
-		"notes.txt",
+		"paper.pdf",
 		"raw/",
 		"raw/2026-01-01-note.md",
 		"raw/2026-01-01-paper.html",
@@ -53,8 +55,34 @@ func TestListMarkdownFiles(t *testing.T) {
 	}
 }
 
-func TestListMarkdownFilesMissingDir(t *testing.T) {
-	result, err := ListMarkdownFiles(context.Background(), filepath.Join(t.TempDir(), "missing"), ListOptions{})
+func TestListDirectoryFiltersWikiDocuments(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"guide.md", "paper.PDF", "page.html", "notes.txt", "assets/image.png"} {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := ListDirectory(context.Background(), dir, "", ListOptions{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"assets/", "guide.md", "page.html", "paper.PDF"}
+	if len(result.Files) != len(want) {
+		t.Fatalf("files = %v want %v", result.Files, want)
+	}
+	for i := range want {
+		if result.Files[i] != want[i] {
+			t.Fatalf("files = %v want %v", result.Files, want)
+		}
+	}
+}
+
+func TestListDocumentFilesMissingDir(t *testing.T) {
+	result, err := ListDocumentFiles(context.Background(), filepath.Join(t.TempDir(), "missing"), ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cometmind/server/wiki_files.go
+++ b/cometmind/server/wiki_files.go
@@ -31,7 +31,7 @@ func (a *App) handleListWikiFiles(c *gin.Context) {
 		}
 	}
 
-	result, err := wikifiles.ListMarkdownFiles(c.Request.Context(), root, wikifiles.ListOptions{
+	result, err := wikifiles.ListDocumentFiles(c.Request.Context(), root, wikifiles.ListOptions{
 		Query: strings.TrimSpace(c.Query("q")),
 		Limit: limit,
 	})

--- a/cometmind/server/wiki_files_test.go
+++ b/cometmind/server/wiki_files_test.go
@@ -25,6 +25,7 @@ func TestListWikiFiles(t *testing.T) {
 	mustWrite(t, filepath.Join(wikiDir, "index.md"), "# index")
 	mustWrite(t, filepath.Join(wikiDir, "entities", "foo.md"), "# foo")
 	mustWrite(t, filepath.Join(wikiDir, "notes.txt"), "note")
+	mustWrite(t, filepath.Join(wikiDir, "paper.pdf"), "%PDF")
 
 	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
 		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
@@ -43,7 +44,7 @@ func TestListWikiFiles(t *testing.T) {
 
 	var got workspaceFileListResponse
 	decodeJSON(t, rec.Body.Bytes(), &got)
-	want := []string{"entities/", "entities/foo.md", "index.md", "notes.txt"}
+	want := []string{"entities/", "entities/foo.md", "index.md", "paper.pdf"}
 	if len(got.Files) != len(want) {
 		t.Fatalf("files = %v want %v", got.Files, want)
 	}


### PR DESCRIPTION
## Background

Workspace and wiki file browsers can list text and image files, but PDF documents cannot be opened in the desktop preview. PDF support needs to preserve Electron isolation without exposing arbitrary local file paths to the renderer.

[53731c9](https://github.com/Cometline/cometline/commit/53731c90d3bf01f8712a90789017753391de65d6): Wiki file listings now include PDF documents alongside the existing supported formats so users can discover them in the workspace panel.

[089e11d](https://github.com/Cometline/cometline/commit/089e11d3e743f04b711e599e40d52d93c188eeb4): Electron serves PDF files through short-lived, exact-file grants over a custom protocol, with path containment, symlink, file-size, and lifecycle checks at the main-process boundary.

[54449bb](https://github.com/Cometline/cometline/commit/54449bb113bcfed95bd0e3226b7acc3e057e3277): Workspace and wiki PDF files render in an embedded preview and refresh when the underlying file changes.