### PR TITLE
[main] feat: keep a persistent shell titlebar

### DIFF
--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -46,9 +46,12 @@
 	--workspace-panel-width: 640px;
 	--workspace-panel-slot-width: calc(var(--workspace-panel-width) + var(--content-panel-inset));
 	--titlebar-height: 48px;
-	/* Shared height for main-panel + workspace-panel chrome headers (incl. border). */
-	/* Shared by collapsed main shell titlebar + workspace panel toolbar. */
-	--panel-header-height: 44px;
+	/* In-card chrome (main titlebar + workspace toolbar). Centers against
+	   the 48px sidebar titlebar after the card inset and border. */
+	--panel-header-height: calc(
+		var(--titlebar-height) - 2 *
+			(var(--content-panel-inset) + var(--content-panel-border-width))
+	);
 	--traffic-light-gutter: 78px;
 
 	/* Chat column tracks avatar + gap + message width; composer is slightly wider. */

--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { PanelLeftOpen, PanelRightOpen } from '@lucide/svelte';
+	import { PanelLeftClose, PanelLeftOpen, PanelRightOpen } from '@lucide/svelte';
 	import Sidebar from './Sidebar.svelte';
 	import RuntimeOverlay from './RuntimeOverlay.svelte';
 	import SettingsModal from './SettingsModal.svelte';
@@ -703,21 +702,16 @@
 		shellStore.setFocusedPane('chat');
 	}
 
-	function titlebarSlideParams() {
-		return {
-			// Utility pages hide the session titlebar on navigation. Remove it
-			// immediately instead of animating while the page layout changes.
-			duration: isUtilityPage ? 0 : sidebarTransitionDuration(),
-			axis: 'y' as const
-		};
-	}
-
 	const isUtilityPage = $derived(
 		page.url.pathname === '/jobs' || page.url.pathname === '/skill-drafts'
 	);
-	const showShellTitlebar = $derived(
-		!shellStore.sidebarOpen && !shellStore.fullscreen && !isUtilityPage
-	);
+	const showShellTitlebar = $derived(!shellStore.fullscreen);
+	const titlebarLabel = $derived.by(() => {
+		if (page.url.pathname === '/jobs') return 'Jobs';
+		if (page.url.pathname === '/skill-drafts') return 'Skill Drafts';
+		return titlebarSessionTitle;
+	});
+	const titlebarRenamable = $derived(Boolean(titlebarSessionTitle && !isUtilityPage));
 
 	// --- Web/file panel resize ---------------------------------------------
 	/** User's preferred share of the content row; survives temporary clamps. */
