### PR TITLE
[main] fix: estimate screenshots as vision tokens

### DIFF
--- a/cometmind/internal/agent/budget.go
+++ b/cometmind/internal/agent/budget.go
@@ -6,6 +6,7 @@ import (
 	"unicode/utf8"
 
 	cometsdk "github.com/cometline/comet-sdk"
+	"github.com/cometline/cometmind/internal/session"
 )
 
 const (
@@ -39,6 +40,12 @@ func EstimateMessageTokens(msg cometsdk.Message) int {
 			total += EstimateTokens(string(b.Input))
 		case cometsdk.ToolResultBlock:
 			total += EstimateTokens(b.Content)
+		case cometsdk.ImageBlock:
+			total += session.EstimateImageTokens(b.MediaType, b.Data)
+		case *cometsdk.ImageBlock:
+			if b != nil {
+				total += session.EstimateImageTokens(b.MediaType, b.Data)
+			}
 		default:
 			if raw, err := json.Marshal(block); err == nil {
 				total += EstimateTokens(string(raw))

--- a/cometmind/internal/agent/budget_test.go
+++ b/cometmind/internal/agent/budget_test.go
@@ -1,6 +1,11 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	cometsdk "github.com/cometline/comet-sdk"
+)
 
 func TestEstimatePromptTokensIncludesSummary(t *testing.T) {
 	base := EstimatePromptTokens(PromptBudgetInput{
@@ -12,5 +17,29 @@ func TestEstimatePromptTokensIncludesSummary(t *testing.T) {
 	})
 	if withSummary <= base {
 		t.Fatalf("summary should increase estimate: base=%d with=%d", base, withSummary)
+	}
+}
+
+func TestEstimatePromptTokensDoesNotCountImageBase64(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("A", 800_000)
+	got := EstimatePromptTokens(PromptBudgetInput{
+		Messages: []cometsdk.Message{{
+			Role: cometsdk.RoleUser,
+			Content: []cometsdk.Block{
+				cometsdk.TextBlock{Text: "look"},
+				cometsdk.ImageBlock{MediaType: "image/png", Data: huge},
+			},
+		}},
+	})
+	textOnly := EstimateTokens("look")
+	if got <= textOnly {
+		t.Fatalf("estimate %d should include image tokens above text %d", got, textOnly)
+	}
+	if got >= len(huge)/4 {
+		t.Fatalf("estimate %d must not use base64 chars/4 (%d)", got, len(huge)/4)
+	}
+	if got > textOnly+3000 {
+		t.Fatalf("estimate %d is still far above a vision fallback (text=%d)", got, textOnly)
 	}
 }

--- a/cometmind/internal/session/compaction.go
+++ b/cometmind/internal/session/compaction.go
@@ -68,11 +68,7 @@ func FormatTranscriptForSummary(rows []db.Message) string {
 	for _, row := range rows {
 		switch row.Role {
 		case "user":
-			text, err := plainTextFromStoredContent(row.Content)
-			if err != nil {
-				text = row.Content
-			}
-			fmt.Fprintf(&b, "User: %s\n", strings.TrimSpace(text))
+			fmt.Fprintf(&b, "User: %s\n", formatUserContentForSummary(row.Content))
 		case "assistant":
 			if strings.TrimSpace(row.Content) != "" {
 				fmt.Fprintf(&b, "Assistant: %s\n", strings.TrimSpace(row.Content))
@@ -91,6 +87,22 @@ func FormatTranscriptForSummary(rows []db.Message) string {
 		}
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func formatUserContentForSummary(content string) string {
+	blocks, err := DecodeMessageContent(content)
+	if err != nil {
+		return strings.TrimSpace(content)
+	}
+	text := strings.TrimSpace(PlainTextFromContent(blocks))
+	if n := countImageBlocks(blocks); n > 0 {
+		note := fmt.Sprintf("[user attached %d image(s)]", n)
+		if text == "" {
+			return note
+		}
+		return text + " " + note
+	}
+	return text
 }
 
 func plainTextFromStoredContent(content string) (string, error) {

--- a/cometmind/internal/session/compaction_test.go
+++ b/cometmind/internal/session/compaction_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cometline/cometmind/internal/db"
@@ -45,5 +46,24 @@ func TestFilterMessagesAfterCompacted(t *testing.T) {
 	got := FilterMessagesAfterCompacted(rows, "m1")
 	if len(got) != 2 || got[0].ID != "m2" {
 		t.Fatalf("filtered = %+v", got)
+	}
+}
+
+func TestFormatTranscriptForSummaryMentionsImages(t *testing.T) {
+	t.Parallel()
+	raw, err := marshalMessageContent([]ContentBlock{
+		{Type: "text", Text: "align the icon"},
+		{Type: "image", MediaType: "image/png", Data: "aGVsbG8="},
+		{Type: "image", MediaType: "image/png", Data: "aGVsbG8="},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("marshalMessageContent() error = %v", err)
+	}
+	got := FormatTranscriptForSummary([]db.Message{{ID: "u1", Role: "user", Content: raw}})
+	if !strings.Contains(got, "align the icon") {
+		t.Fatalf("summary missing caption: %q", got)
+	}
+	if !strings.Contains(got, "[user attached 2 image(s)]") {
+		t.Fatalf("summary missing image note: %q", got)
 	}
 }

--- a/cometmind/internal/session/image_tokens.go
+++ b/cometmind/internal/session/image_tokens.go
@@ -1,0 +1,92 @@
+package session
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"strings"
+)
+
+const (
+	imageTokenFallback  = 2048
+	imageTileSize       = 512
+	imageBaseTokens     = 85
+	imageTokensPerTile  = 170
+	dataURLBase64Marker = "base64,"
+)
+
+// EstimateImageTokens estimates vision tokens for an inline image.
+// When PNG/JPEG dimensions can be read, this uses an OpenAI-style tile
+// formula (85 + 170 × ceil(w/512) × ceil(h/512)). Invalid or undecodable
+// payloads fall back to a flat 2048 — never chars/4 of the base64.
+func EstimateImageTokens(mediaType, data string) int {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return 0
+	}
+	if w, h, ok := decodeImageDimensions(data); ok {
+		return imageTileTokens(w, h)
+	}
+	return imageTokenFallback
+}
+
+func imageTileTokens(width, height int) int {
+	if width <= 0 || height <= 0 {
+		return imageTokenFallback
+	}
+	tilesX := (width + imageTileSize - 1) / imageTileSize
+	tilesY := (height + imageTileSize - 1) / imageTileSize
+	return imageBaseTokens + imageTokensPerTile*tilesX*tilesY
+}
+
+func decodeImageDimensions(data string) (width, height int, ok bool) {
+	raw, err := decodeImageBytes(data)
+	if err != nil || len(raw) == 0 {
+		return 0, 0, false
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil || cfg.Width <= 0 || cfg.Height <= 0 {
+		return 0, 0, false
+	}
+	return cfg.Width, cfg.Height, true
+}
+
+func decodeImageBytes(data string) ([]byte, error) {
+	payload := data
+	if i := strings.Index(strings.ToLower(data), dataURLBase64Marker); i >= 0 {
+		payload = data[i+len(dataURLBase64Marker):]
+	}
+	payload = strings.TrimSpace(payload)
+	if decoded, err := base64.StdEncoding.DecodeString(payload); err == nil {
+		return decoded, nil
+	}
+	return base64.RawStdEncoding.DecodeString(payload)
+}
+
+// EstimateContentBlocksTokens estimates tokens for persisted content blocks.
+// Text uses chars/4; images use EstimateImageTokens.
+func EstimateContentBlocksTokens(blocks []ContentBlock) int {
+	total := 0
+	for _, block := range blocks {
+		if block.Type == "image" {
+			total += EstimateImageTokens(block.MediaType, block.Data)
+			continue
+		}
+		if block.Text != "" {
+			total += EstimateTokens(block.Text)
+		}
+	}
+	return total
+}
+
+func countImageBlocks(blocks []ContentBlock) int {
+	n := 0
+	for _, block := range blocks {
+		if block.Type == "image" {
+			n++
+		}
+	}
+	return n
+}

--- a/cometmind/internal/session/image_tokens_test.go
+++ b/cometmind/internal/session/image_tokens_test.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"strings"
+	"testing"
+)
+
+func TestEstimateImageTokensUsesTilesNotBase64Length(t *testing.T) {
+	t.Parallel()
+	png := pngIHDR(64, 64)
+	got := EstimateImageTokens("image/png", base64.StdEncoding.EncodeToString(png))
+	if got != 255 {
+		t.Fatalf("64x64 PNG tokens = %d, want 255 (1 tile)", got)
+	}
+
+	huge := strings.Repeat("A", 800_000)
+	fallback := EstimateImageTokens("image/png", huge)
+	if fallback != imageTokenFallback {
+		t.Fatalf("undecodable payload tokens = %d, want fallback %d", fallback, imageTokenFallback)
+	}
+	if fallback >= len(huge)/4 {
+		t.Fatalf("undecodable payload must not use chars/4: got %d chars/4=%d", fallback, len(huge)/4)
+	}
+}
+
+func TestEstimateImageTokensScalesWithDimensions(t *testing.T) {
+	t.Parallel()
+	png := pngIHDR(1920, 1080)
+	got := EstimateImageTokens("image/png", base64.StdEncoding.EncodeToString(png))
+	// ceil(1920/512)=4, ceil(1080/512)=3 → 85 + 170*12 = 2125
+	if got != 2125 {
+		t.Fatalf("1920x1080 PNG tokens = %d, want 2125", got)
+	}
+}
+
+func TestEstimateImageTokensAcceptsDataURL(t *testing.T) {
+	t.Parallel()
+	png := pngIHDR(512, 512)
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
+	got := EstimateImageTokens("image/png", dataURL)
+	if got != 255 {
+		t.Fatalf("data URL tokens = %d, want 255", got)
+	}
+}
+
+func TestEstimateImageTokensEmpty(t *testing.T) {
+	t.Parallel()
+	if got := EstimateImageTokens("image/png", ""); got != 0 {
+		t.Fatalf("empty data tokens = %d, want 0", got)
+	}
+}
+
+func pngIHDR(width, height int) []byte {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a})
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], uint32(width))
+	binary.BigEndian.PutUint32(ihdr[4:8], uint32(height))
+	ihdr[8] = 8
+	ihdr[9] = 2
+	writePNGChunk(&buf, "IHDR", ihdr)
+	writePNGChunk(&buf, "IEND", nil)
+	return buf.Bytes()
+}
+
+func writePNGChunk(buf *bytes.Buffer, name string, data []byte) {
+	var chunk bytes.Buffer
+	chunk.WriteString(name)
+	chunk.Write(data)
+	_ = binary.Write(buf, binary.BigEndian, uint32(len(data)))
+	buf.Write(chunk.Bytes())
+	_ = binary.Write(buf, binary.BigEndian, crc32.ChecksumIEEE(chunk.Bytes()))
+}

--- a/cometmind/internal/session/prompt_budget.go
+++ b/cometmind/internal/session/prompt_budget.go
@@ -68,11 +68,12 @@ func EstimateRowsTokens(rows []db.Message, callsByMessage map[string][]db.ToolCa
 	for _, row := range rows {
 		switch row.Role {
 		case "user":
-			text, err := plainTextFromStoredContent(row.Content)
+			blocks, err := DecodeMessageContent(row.Content)
 			if err != nil {
-				text = row.Content
+				total += EstimateTokens(row.Content)
+				break
 			}
-			total += EstimateTokens(text)
+			total += EstimateContentBlocksTokens(blocks)
 		case "assistant":
 			total += EstimateTokens(row.Content)
 			for _, tc := range callsByMessage[row.ID] {

--- a/cometmind/internal/session/prompt_budget_test.go
+++ b/cometmind/internal/session/prompt_budget_test.go
@@ -37,3 +37,52 @@ func TestRecentWindowStartForBudget_shrinksHugeTurn(t *testing.T) {
 		t.Fatalf("budgeted recent start = %d (%q), want u2", budgeted, rows[budgeted].ID)
 	}
 }
+
+func TestEstimateRowsTokensCountsImagesAsVisionTokens(t *testing.T) {
+	t.Parallel()
+	raw, err := marshalMessageContent([]ContentBlock{
+		{Type: "text", Text: "look at this"},
+		{Type: "image", MediaType: "image/png", Data: strings.Repeat("A", 800_000)},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("marshalMessageContent() error = %v", err)
+	}
+	rows := []db.Message{{ID: "u1", Role: "user", Content: raw}}
+	got := EstimateRowsTokens(rows, nil)
+	textOnly := EstimateTokens("look at this")
+	if got <= textOnly {
+		t.Fatalf("image row tokens = %d, want more than text-only %d", got, textOnly)
+	}
+	if got >= 800_000/4 {
+		t.Fatalf("image row tokens = %d, must not count base64 chars/4", got)
+	}
+	if got != textOnly+imageTokenFallback {
+		t.Fatalf("image row tokens = %d, want text %d + fallback %d", got, textOnly, imageTokenFallback)
+	}
+}
+
+func TestRecentWindowStartForBudget_shrinksScreenshotTurn(t *testing.T) {
+	t.Parallel()
+	screenshot, err := marshalMessageContent([]ContentBlock{
+		{Type: "text", Text: "align the sidebar icon"},
+		{Type: "image", MediaType: "image/png", Data: strings.Repeat("A", 800_000)},
+		{Type: "image", MediaType: "image/png", Data: strings.Repeat("B", 600_000)},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("marshalMessageContent() error = %v", err)
+	}
+	rows := []db.Message{
+		{ID: "u1", Role: "user", Content: screenshot},
+		{ID: "a1", Role: "assistant", Content: "ok"},
+		{ID: "u2", Role: "user", Content: "thanks"},
+	}
+
+	// Two fallback images (4096) exceed 45% of 4k-2k available (~878).
+	got := RecentWindowStartForBudget(rows, nil, 10, 4_000, 2048)
+	if got == 0 {
+		t.Fatal("expected screenshot turn to be dropped from the recent window")
+	}
+	if rows[got].ID != "u2" {
+		t.Fatalf("recent start = %d (%q), want u2", got, rows[got].ID)
+	}
+}


### PR DESCRIPTION
## Background

After context compaction the composer ring could stay at 100% because inline screenshots were counted as chars/4 of their base64 payload. The recent-window planner ignored those images, so a second compact had nothing to fold.

[de76328](https://github.com/Cometline/cometline/commit/de7632857c49c6ab6889ea38e8c4f356d48cd7a2): Context budget and compaction now estimate images with a vision tile formula, and the rolling summary records that screenshots were attached.
