### PR TITLE
[main] feat: load workspace files from a local index

### DIFF
--- a/cometline/src/lib/client/cometmind.ts
+++ b/cometline/src/lib/client/cometmind.ts
@@ -334,10 +334,16 @@ export interface WorkspaceFiles {
 export function listWorkspaceFiles(
 	workspacePath: string,
 	query = '',
-	limit = 50
+	limit = 50,
+	options?: { index?: boolean }
 ): Promise<WorkspaceFiles> {
 	return listWorkspaceFilesApi({
-		query: { workspace_path: workspacePath, q: query, limit },
+		query: {
+			workspace_path: workspacePath,
+			q: query,
+			limit,
+			...(options?.index ? { index: true } : {})
+		},
 		throwOnError: true
 	}).then(({ data }) => ({ files: data.files ?? [], truncated: Boolean(data.truncated) }));
 }

--- a/cometline/src/lib/components/FileTreeBrowser.svelte
+++ b/cometline/src/lib/components/FileTreeBrowser.svelte
@@ -1,22 +1,30 @@
 <script lang="ts">
 	import { tick, untrack } from 'svelte';
 	import { ChevronDown, ChevronRight, Folder, FolderOpen, Loader } from '@lucide/svelte';
-	import {
-		listWikiFileChildren,
-		listWikiFiles,
-		listWorkspaceFileChildren,
-		listWorkspaceFiles
-	} from '$lib/client/cometmind';
+	import { listWikiFileChildren, listWorkspaceFileChildren } from '$lib/client/cometmind';
 	import FileTypeIcon from '$lib/components/FileTypeIcon.svelte';
 	import { shellStore, type FileTreeExpandSource } from '$lib/stores/shell.svelte';
 	import { toWikiUiPath } from '$lib/wiki/paths';
+	import { getCachedWikiFiles, refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
+	import { rankMatchingFiles } from '$lib/workspace/file-search';
+	import {
+		getFileIndex,
+		isFileIndexTruncated,
+		normalizeWorkspacePath,
+		refreshFileIndex,
+		searchWorkspaceFiles
+	} from '$lib/workspace/file-index';
 	import {
 		buildFileTree,
 		dirKeysToExpandForPaths,
 		flattenVisibleFileTreeRows,
 		type FileTreeNode
 	} from '$lib/workspace/file-tree';
-	import { normalizeWorkspacePath } from '$lib/workspace/file-index';
+	import {
+		FILE_TREE_SEARCH_LIMIT,
+		FILE_TREE_SEARCH_ROW_HEIGHT,
+		virtualWindow
+	} from '$lib/workspace/virtual-list';
 	import { workspaceChangeVersion } from '$lib/workspace/workspace-change.svelte';
 
 	const LIST_LIMIT = 10000;
@@ -42,13 +50,46 @@
 	let selectedKey = $state<string | null>(null);
 	let loadSeq = 0;
 	let browserEl = $state<HTMLDivElement | null>(null);
+	let searchResults = $state<string[]>([]);
+	let searchScrollEl = $state<HTMLDivElement | null>(null);
+	let searchScrollTop = $state(0);
+	let searchViewportHeight = $state(320);
 
 	const normalizedWorkspace = $derived(normalizeWorkspacePath(workspacePath));
 	const workspaceAvailable = $derived(
 		Boolean(normalizedWorkspace && normalizedWorkspace !== '/')
 	);
+	const searching = $derived(Boolean(filter.trim()));
 	const tree = $derived(buildFileTree(files));
-	const visibleRows = $derived(flattenVisibleFileTreeRows(tree, expanded));
+	const visibleRows = $derived(
+		searching
+			? searchResults.map((path) => ({
+					kind: 'file' as const,
+					key: path,
+					name: fileName(path),
+					path
+				}))
+			: flattenVisibleFileTreeRows(tree, expanded)
+	);
+	const searchWindow = $derived(
+		virtualWindow(
+			searchResults.length,
+			searchScrollTop,
+			searchViewportHeight,
+			FILE_TREE_SEARCH_ROW_HEIGHT
+		)
+	);
+	const visibleSearchResults = $derived(searchResults.slice(searchWindow.start, searchWindow.end));
+
+	function fileName(path: string): string {
+		return path.split(/[/\\]/).filter(Boolean).pop() || path;
+	}
+
+	function fileDir(path: string): string {
+		const parts = path.split(/[/\\]/).filter(Boolean);
+		if (parts.length <= 1) return '';
+		return parts.slice(0, -1).join('/');
+	}
 
 	function persistExpanded(next: Record<string, boolean>) {
 		shellStore.setFileTreeExpanded(source, next);
@@ -89,9 +130,25 @@
 		onSelectFile(relativePath);
 	}
 
+	function scrollSearchIndexIntoView(index: number) {
+		if (!searchScrollEl) return;
+		const top = index * FILE_TREE_SEARCH_ROW_HEIGHT;
+		const bottom = top + FILE_TREE_SEARCH_ROW_HEIGHT;
+		const viewTop = searchScrollEl.scrollTop;
+		const viewBottom = viewTop + searchScrollEl.clientHeight;
+		if (top < viewTop) searchScrollEl.scrollTop = top;
+		else if (bottom > viewBottom) searchScrollEl.scrollTop = bottom - searchScrollEl.clientHeight;
+	}
+
 	async function scrollSelectedIntoView() {
 		const key = selectedKey;
-		if (!key || !browserEl) return;
+		if (!key) return;
+		if (searching) {
+			const index = searchResults.indexOf(key);
+			if (index >= 0) scrollSearchIndexIntoView(index);
+			return;
+		}
+		if (!browserEl) return;
 		await tick();
 		const el = browserEl.querySelector(`[data-tree-key="${CSS.escape(key)}"]`);
 		el?.scrollIntoView({ block: 'nearest' });
@@ -193,12 +250,54 @@
 		}
 	}
 
+	async function loadSearch(seq: number) {
+		const query = filter.trim();
+		error = null;
+		if (source === 'workspace' && !workspaceAvailable) {
+			searchResults = [];
+			loading = false;
+			return;
+		}
+		try {
+			if (source === 'wiki') {
+				let wikiFiles = getCachedWikiFiles();
+				if (wikiFiles.length === 0) {
+					loading = true;
+					wikiFiles = await refreshWikiFileIndex();
+					if (seq !== loadSeq) return;
+				}
+				searchResults = rankMatchingFiles(wikiFiles, query, FILE_TREE_SEARCH_LIMIT);
+				return;
+			}
+
+			let index = getFileIndex(normalizedWorkspace);
+			if (!index?.loaded) {
+				loading = true;
+				index = await refreshFileIndex(normalizedWorkspace);
+				if (seq !== loadSeq) return;
+			}
+			let matches = rankMatchingFiles(index.files, query, FILE_TREE_SEARCH_LIMIT);
+			if (isFileIndexTruncated(normalizedWorkspace)) {
+				const extra = await searchWorkspaceFiles(normalizedWorkspace, query);
+				if (seq !== loadSeq) return;
+				matches = rankMatchingFiles([...index.files, ...extra], query, FILE_TREE_SEARCH_LIMIT);
+			}
+			searchResults = matches;
+		} catch (err) {
+			if (seq !== loadSeq) return;
+			searchResults = [];
+			error = err instanceof Error ? err.message : 'Failed to search files';
+		} finally {
+			if (seq === loadSeq) loading = false;
+		}
+	}
+
 	async function loadFiles() {
 		const seq = ++loadSeq;
-		const query = filter.trim();
 		loading = true;
 		error = null;
 		files = [];
+		searchResults = [];
 		loadedDirectories = {};
 		loadingDirectories = {};
 
@@ -209,35 +308,22 @@
 		}
 
 		try {
-			if (query) {
-				const result =
-					source === 'wiki'
-						? await listWikiFiles(query, LIST_LIMIT)
-						: await listWorkspaceFiles(normalizedWorkspace, query, LIST_LIMIT);
-				if (seq !== loadSeq) return;
-				files = result.files;
-				// Filter mode: expand matches only (do not overwrite the stored map).
-				expanded = dirKeysToExpandForPaths(files);
-			} else {
-				expanded = { ...shellStore.getFileTreeExpanded(source) };
-				await loadDirectory('', seq);
-				if (seq !== loadSeq) return;
+			expanded = { ...shellStore.getFileTreeExpanded(source) };
+			await loadDirectory('', seq);
+			if (seq !== loadSeq) return;
 
-				const openDirectories = Object.keys(expanded)
-					.filter((directory) => expanded[directory])
-					.sort((a, b) => a.split('/').length - b.split('/').length);
-				for (const directory of openDirectories) {
-					await loadDirectory(directory, seq);
-					if (seq !== loadSeq) return;
-				}
+			const openDirectories = Object.keys(expanded)
+				.filter((directory) => expanded[directory])
+				.sort((a, b) => a.split('/').length - b.split('/').length);
+			for (const directory of openDirectories) {
+				await loadDirectory(directory, seq);
+				if (seq !== loadSeq) return;
 			}
 		} catch (err) {
 			if (seq !== loadSeq) return;
 			files = [];
 			loadedDirectories = {};
-			if (!query) {
-				expanded = { ...shellStore.getFileTreeExpanded(source) };
-			}
+			expanded = { ...shellStore.getFileTreeExpanded(source) };
 			error = err instanceof Error ? err.message : 'Failed to load files';
 		} finally {
 			if (seq === loadSeq) loading = false;
@@ -245,9 +331,32 @@
 	}
 
 	$effect(() => {
-		void [filter, normalizedWorkspace, workspaceChangeVersion(normalizedWorkspace)];
+		if (source === 'workspace' && workspaceAvailable) {
+			void [normalizedWorkspace, workspaceChangeVersion(normalizedWorkspace)];
+			untrack(() => void refreshFileIndex(normalizedWorkspace));
+		} else if (source === 'wiki') {
+			untrack(() => void refreshWikiFileIndex());
+		}
+	});
+
+	$effect(() => {
+		void [filter, normalizedWorkspace, workspaceChangeVersion(normalizedWorkspace), source];
 		// Loading mutates the lazy cache; do not make those mutations dependencies of this effect.
-		untrack(() => void loadFiles());
+		untrack(() => {
+			if (filter.trim()) void loadSearch(++loadSeq);
+			else void loadFiles();
+		});
+	});
+
+	function onSearchScroll(event: Event) {
+		const el = event.currentTarget as HTMLDivElement;
+		searchScrollTop = el.scrollTop;
+		searchViewportHeight = el.clientHeight;
+	}
+
+	$effect(() => {
+		if (!searchScrollEl) return;
+		searchViewportHeight = searchScrollEl.clientHeight || 320;
 	});
 
 	$effect(() => {
@@ -346,16 +455,57 @@
 >
 	{#if source === 'workspace' && !workspaceAvailable}
 		<div class="file-tree-state">Select a workspace to browse its files.</div>
-	{:else if loading && files.length === 0}
+	{:else if searching && loading && searchResults.length === 0}
+		<div class="file-tree-state">
+			<Loader size={16} stroke-width={2} class="file-tree-spinner" />
+			<span>Loading files…</span>
+		</div>
+	{:else if !searching && loading && files.length === 0}
 		<div class="file-tree-state">
 			<Loader size={16} stroke-width={2} class="file-tree-spinner" />
 			<span>Loading files…</span>
 		</div>
 	{:else if error}
 		<div class="file-tree-state file-tree-error">{error}</div>
-	{:else if tree.length === 0}
-		<div class="file-tree-state">
-			{filter.trim() ? 'No matching files.' : 'No files found.'}
+	{:else if searching && searchResults.length === 0}
+		<div class="file-tree-state">No matching files.</div>
+	{:else if !searching && tree.length === 0}
+		<div class="file-tree-state">No files found.</div>
+	{:else if searching}
+		<div
+			class="file-tree-scroll scrollbar-none"
+			bind:this={searchScrollEl}
+			onscroll={onSearchScroll}
+		>
+			<div class="file-search-virtual" style:height="{searchWindow.height}px">
+				<div class="file-search-virtual-inner" style:transform="translateY({searchWindow.offset}px)">
+					{#each visibleSearchResults as path, offset (path)}
+						{@const index = searchWindow.start + offset}
+						<button
+							type="button"
+							class="file-tree-row file-tree-file file-search-row"
+							class:selected={selectedKey === path}
+							data-tree-key={path}
+							data-result-index={index}
+							onclick={() => {
+								selectedKey = path;
+								selectRelative(path);
+							}}
+							title={path}
+						>
+							<span class="file-tree-icon" aria-hidden="true">
+								<FileTypeIcon {path} size={14} />
+							</span>
+							<span class="file-search-labels">
+								<span class="file-search-name">{fileName(path)}</span>
+								{#if fileDir(path)}
+									<span class="file-search-dir">{fileDir(path)}</span>
+								{/if}
+							</span>
+						</button>
+					{/each}
+				</div>
+			</div>
 		</div>
 	{:else}
 		<div class="file-tree-scroll scrollbar-none">
@@ -459,6 +609,53 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.file-search-virtual {
+		position: relative;
+		width: 100%;
+	}
+
+	.file-search-virtual-inner {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+	}
+
+	.file-search-row {
+		box-sizing: border-box;
+		height: 22px;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	.file-search-labels {
+		display: flex;
+		align-items: baseline;
+		gap: 8px;
+		min-width: 0;
+		flex: 1 1 auto;
+	}
+
+	.file-search-name {
+		flex: 0 1 auto;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-weight: 550;
+	}
+
+	.file-search-dir {
+		flex: 1 1 auto;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 	}
 
 	.file-tree-state {

--- a/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
+++ b/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
@@ -2,17 +2,37 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getFileTreeExpanded, listWikiFileChildren, setFileTreeExpanded } = vi.hoisted(() => ({
+const {
+	getFileTreeExpanded,
+	listWikiFileChildren,
+	listWorkspaceFileChildren,
+	listWorkspaceFiles,
+	setFileTreeExpanded,
+	getFileIndex,
+	refreshFileIndex,
+	searchWorkspaceFiles,
+	isFileIndexTruncated,
+	getCachedWikiFiles,
+	refreshWikiFileIndex
+} = vi.hoisted(() => ({
 	getFileTreeExpanded: vi.fn(() => ({})),
 	listWikiFileChildren: vi.fn(),
-	setFileTreeExpanded: vi.fn()
+	listWorkspaceFileChildren: vi.fn(),
+	listWorkspaceFiles: vi.fn(),
+	setFileTreeExpanded: vi.fn(),
+	getFileIndex: vi.fn(),
+	refreshFileIndex: vi.fn(),
+	searchWorkspaceFiles: vi.fn(),
+	isFileIndexTruncated: vi.fn(() => false),
+	getCachedWikiFiles: vi.fn(() => []),
+	refreshWikiFileIndex: vi.fn(async () => [])
 }));
 
 vi.mock('$lib/client/cometmind', () => ({
 	listWikiFileChildren,
 	listWikiFiles: vi.fn(),
-	listWorkspaceFileChildren: vi.fn(),
-	listWorkspaceFiles: vi.fn()
+	listWorkspaceFileChildren,
+	listWorkspaceFiles
 }));
 
 vi.mock('$lib/stores/shell.svelte', () => ({
@@ -20,7 +40,21 @@ vi.mock('$lib/stores/shell.svelte', () => ({
 }));
 
 vi.mock('$lib/workspace/file-index', () => ({
-	normalizeWorkspacePath: (path: string) => path
+	normalizeWorkspacePath: (path: string) => path,
+	getFileIndex,
+	refreshFileIndex,
+	searchWorkspaceFiles,
+	isFileIndexTruncated,
+	filterFileIndex: (files: string[], query: string) => {
+		const q = query.trim().toLowerCase();
+		if (!q) return files;
+		return files.filter((path) => path.toLowerCase().includes(q));
+	}
+}));
+
+vi.mock('$lib/wiki/wiki-file-index', () => ({
+	getCachedWikiFiles,
+	refreshWikiFileIndex
 }));
 
 vi.mock('$lib/workspace/workspace-change.svelte', () => ({
@@ -34,7 +68,16 @@ describe('FileTreeBrowser', () => {
 		getFileTreeExpanded.mockReturnValue({});
 		listWikiFileChildren.mockReset();
 		listWikiFileChildren.mockResolvedValue({ files: ['entities/'], truncated: false });
+		listWorkspaceFileChildren.mockReset();
+		listWorkspaceFileChildren.mockResolvedValue({ files: ['src/'], truncated: false });
+		listWorkspaceFiles.mockReset();
 		setFileTreeExpanded.mockReset();
+		getFileIndex.mockReset();
+		refreshFileIndex.mockReset();
+		searchWorkspaceFiles.mockReset();
+		isFileIndexTruncated.mockReturnValue(false);
+		getCachedWikiFiles.mockReturnValue([]);
+		refreshWikiFileIndex.mockResolvedValue([]);
 	});
 
 	it('loads the root directory once without retriggering from its cache update', async () => {
@@ -50,5 +93,30 @@ describe('FileTreeBrowser', () => {
 		await new Promise((resolve) => setTimeout(resolve, 20));
 		expect(listWikiFileChildren).toHaveBeenCalledTimes(1);
 		expect(listWikiFileChildren).toHaveBeenCalledWith('', 10000);
+	});
+
+	it('filters workspace files from the local index without a 10k list query', async () => {
+		getFileIndex.mockReturnValue({
+			files: ['src/app.ts', 'src/lib/foo.ts', 'README.md'],
+			loading: false,
+			loaded: true,
+			error: null,
+			loadedAt: Date.now(),
+			truncated: false
+		});
+
+		render(FileTreeBrowser, {
+			workspacePath: '/repo',
+			onSelectFile: () => {},
+			source: 'workspace',
+			filter: 'app'
+		});
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /app\.ts/ })).toBeTruthy();
+		});
+		expect(listWorkspaceFiles).not.toHaveBeenCalled();
+		expect(listWorkspaceFileChildren).not.toHaveBeenCalled();
+		expect(screen.queryByRole('button', { name: 'src' })).toBeNull();
 	});
 });

--- a/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
+++ b/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
@@ -24,8 +24,8 @@ const {
 	refreshFileIndex: vi.fn(),
 	searchWorkspaceFiles: vi.fn(),
 	isFileIndexTruncated: vi.fn(() => false),
-	getCachedWikiFiles: vi.fn(() => []),
-	refreshWikiFileIndex: vi.fn(async () => [])
+	getCachedWikiFiles: vi.fn((): string[] => []),
+	refreshWikiFileIndex: vi.fn(async (): Promise<string[]> => [])
 }));
 
 vi.mock('$lib/client/cometmind', () => ({

--- a/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
+++ b/cometline/src/lib/components/FileTreeBrowser.svelte.test.ts
@@ -119,4 +119,48 @@ describe('FileTreeBrowser', () => {
 		expect(listWorkspaceFileChildren).not.toHaveBeenCalled();
 		expect(screen.queryByRole('button', { name: 'src' })).toBeNull();
 	});
+
+	it('filters wiki files from the wiki index without a query list', async () => {
+		getCachedWikiFiles.mockReturnValue(['topics/setup.md', 'topics/overview.md']);
+
+		render(FileTreeBrowser, {
+			workspacePath: '',
+			onSelectFile: () => {},
+			source: 'wiki',
+			filter: 'setup'
+		});
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /setup\.md/ })).toBeTruthy();
+		});
+		expect(screen.queryByRole('button', { name: /overview\.md/ })).toBeNull();
+		expect(listWikiFileChildren).not.toHaveBeenCalled();
+	});
+
+	it('merges server search hits when the workspace index is truncated', async () => {
+		getFileIndex.mockReturnValue({
+			files: ['src/app.ts'],
+			loading: false,
+			loaded: true,
+			error: null,
+			loadedAt: Date.now(),
+			truncated: true
+		});
+		isFileIndexTruncated.mockReturnValue(true);
+		searchWorkspaceFiles.mockResolvedValue(['pkg/beyond-cap.ts']);
+
+		render(FileTreeBrowser, {
+			workspacePath: '/repo',
+			onSelectFile: () => {},
+			source: 'workspace',
+			filter: 'ts'
+		});
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /app\.ts/ })).toBeTruthy();
+			expect(screen.getByRole('button', { name: /beyond-cap\.ts/ })).toBeTruthy();
+		});
+		expect(searchWorkspaceFiles).toHaveBeenCalledWith('/repo', 'ts');
+		expect(listWorkspaceFiles).not.toHaveBeenCalled();
+	});
 });

--- a/cometline/src/lib/generated/cometmind-api/sdk.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/sdk.gen.ts
@@ -196,6 +196,8 @@ export const commitWorkspaceGit = <ThrowOnError extends boolean = false>(options
  * Returns all workspace-relative file and directory paths for the requested workspace.
  * Directory paths end with `/`.
  * `.git` and `node_modules` directories are skipped.
+ * When `index=true`, common build directories and root `.gitignore` rules are
+ * also skipped and `limit` may be raised up to 50000 for a search index.
  *
  */
 export const listWorkspaceFiles = <ThrowOnError extends boolean = false>(options?: Options<ListWorkspaceFilesData, ThrowOnError>) => {

--- a/cometline/src/lib/generated/cometmind-api/types.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/types.gen.ts
@@ -1697,6 +1697,12 @@ export type ListWorkspaceFilesData = {
          * Maximum number of results to return.
          */
         limit?: number;
+        /**
+         * When true, build a search index listing (skip gitignored and build paths,
+         * allow a higher limit). Browse listings should omit this flag.
+         *
+         */
+        index?: boolean;
     };
     url: '/api/v1/workspaces/files';
 };

--- a/cometline/src/lib/wiki/wiki-file-index.ts
+++ b/cometline/src/lib/wiki/wiki-file-index.ts
@@ -1,6 +1,6 @@
 import { listWikiFiles } from '$lib/client/cometmind';
 
-const INDEX_LIMIT = 500;
+const INDEX_LIMIT = 10_000;
 const TTL_MS = 30_000;
 
 type WikiFileIndex = {

--- a/cometline/src/lib/workspace/file-index.test.ts
+++ b/cometline/src/lib/workspace/file-index.test.ts
@@ -7,6 +7,7 @@ import {
 	getFileIndex,
 	isFileIndexFresh,
 	isFileIndexReady,
+	INDEX_LIMIT,
 	isFileIndexTruncated,
 	refreshFileIndex,
 	searchWorkspaceFiles
@@ -44,6 +45,9 @@ describe('file-index', () => {
 		expect(result.truncated).toBe(false);
 		expect(isFileIndexReady('/workspace')).toBe(true);
 		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledTimes(1);
+		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledWith('/workspace', '', INDEX_LIMIT, {
+			index: true
+		});
 
 		const cached = await refreshFileIndex('/workspace');
 		expect(cached.files).toEqual(['a.go', 'b.md']);
@@ -130,7 +134,9 @@ describe('file-index', () => {
 		vi.mocked(cometmind.listWorkspaceFiles).mockResolvedValue(wf(['deep/nested/match.go']));
 		const result = await searchWorkspaceFiles('/workspace', 'match');
 		expect(result).toEqual(['deep/nested/match.go']);
-		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledWith('/workspace', 'match', 50);
+		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledWith('/workspace', 'match', 50, {
+			index: true
+		});
 	});
 
 	it('normalizes workspace paths for cache keys', async () => {
@@ -167,6 +173,21 @@ describe('file-index', () => {
 		const hits = filterMentionPaths(['src/lib/a.ts', 'src/b.ts', 'README.md'], 'src');
 		expect(hits.filter((h) => h.kind === 'dir').map((h) => h.path)).toEqual(['src/', 'src/lib/']);
 		expect(hits.some((h) => h.kind === 'file' && h.path === 'src/lib/a.ts')).toBe(true);
+	});
+
+	it('evicts the oldest workspace index after three cached workspaces', async () => {
+		vi.mocked(cometmind.listWorkspaceFiles).mockImplementation(async (_path, _q, _limit, _opts) =>
+			wf([`${_path}.go`])
+		);
+		await refreshFileIndex('/a');
+		await refreshFileIndex('/b');
+		await refreshFileIndex('/c');
+		await refreshFileIndex('/d');
+
+		expect(getFileIndex('/a')).toBeNull();
+		expect(getFileIndex('/d')?.files).toEqual(['/d.go']);
+		expect(getFileIndex('/b')).not.toBeNull();
+		expect(getFileIndex('/c')).not.toBeNull();
 	});
 
 	it('does not surface directories as file mentions', () => {

--- a/cometline/src/lib/workspace/file-index.ts
+++ b/cometline/src/lib/workspace/file-index.ts
@@ -11,13 +11,27 @@ export interface FileIndexEntry {
 	truncated: boolean;
 }
 
-/** Page size for the warm cache used by the @-mention picker. */
-const INDEX_LIMIT = 500;
+/** Page size for the warm search index (gitignore / build dirs skipped). */
+export const INDEX_LIMIT = 50_000;
 /** Page size for an on-demand server-side search in a truncated workspace. */
 const SEARCH_LIMIT = 50;
+const MAX_CACHED_INDEXES = 3;
 
 const cache = new Map<string, FileIndexEntry>();
 const inFlight = new Map<string, Promise<void>>();
+let lruKeys: string[] = [];
+
+function touchIndex(workspacePath: string) {
+	const key = normalizeWorkspacePath(workspacePath);
+	if (!key) return;
+	lruKeys = [key, ...lruKeys.filter((entry) => entry !== key)];
+	while (lruKeys.length > MAX_CACHED_INDEXES) {
+		const evict = lruKeys.pop();
+		if (!evict || evict === key) continue;
+		cache.delete(evict);
+		inFlight.delete(evict);
+	}
+}
 
 /** How long a loaded index is considered fresh before a background refresh. */
 export const FILE_INDEX_TTL_MS = 30_000;
@@ -30,7 +44,10 @@ export function normalizeWorkspacePath(workspacePath: string): string {
 }
 
 export function getFileIndex(workspacePath: string): FileIndexEntry | null {
-	return cache.get(normalizeWorkspacePath(workspacePath)) ?? null;
+	const key = normalizeWorkspacePath(workspacePath);
+	const entry = cache.get(key) ?? null;
+	if (entry) touchIndex(key);
+	return entry;
 }
 
 export function isFileIndexReady(workspacePath: string): boolean {
@@ -49,11 +66,13 @@ export function clearFileIndex(workspacePath: string): void {
 	const key = normalizeWorkspacePath(workspacePath);
 	cache.delete(key);
 	inFlight.delete(key);
+	lruKeys = lruKeys.filter((entry) => entry !== key);
 }
 
 export function clearAllFileIndexes(): void {
 	cache.clear();
 	inFlight.clear();
+	lruKeys = [];
 }
 
 export async function refreshFileIndex(workspacePath: string): Promise<FileIndexEntry> {
@@ -109,7 +128,10 @@ export async function refreshFileIndex(workspacePath: string): Promise<FileIndex
 
 async function load(workspacePath: string): Promise<void> {
 	try {
-		const { files, truncated } = await listWorkspaceFiles(workspacePath, '', INDEX_LIMIT);
+		const { files, truncated } = await listWorkspaceFiles(workspacePath, '', INDEX_LIMIT, {
+			index: true
+		});
+		touchIndex(workspacePath);
 		cache.set(workspacePath, {
 			files: files ?? [],
 			loading: false,
@@ -150,7 +172,9 @@ export async function searchWorkspaceFiles(
 ): Promise<string[]> {
 	workspacePath = normalizeWorkspacePath(workspacePath);
 	if (!workspacePath || !query.trim()) return [];
-	const { files } = await listWorkspaceFiles(workspacePath, query.trim(), SEARCH_LIMIT);
+	const { files } = await listWorkspaceFiles(workspacePath, query.trim(), SEARCH_LIMIT, {
+		index: true
+	});
 	return files ?? [];
 }
 

--- a/cometline/src/lib/workspace/file-search.test.ts
+++ b/cometline/src/lib/workspace/file-search.test.ts
@@ -5,7 +5,6 @@ vi.mock('$lib/client/cometmind', () => ({
 }));
 
 vi.mock('$lib/wiki/wiki-file-index', () => ({
-	getCachedWikiFiles: vi.fn(() => []),
 	refreshWikiFileIndex: vi.fn(async () => [])
 }));
 
@@ -31,7 +30,7 @@ vi.mock('$lib/workspace/file-index', () => ({
 
 import { listWikiFiles } from '$lib/client/cometmind';
 import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
-import { refreshFileIndex } from '$lib/workspace/file-index';
+import { refreshFileIndex, searchWorkspaceFiles } from '$lib/workspace/file-index';
 import { loadFileSearchOptions, rankFilePaths, rankMatchingFiles } from './file-search';
 
 describe('rankFilePaths', () => {
@@ -86,24 +85,38 @@ describe('loadFileSearchOptions', () => {
 		expect(files).toEqual(['index.md', 'topics/overview.md']);
 	});
 
-	it('queries listWikiFiles when filtering wiki results', async () => {
-		vi.mocked(listWikiFiles).mockResolvedValueOnce({
-			files: ['topics/', 'topics/setup.md', 'topics/setup-guide.md'],
-			truncated: false
-		});
+	it('filters wiki results from the wiki file index without a query list', async () => {
+		vi.mocked(refreshWikiFileIndex).mockResolvedValueOnce([
+			'topics/',
+			'topics/setup.md',
+			'topics/setup-guide.md'
+		]);
 		const files = await loadFileSearchOptions('wiki', '/repo', 'setup', 10);
-		expect(listWikiFiles).toHaveBeenCalled();
+		expect(listWikiFiles).not.toHaveBeenCalled();
 		expect(files[0]).toBe('topics/setup.md');
 		expect(files).not.toContain('topics/');
 	});
 
 	it('returns hidden files when the query matches', async () => {
-		vi.mocked(listWikiFiles).mockResolvedValueOnce({
-			files: ['.private.md'],
-			truncated: false
-		});
+		vi.mocked(refreshWikiFileIndex).mockResolvedValueOnce(['.private.md']);
 		const files = await loadFileSearchOptions('wiki', '/repo', 'private', 10);
+		expect(listWikiFiles).not.toHaveBeenCalled();
 		expect(files).toEqual(['.private.md']);
+	});
+
+	it('merges local index hits with server search when the workspace index is truncated', async () => {
+		vi.mocked(refreshFileIndex).mockResolvedValueOnce({
+			files: ['src/app.ts', 'src/z-local.ts'],
+			loading: false,
+			loaded: true,
+			error: null,
+			loadedAt: Date.now(),
+			truncated: true
+		});
+		vi.mocked(searchWorkspaceFiles).mockResolvedValueOnce(['pkg/beyond-cap.ts']);
+		const files = await loadFileSearchOptions('workspace', '/repo', 'ts', 10);
+		expect(searchWorkspaceFiles).toHaveBeenCalledWith('/repo', 'ts');
+		expect(files).toEqual(['pkg/beyond-cap.ts', 'src/app.ts', 'src/z-local.ts']);
 	});
 
 	it('omits directories from workspace search results', async () => {

--- a/cometline/src/lib/workspace/file-search.test.ts
+++ b/cometline/src/lib/workspace/file-search.test.ts
@@ -32,7 +32,7 @@ vi.mock('$lib/workspace/file-index', () => ({
 import { listWikiFiles } from '$lib/client/cometmind';
 import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
 import { refreshFileIndex } from '$lib/workspace/file-index';
-import { loadFileSearchOptions, rankFilePaths } from './file-search';
+import { loadFileSearchOptions, rankFilePaths, rankMatchingFiles } from './file-search';
 
 describe('rankFilePaths', () => {
 	it('ranks basename prefix matches above path substring matches', () => {
@@ -45,6 +45,14 @@ describe('rankFilePaths', () => {
 
 	it('sorts alphabetically when the query is empty', () => {
 		expect(rankFilePaths(['b.ts', 'a.ts'], '')).toEqual(['a.ts', 'b.ts']);
+	});
+});
+
+describe('rankMatchingFiles', () => {
+	it('omits directories and caps the result list', () => {
+		expect(
+			rankMatchingFiles(['src/', 'src/app.ts', 'src/foo.ts', 'README.md'], 'src', 1)
+		).toEqual(['src/app.ts']);
 	});
 });
 

--- a/cometline/src/lib/workspace/file-search.ts
+++ b/cometline/src/lib/workspace/file-search.ts
@@ -1,6 +1,5 @@
-import { listWikiFiles } from '$lib/client/cometmind';
 import type { FileSearchSource } from '$lib/settings/schema';
-import { getCachedWikiFiles, refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
+import { refreshWikiFileIndex } from '$lib/wiki/wiki-file-index';
 import {
 	filterFileIndex,
 	getFileIndex,
@@ -51,7 +50,10 @@ function rankFile(path: string, query: string): number {
 }
 
 export function rankMatchingFiles(files: string[], query: string, limit: number): string[] {
-	return rankFilePaths(onlyFiles(filterFileIndex(files, query)), query).slice(0, limit);
+	return rankFilePaths(onlyFiles(filterFileIndex([...new Set(files)], query)), query).slice(
+		0,
+		limit
+	);
 }
 
 /** Rank paths for quick-open: exact / basename / prefix beats substring. */
@@ -68,21 +70,12 @@ export function rankFilePaths(files: string[], query: string): string[] {
 }
 
 async function loadWikiOptions(query: string, limit: number): Promise<string[]> {
+	const files = await refreshWikiFileIndex();
 	const trimmed = query.trim();
 	if (!trimmed) {
-		return rankFilePaths(visibleFiles(await refreshWikiFileIndex()), '').slice(0, limit);
+		return rankFilePaths(visibleFiles(files), '').slice(0, limit);
 	}
-
-	const cached = getCachedWikiFiles();
-	if (cached.length > 0) {
-		const local = onlyFiles(filterFileIndex(cached, trimmed));
-		if (local.length >= limit) {
-			return rankFilePaths(local, trimmed).slice(0, limit);
-		}
-	}
-
-	const { files } = await listWikiFiles(trimmed, Math.max(limit, 100));
-	return rankFilePaths(onlyFiles(files ?? []), trimmed).slice(0, limit);
+	return rankMatchingFiles(files, trimmed, limit);
 }
 
 async function loadWorkspaceOptions(
@@ -98,15 +91,17 @@ async function loadWorkspaceOptions(
 	if (!isFileIndexFresh(path)) {
 		index = await refreshFileIndex(path);
 	}
+	const files = index?.files ?? [];
 	if (!trimmed) {
-		return rankFilePaths(visibleFiles(index?.files ?? []), '').slice(0, limit);
+		return rankFilePaths(visibleFiles(files), '').slice(0, limit);
 	}
 
-	const matches = index?.truncated
-		? await searchWorkspaceFiles(path, trimmed)
-		: filterFileIndex(index?.files ?? [], trimmed);
-
-	return rankFilePaths(onlyFiles(matches), trimmed).slice(0, limit);
+	let matches = rankMatchingFiles(files, trimmed, limit);
+	if (index?.truncated) {
+		const extra = await searchWorkspaceFiles(path, trimmed);
+		matches = rankMatchingFiles([...files, ...extra], trimmed, limit);
+	}
+	return matches;
 }
 
 /** Load ranked file paths for the ⌘P file search modal. */

--- a/cometline/src/lib/workspace/file-search.ts
+++ b/cometline/src/lib/workspace/file-search.ts
@@ -50,6 +50,10 @@ function rankFile(path: string, query: string): number {
 	return 8;
 }
 
+export function rankMatchingFiles(files: string[], query: string, limit: number): string[] {
+	return rankFilePaths(onlyFiles(filterFileIndex(files, query)), query).slice(0, limit);
+}
+
 /** Rank paths for quick-open: exact / basename / prefix beats substring. */
 export function rankFilePaths(files: string[], query: string): string[] {
 	const trimmed = query.trim();

--- a/cometline/src/lib/workspace/virtual-list.test.ts
+++ b/cometline/src/lib/workspace/virtual-list.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { virtualWindow } from './virtual-list';
+
+describe('virtualWindow', () => {
+	it('returns an empty window for no rows', () => {
+		expect(virtualWindow(0, 0, 200)).toEqual({ start: 0, end: 0, offset: 0, height: 0 });
+	});
+
+	it('only includes rows around the viewport plus overscan', () => {
+		const window = virtualWindow(80, 220, 200, 22, 2);
+		expect(window.start).toBe(8);
+		expect(window.end).toBe(22);
+		expect(window.offset).toBe(8 * 22);
+		expect(window.height).toBe(80 * 22);
+	});
+
+	it('clamps to the list bounds', () => {
+		const window = virtualWindow(5, 0, 400, 22, 8);
+		expect(window.start).toBe(0);
+		expect(window.end).toBe(5);
+	});
+});

--- a/cometline/src/lib/workspace/virtual-list.ts
+++ b/cometline/src/lib/workspace/virtual-list.ts
@@ -1,0 +1,24 @@
+export const FILE_TREE_SEARCH_ROW_HEIGHT = 22;
+export const FILE_TREE_SEARCH_LIMIT = 80;
+
+export function virtualWindow(
+	count: number,
+	scrollTop: number,
+	viewportHeight: number,
+	rowHeight = FILE_TREE_SEARCH_ROW_HEIGHT,
+	overscan = 8
+): { start: number; end: number; offset: number; height: number } {
+	if (count <= 0) {
+		return { start: 0, end: 0, offset: 0, height: 0 };
+	}
+	const safeRow = Math.max(1, rowHeight);
+	const start = Math.max(0, Math.floor(Math.max(0, scrollTop) / safeRow) - overscan);
+	const visible = Math.ceil(Math.max(0, viewportHeight) / safeRow) + overscan * 2;
+	const end = Math.min(count, start + Math.max(visible, 1));
+	return {
+		start,
+		end,
+		offset: start * safeRow,
+		height: count * safeRow
+	};
+}

--- a/cometline/src/lib/workspace/workspace-panel-input-options.test.ts
+++ b/cometline/src/lib/workspace/workspace-panel-input-options.test.ts
@@ -31,7 +31,9 @@ describe('workspace-panel-input-options', () => {
 		const result = await loadWorkspacePanelFileOptions('/workspace', 'youtube');
 
 		expect(result).toEqual(['youtube', 'src/youtube.ts']);
-		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledWith('/workspace', '', 500);
+		expect(cometmind.listWorkspaceFiles).toHaveBeenCalledWith('/workspace', '', 50000, {
+			index: true
+		});
 	});
 
 	it('uses cached fresh index without another refresh', async () => {
@@ -52,7 +54,9 @@ describe('workspace-panel-input-options', () => {
 		const result = await loadWorkspacePanelFileOptions('/workspace', 'youtube');
 
 		expect(result).toEqual(['youtube', 'deep/youtube.md']);
-		expect(cometmind.listWorkspaceFiles).toHaveBeenNthCalledWith(2, '/workspace', 'youtube', 50);
+		expect(cometmind.listWorkspaceFiles).toHaveBeenNthCalledWith(2, '/workspace', 'youtube', 50, {
+			index: true
+		});
 	});
 
 	it('limits returned file options', async () => {

--- a/cometmind/internal/apigen/types.gen.go
+++ b/cometmind/internal/apigen/types.gen.go
@@ -2534,6 +2534,10 @@ type ListWorkspaceFilesParams struct {
 
 	// Limit Maximum number of results to return.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Index When true, build a search index listing (skip gitignored and build paths,
+	// allow a higher limit). Browse listings should omit this flag.
+	Index *bool `form:"index,omitempty" json:"index,omitempty"`
 }
 
 // ListWorkspaceFileChildrenParams defines parameters for ListWorkspaceFileChildren.

--- a/cometmind/internal/filelist/filelist.go
+++ b/cometmind/internal/filelist/filelist.go
@@ -11,16 +11,38 @@ import (
 )
 
 const (
-	DefaultLimit = 50
-	MaxLimit     = 10000
+	DefaultLimit  = 50
+	MaxLimit      = 10000
+	IndexMaxLimit = 50000
 )
 
 // Options controls a relative filesystem entry listing.
 type Options struct {
-	Query              string
-	Limit              int
+	Query string
+	Limit int
+	// Index raises the result cap to IndexMaxLimit and is reserved for
+	// search-index walks. Browse listing stays on MaxLimit.
+	Index              bool
 	SkipDirectoryNames map[string]bool
-	IncludeFile        func(relativePath string) bool
+	// SkipPath, when set, skips a relative path (directories include a trailing /).
+	// Skipped directories are not descended into.
+	SkipPath    func(relativePath string, isDir bool) bool
+	IncludeFile func(relativePath string) bool
+}
+
+func resolveLimit(opts Options) int {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	max := MaxLimit
+	if opts.Index {
+		max = IndexMaxLimit
+	}
+	if limit > max {
+		return max
+	}
+	return limit
 }
 
 // Result is the outcome of an entry listing.
@@ -43,13 +65,7 @@ func List(ctx context.Context, root string, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("path is not a directory: %s", root)
 	}
 
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = DefaultLimit
-	}
-	if limit > MaxLimit {
-		limit = MaxLimit
-	}
+	limit := resolveLimit(opts)
 
 	query := strings.ToLower(strings.TrimSpace(opts.Query))
 	var results []string
@@ -83,8 +99,13 @@ func List(ctx context.Context, root string, opts Options) (Result, error) {
 			}
 			rel = filepath.ToSlash(rel)
 			if isDir {
-				directories = append(directories, filepath.Join(dir, entry.Name()))
 				rel += "/"
+				if opts.SkipPath != nil && opts.SkipPath(rel, true) {
+					continue
+				}
+				directories = append(directories, filepath.Join(dir, entry.Name()))
+			} else if opts.SkipPath != nil && opts.SkipPath(rel, false) {
+				continue
 			} else if opts.IncludeFile != nil && !opts.IncludeFile(rel) {
 				continue
 			}
@@ -151,13 +172,7 @@ func ListDirectory(ctx context.Context, root, directory string, opts Options) (R
 		return Result{}, fmt.Errorf("not a directory")
 	}
 
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = DefaultLimit
-	}
-	if limit > MaxLimit {
-		limit = MaxLimit
-	}
+	limit := resolveLimit(opts)
 	query := strings.ToLower(strings.TrimSpace(opts.Query))
 	entries, err := os.ReadDir(resolvedTarget)
 	if err != nil {
@@ -181,7 +196,11 @@ func ListDirectory(ctx context.Context, root, directory string, opts Options) (R
 		}
 		if isDir {
 			path += "/"
-		} else if opts.IncludeFile != nil && !opts.IncludeFile(path) {
+		}
+		if opts.SkipPath != nil && opts.SkipPath(path, isDir) {
+			continue
+		}
+		if !isDir && opts.IncludeFile != nil && !opts.IncludeFile(path) {
 			continue
 		}
 		if query != "" && !strings.Contains(strings.ToLower(path), query) {

--- a/cometmind/internal/filelist/filelist_test.go
+++ b/cometmind/internal/filelist/filelist_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -72,6 +73,43 @@ func TestListDirectoryReturnsOnlyDirectChildren(t *testing.T) {
 	}
 	if want := []string{"src/app.ts", "src/lib/"}; !reflect.DeepEqual(srcEntries.Files, want) {
 		t.Fatalf("src files = %v, want %v", srcEntries.Files, want)
+	}
+}
+
+func TestResolveLimit(t *testing.T) {
+	if got := resolveLimit(Options{Limit: IndexMaxLimit + 1, Index: true}); got != IndexMaxLimit {
+		t.Fatalf("index cap = %d, want %d", got, IndexMaxLimit)
+	}
+	if got := resolveLimit(Options{Limit: MaxLimit + 1}); got != MaxLimit {
+		t.Fatalf("browse cap = %d, want %d", got, MaxLimit)
+	}
+	if got := resolveLimit(Options{}); got != DefaultLimit {
+		t.Fatalf("default = %d, want %d", got, DefaultLimit)
+	}
+}
+
+func TestSkipPathOmitsDirectoryAndDescendants(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{"keep.txt", "skip/secret.txt"} {
+		fullPath := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := List(context.Background(), root, Options{
+		SkipPath: func(relativePath string, isDir bool) bool {
+			return relativePath == "skip/" || strings.HasPrefix(relativePath, "skip/")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"keep.txt"}; !reflect.DeepEqual(result.Files, want) {
+		t.Fatalf("files = %v, want %v", result.Files, want)
 	}
 }
 

--- a/cometmind/internal/workspace/files/files.go
+++ b/cometmind/internal/workspace/files/files.go
@@ -2,18 +2,42 @@ package files
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/sabhiram/go-gitignore"
 
 	"github.com/cometline/cometmind/internal/filelist"
 )
 
 const (
-	DefaultLimit = filelist.DefaultLimit
-	MaxLimit     = filelist.MaxLimit
+	DefaultLimit  = filelist.DefaultLimit
+	MaxLimit      = filelist.MaxLimit
+	IndexMaxLimit = filelist.IndexMaxLimit
 )
 
 var defaultSkippedDirs = map[string]bool{
 	".git":         true,
 	"node_modules": true,
+}
+
+var indexSkippedDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	".next":        true,
+	"out":          true,
+	"coverage":     true,
+	"__pycache__":  true,
+	".git":         true,
+	".svn":         true,
+	".hg":          true,
+	".svelte-kit":  true,
+	"target":       true,
+	".turbo":       true,
+	".cache":       true,
 }
 
 type ListOptions = filelist.Options
@@ -22,7 +46,11 @@ type Result = filelist.Result
 
 // ListFiles returns workspace-relative file and directory paths matching the query, sorted.
 // Directories have a trailing slash. Git metadata and dependency directories are skipped.
+// When opts.Index is true, common build directories and root .gitignore rules are also skipped.
 func ListFiles(ctx context.Context, root string, opts ListOptions) (Result, error) {
+	if opts.Index {
+		return listIndex(ctx, root, opts)
+	}
 	opts.SkipDirectoryNames = defaultSkippedDirs
 	return filelist.List(ctx, root, opts)
 }
@@ -31,4 +59,31 @@ func ListFiles(ctx context.Context, root string, opts ListOptions) (Result, erro
 func ListDirectory(ctx context.Context, root, directory string, opts ListOptions) (Result, error) {
 	opts.SkipDirectoryNames = defaultSkippedDirs
 	return filelist.ListDirectory(ctx, root, directory, opts)
+}
+
+func listIndex(ctx context.Context, root string, opts ListOptions) (Result, error) {
+	opts.SkipDirectoryNames = indexSkippedDirs
+	ignorer := loadGitignore(root)
+	opts.SkipPath = func(relativePath string, isDir bool) bool {
+		name := filepath.Base(strings.TrimSuffix(relativePath, "/"))
+		if isDir && strings.HasPrefix(name, ".") {
+			return true
+		}
+		if ignorer == nil {
+			return false
+		}
+		if isDir {
+			return ignorer.MatchesPath(strings.TrimSuffix(relativePath, "/") + "/")
+		}
+		return ignorer.MatchesPath(relativePath)
+	}
+	return filelist.List(ctx, root, opts)
+}
+
+func loadGitignore(root string) *gitignore.GitIgnore {
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		return nil
+	}
+	return gitignore.CompileIgnoreLines(strings.Split(string(data), "\n")...)
 }

--- a/cometmind/internal/workspace/files/files_test.go
+++ b/cometmind/internal/workspace/files/files_test.go
@@ -106,6 +106,26 @@ func TestListFiles(t *testing.T) {
 	})
 }
 
+func TestListFilesIndexSkipsGitignoreAndBuildDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "keep.go"), "package main")
+	mustWrite(t, filepath.Join(root, "ignore.log"), "log")
+	mustWrite(t, filepath.Join(root, "build", "out.js"), "out")
+	mustWrite(t, filepath.Join(root, "dist", "bundle.js"), "bundle")
+	mustWrite(t, filepath.Join(root, ".hidden", "secret.go"), "package hidden")
+	mustWrite(t, filepath.Join(root, ".gitignore"), "*.log\nbuild/\n")
+
+	got, err := ListFiles(context.Background(), root, ListOptions{Index: true})
+	if err != nil {
+		t.Fatalf("ListFiles index error: %v", err)
+	}
+	want := []string{".gitignore", "keep.go"}
+	assertSlice(t, got.Files, want)
+	if got.Truncated {
+		t.Fatal("did not expect truncation")
+	}
+}
+
 func TestListFilesGitignore(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "keep.go"), "package main")

--- a/cometmind/openapi.yaml
+++ b/cometmind/openapi.yaml
@@ -353,6 +353,8 @@ paths:
         Returns all workspace-relative file and directory paths for the requested workspace.
         Directory paths end with `/`.
         `.git` and `node_modules` directories are skipped.
+        When `index=true`, common build directories and root `.gitignore` rules are
+        also skipped and `limit` may be raised up to 50000 for a search index.
       operationId: listWorkspaceFiles
       parameters:
         - name: workspace_id
@@ -379,8 +381,17 @@ paths:
           schema:
             type: integer
             default: 50
-            maximum: 500
+            maximum: 50000
           description: Maximum number of results to return.
+        - name: index
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            When true, build a search index listing (skip gitignored and build paths,
+            allow a higher limit). Browse listings should omit this flag.
       responses:
         '200':
           description: Workspace file and directory list

--- a/cometmind/server/server_test.go
+++ b/cometmind/server/server_test.go
@@ -525,6 +525,34 @@ func TestListWorkspaceFilesFiltersByQuery(t *testing.T) {
 	assertSlice(t, got.Files, want)
 }
 
+func TestListWorkspaceFilesIndexSkipsIgnoredPaths(t *testing.T) {
+	t.Parallel()
+
+	engine, _, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
+		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
+			ch <- event.Done()
+			return nil
+		}), nil
+	})
+	defer cleanup()
+
+	workspacePath := t.TempDir()
+	mustWrite(t, filepath.Join(workspacePath, "keep.go"), "package main")
+	mustWrite(t, filepath.Join(workspacePath, "dist", "bundle.js"), "bundle")
+	mustWrite(t, filepath.Join(workspacePath, ".gitignore"), "dist/\n")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/files?index=true&workspace_path="+workspacePath, nil)
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got workspaceFileListResponse
+	decodeJSON(t, rec.Body.Bytes(), &got)
+	assertSlice(t, got.Files, []string{".gitignore", "keep.go"})
+}
+
 func TestListWorkspaceFilesMissingWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/cometmind/server/workspaces.go
+++ b/cometmind/server/workspaces.go
@@ -111,6 +111,15 @@ func (a *App) handlePruneWorkspaces(c *gin.Context) {
 	c.JSON(http.StatusOK, pruneWorkspacesResponse{Pruned: pruned})
 }
 
+func parseBoolQuery(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func (a *App) handleListWorkspaceFiles(c *gin.Context) {
 	ws, ok := a.resolveCreateWorkspace(c, c.Query("workspace_id"), c.Query("workspace_path"))
 	if !ok {
@@ -128,6 +137,7 @@ func (a *App) handleListWorkspaceFiles(c *gin.Context) {
 	result, err := workspacefiles.ListFiles(c.Request.Context(), ws.Path, workspacefiles.ListOptions{
 		Query: strings.TrimSpace(c.Query("q")),
 		Limit: limit,
+		Index: parseBoolQuery(c.Query("index")),
 	})
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "internal_error", err.Error())


### PR DESCRIPTION
## Background

Large workspaces stall the file panel when search walks the tree through the sidecar. The panel now loads an index once and filters locally.

[3f84397](https://github.com/Cometline/cometline/commit/3f843979f6b9bfbdee46c620414fd2ce891aba88): The API returns a workspace file index so the panel can load the listing in one request.

[cfd47fb](https://github.com/Cometline/cometline/commit/cfd47fbd59b7999ec2f6f154826eda6c4c9c953f): The file tree filters and virtualizes from that local index instead of asking the sidecar on every search.

[4ebc6ad](https://github.com/Cometline/cometline/commit/4ebc6ad106840f844c9328bfe5696de89dcd0ed5): Verification notes record how to check file search after the index change.