@@ -881,53 +875,58 @@
 			onmousedown={handleMainMouseDown}
 		>
 			{#if showShellTitlebar}
-				<header
-					class="shell-titlebar"
-					aria-label="Window title bar"
-					transition:slide={titlebarSlideParams()}
-				>
-					{#if titlebarSessionTitle}
-						<button
-							type="button"
-							class="shell-titlebar-title"
-							title={titlebarSessionTitleAttr}
-							aria-label={`Rename session: ${titlebarSessionTitle}`}
-							ondblclick={startRenameFromTitlebar}
+				<header class="shell-titlebar" aria-label="Window title bar">
+					<div class="shell-titlebar-start">
+						<Tooltip
+							label={shellStore.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+							action="toggleSidebar"
 						>
-							{titlebarSessionTitle}
-						</button>
+							<button
+								type="button"
+								class="shell-titlebar-btn"
+								aria-label={shellStore.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+								aria-pressed={shellStore.sidebarOpen}
+								onclick={() => shellStore.toggleSidebar()}
+							>
+								{#if shellStore.sidebarOpen}
+									<PanelLeftClose size={16} stroke-width={1.8} />
+								{:else}
+									<PanelLeftOpen size={16} stroke-width={1.8} />
+								{/if}
+							</button>
+						</Tooltip>
+					</div>
+					{#if titlebarLabel}
+						{#if titlebarRenamable}
+							<button
+								type="button"
+								class="shell-titlebar-title"
+								title={titlebarSessionTitleAttr}
+								aria-label={`Rename session: ${titlebarLabel}`}
+								ondblclick={startRenameFromTitlebar}
+							>
+								{titlebarLabel}
+							</button>
+						{:else}
+							<span class="shell-titlebar-title">{titlebarLabel}</span>
+						{/if}
+					{/if}
+					{#if !shellStore.workspacePanelOpen && !isUtilityPage}
+						<div class="shell-titlebar-end">
+							<Tooltip label="Show workspace panel" action="toggleWorkspacePanel">
+								<button
+									type="button"
+									class="shell-titlebar-btn"
+									aria-label="Show workspace panel"
+									disabled={!activeSessionId}
+									onclick={() => shellStore.toggleWorkspacePanel()}
+								>
+									<PanelRightOpen size={16} stroke-width={1.8} />
+								</button>
+							</Tooltip>
+						</div>
 					{/if}
 				</header>
-			{/if}
-			<!-- Fixed corner chrome: independent of the sliding shell titlebar. -->
-			{#if !shellStore.fullscreen && !shellStore.sidebarOpen && !isUtilityPage}
-				<div class="main-corner-actions main-corner-actions-start">
-					<Tooltip label="Show sidebar" action="toggleSidebar">
-						<button
-							type="button"
-							class="shell-titlebar-btn"
-							aria-label="Show sidebar"
-							onclick={() => shellStore.toggleSidebar()}
-						>
-							<PanelLeftOpen size={16} stroke-width={1.8} />
-						</button>
-					</Tooltip>
-				</div>
-			{/if}
-			{#if !shellStore.fullscreen && !shellStore.workspacePanelOpen && !isUtilityPage}
-				<div class="main-corner-actions main-corner-actions-end">
-					<Tooltip label="Show workspace panel" action="toggleWorkspacePanel">
-						<button
-							type="button"
-							class="shell-titlebar-btn"
-							aria-label="Show workspace panel"
-							disabled={!activeSessionId}
-							onclick={() => shellStore.toggleWorkspacePanel()}
-						>
-							<PanelRightOpen size={16} stroke-width={1.8} />
-						</button>
-					</Tooltip>
-				</div>
 			{/if}
 			{@render children()}
 			<RuntimeOverlay />
@@ -1168,8 +1167,6 @@
 		--traffic-light-gutter: 0px;
 	}
 
-	/* Internal chrome of the main card. Traffic lights are hidden while the
-	   sidebar is collapsed, so no gutter reserved for native window buttons. */
 	.shell-titlebar {
 		position: relative;
 		flex-shrink: 0;
@@ -1182,6 +1179,19 @@
 		border-bottom: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
 		background: transparent;
 		-webkit-app-region: drag;
+	}
+
+	.shell-titlebar-start,
+	.shell-titlebar-end {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		-webkit-app-region: no-drag;
+	}
+
+	.shell-titlebar-end {
+		margin-left: auto;
 	}
 
 	.shell-titlebar-title {
@@ -1249,34 +1259,6 @@
 	.shell-titlebar-btn:disabled {
 		opacity: 0.4;
 		cursor: default;
-	}
-
-	/*
-	 * Sidebar toggles stay fixed in the main pane corners so they do not
-	 * remount / slide with the shell titlebar transition.
-	 * Vertically centered against --panel-header-height (44px) with a 26px btn.
-	 */
-	.main-corner-actions {
-		position: absolute;
-		top: calc((var(--panel-header-height) - 26px) / 2);
-		z-index: 41;
-		display: flex;
-		align-items: center;
-		-webkit-app-region: no-drag;
-		pointer-events: none;
-	}
-
-	.main-corner-actions-start {
-		left: 12px;
-	}
-
-	.main-corner-actions-end {
-		right: 10px;
-	}
-
-	.main-corner-actions :global(.tooltip-wrap),
-	.main-corner-actions .shell-titlebar-btn {
-		pointer-events: auto;
 	}
 
 	.content-row {

--- a/cometline/src/lib/components/WorkspacePanel.svelte
+++ b/cometline/src/lib/components/WorkspacePanel.svelte
@@ -915,8 +915,9 @@
 		align-items: center;
 		gap: 8px;
 		box-sizing: border-box;
-		min-height: var(--panel-header-height);
+		height: var(--panel-header-height);
 		padding: 0 10px;
+		overflow: hidden;
 		border-bottom: 1px solid var(--border-soft);
 		background: rgba(250, 250, 249, 0.95);
 	}

--- a/cometline/src/lib/components/jobs/JobsPage.svelte
+++ b/cometline/src/lib/components/jobs/JobsPage.svelte
@@ -585,10 +585,7 @@
 
 <div class="jobs-page settings-ui">
 	<header class="jobs-header">
-		<div>
-			<h1>Jobs</h1>
-			<p>Global work queue shared across sessions.</p>
-		</div>
+		<p>Global work queue shared across sessions.</p>
 		<div class="jobs-header-actions">
 			{#if view === 'active'}
 				<div class="status-filters" role="group" aria-label="Filter by status">
@@ -989,19 +986,10 @@
 		margin-bottom: 16px;
 	}
 
-	.jobs-header > div:first-child {
+	.jobs-header > p {
 		min-width: 0;
-	}
-
-	.jobs-header h1 {
-		margin: 0 0 4px;
-		font-size: 20px;
-		font-weight: 650;
-		color: var(--text-main);
-	}
-
-	.jobs-header p {
 		margin: 0;
+		padding-left: 14px;
 		font-size: 12px;
 		color: var(--text-muted);
 	}

--- a/cometline/src/lib/components/skills/SkillDraftsPage.svelte
+++ b/cometline/src/lib/components/skills/SkillDraftsPage.svelte
@@ -111,14 +111,11 @@
 
 <div class="skill-drafts-page settings-ui">
 	<header class="page-header">
-		<div>
-			<h1>Skill Drafts</h1>
-			<p>
-				Review and edit reusable skills drafted from <code>/create-skill</code> or completed
-				jobs. Drafts stay inactive until you promote them into
-				<code>~/.cometmind/skills</code>.
-			</p>
-		</div>
+		<p>
+			Review and edit reusable skills drafted from <code>/create-skill</code> or completed
+			jobs. Drafts stay inactive until you promote them into
+			<code>~/.cometmind/skills</code>.
+		</p>
 		<button class="secondary" type="button" onclick={() => void refreshDrafts({ keepSelection: true })}>
 			{busy ? 'Loading...' : 'Refresh drafts'}
 		</button>
@@ -223,16 +220,17 @@
 		align-items: flex-start;
 	}
 
-	.page-header > div,
-	.preview-header > div:first-child {
+	.page-header > p {
 		min-width: 0;
+		margin: 0;
+		padding-left: 14px;
+		font-size: 12px;
+		line-height: 1.5;
+		color: var(--text-muted);
 	}
 
-	.page-header h1 {
-		margin: 0 0 4px;
-		font-size: 20px;
-		font-weight: 650;
-		color: var(--text-main);
+	.preview-header > div:first-child {
+		min-width: 0;
 	}
 
 	.section-header h2,
@@ -242,7 +240,6 @@
 		color: var(--text-main);
 	}
 
-	.page-header p,
 	.preview-header p,
 	.empty-state p,
 	.page-status,


### PR DESCRIPTION
## Background

The shell chrome currently disappears or floats over content as the sidebar and utility routes change. Keeping one titlebar mounted gives chat, Jobs, and Skill Drafts a stable heading and a consistent place for panel controls.

[28537da](https://github.com/Cometline/cometline/commit/28537da51174194ae55c4fab614bf53f855483b9): Moves sidebar and workspace toggles into the persistent shell titlebar, gives utility routes titlebar labels, and aligns utility and workspace-panel headers with shared chrome sizing.