### PR TITLE
[main] fix: keep stream token usage and show spend on /usage

### DIFF
--- a/comet-sdk/provider/anthropic/convert.go
+++ b/comet-sdk/provider/anthropic/convert.go
@@ -232,7 +232,7 @@ type anthropicSSEEvent struct {
 		Name string `json:"name"`
 	} `json:"content_block"`
 
-	// content_block_delta
+	// content_block_delta / message_delta
 	Delta *struct {
 		Type        string `json:"type"`
 		Text        string `json:"text"`
@@ -241,13 +241,50 @@ type anthropicSSEEvent struct {
 		Reasoning   string `json:"reasoning"`
 	} `json:"delta"`
 
+	// message_start
+	Message *struct {
+		Usage *anthropicUsage `json:"usage"`
+	} `json:"message"`
+
 	// message_delta
-	Usage *struct {
-		InputTokens              int `json:"input_tokens"`
-		OutputTokens             int `json:"output_tokens"`
-		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
-		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
-	} `json:"usage"`
+	Usage *anthropicUsage `json:"usage"`
+}
+
+type anthropicUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+
+func tokenUsageFrom(u *anthropicUsage) cometsdk.TokenUsage {
+	if u == nil {
+		return cometsdk.TokenUsage{}
+	}
+	return cometsdk.TokenUsage{
+		InputTokens:  u.InputTokens,
+		OutputTokens: u.OutputTokens,
+		CacheRead:    u.CacheReadInputTokens,
+		CacheWrite:   u.CacheCreationInputTokens,
+	}
+}
+
+// mergeUsage overlays incoming onto base. Official Anthropic streams put
+// input/cache counts on message_start and only output_tokens on message_delta.
+func mergeUsage(base, incoming cometsdk.TokenUsage) cometsdk.TokenUsage {
+	if incoming.InputTokens > 0 {
+		base.InputTokens = incoming.InputTokens
+	}
+	if incoming.OutputTokens > 0 {
+		base.OutputTokens = incoming.OutputTokens
+	}
+	if incoming.CacheRead > 0 {
+		base.CacheRead = incoming.CacheRead
+	}
+	if incoming.CacheWrite > 0 {
+		base.CacheWrite = incoming.CacheWrite
+	}
+	return base
 }
 
 // streamState tracks in-progress tool calls so we can emit ToolCallDoneEvent.
@@ -255,7 +292,9 @@ type streamState struct {
 	// toolCallBuffers maps content block index → accumulated input JSON.
 	toolCallBuffers map[int]*strings.Builder
 	// toolCallMeta maps content block index → (id, name).
-	toolCallMeta map[int][2]string
+	toolCallMeta  map[int][2]string
+	pendingUsage  cometsdk.TokenUsage
+	emittedFinish bool
 }
 
 func newStreamState() *streamState {
@@ -337,31 +376,41 @@ func toSDKEvents(eventType, data string, state *streamState) ([]cometsdk.Event, 
 			Input: json.RawMessage(buf.String()),
 		}}, nil
 
+	case "message_start":
+		var ev anthropicSSEEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return nil, fmt.Errorf("anthropic: parse message_start: %w", err)
+		}
+		if ev.Message != nil {
+			state.pendingUsage = mergeUsage(state.pendingUsage, tokenUsageFrom(ev.Message.Usage))
+		}
+		return nil, nil
+
 	case "message_delta":
 		var ev anthropicSSEEvent
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return nil, fmt.Errorf("anthropic: parse message_delta: %w", err)
 		}
-		usage := cometsdk.TokenUsage{}
-		if ev.Usage != nil {
-			usage.InputTokens = ev.Usage.InputTokens
-			usage.OutputTokens = ev.Usage.OutputTokens
-			usage.CacheRead = ev.Usage.CacheReadInputTokens
-			usage.CacheWrite = ev.Usage.CacheCreationInputTokens
-		}
+		state.pendingUsage = mergeUsage(state.pendingUsage, tokenUsageFrom(ev.Usage))
 		reason := ""
 		if ev.Delta != nil {
 			reason = ev.Delta.StopReason
 		}
+		state.emittedFinish = true
 		return []cometsdk.Event{cometsdk.StepFinishEvent{
 			FinishReason: cometsdk.NormalizeFinishReason(reason),
-			Usage:        usage,
+			Usage:        state.pendingUsage,
 		}}, nil
 
 	case "message_stop":
-		return []cometsdk.Event{cometsdk.DoneEvent{}}, nil
+		var events []cometsdk.Event
+		if !state.emittedFinish {
+			events = append(events, cometsdk.StepFinishEvent{Usage: state.pendingUsage})
+			state.emittedFinish = true
+		}
+		return append(events, cometsdk.DoneEvent{}), nil
 
-	// Ignore ping, message_start, and any unknown event types.
+	// Ignore ping and any unknown event types.
 	default:
 		return nil, nil
 	}

--- a/comet-sdk/provider/anthropic/convert_test.go
+++ b/comet-sdk/provider/anthropic/convert_test.go
@@ -248,6 +248,44 @@ func TestConvertEvent_StepFinish(t *testing.T) {
 	require.Equal(t, 1, sf.Usage.CacheWrite)
 }
 
+func TestConvertEvent_UsageMergesMessageStartAndDelta(t *testing.T) {
+	state := newStreamState()
+	_, err := toSDKEvents("message_start",
+		`{"type":"message_start","message":{"usage":{"input_tokens":25,"cache_read_input_tokens":8,"cache_creation_input_tokens":3,"output_tokens":1}}}`,
+		state)
+	require.NoError(t, err)
+
+	events, err := toSDKEvents("message_delta",
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		state)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	sf, ok := events[0].(cometsdk.StepFinishEvent)
+	require.True(t, ok)
+	require.Equal(t, 25, sf.Usage.InputTokens)
+	require.Equal(t, 15, sf.Usage.OutputTokens)
+	require.Equal(t, 8, sf.Usage.CacheRead)
+	require.Equal(t, 3, sf.Usage.CacheWrite)
+}
+
+func TestConvertEvent_UsageOnMessageStopWithoutDelta(t *testing.T) {
+	state := newStreamState()
+	_, err := toSDKEvents("message_start",
+		`{"type":"message_start","message":{"usage":{"input_tokens":9,"output_tokens":0}}}`,
+		state)
+	require.NoError(t, err)
+
+	events, err := toSDKEvents("message_stop", `{"type":"message_stop"}`, state)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	sf, ok := events[0].(cometsdk.StepFinishEvent)
+	require.True(t, ok)
+	require.Equal(t, 9, sf.Usage.InputTokens)
+	_, ok = events[1].(cometsdk.DoneEvent)
+	require.True(t, ok)
+}
+
 // ─── Options passthrough tests ────────────────────────────────────────────────
 
 func TestConvertRequest_OptionsPassthrough(t *testing.T) {

--- a/comet-sdk/provider/anthropic/fixtures/text_usage_start_only.sse
+++ b/comet-sdk/provider/anthropic/fixtures/text_usage_start_only.sse
@@ -1,0 +1,17 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"usage":{"input_tokens":25,"cache_read_input_tokens":8,"cache_creation_input_tokens":3,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/comet-sdk/provider/anthropic/stream_test.go
+++ b/comet-sdk/provider/anthropic/stream_test.go
@@ -125,6 +125,33 @@ func TestStream_ToolCall(t *testing.T) {
 
 	require.NotNil(t, stepFinish)
 	require.Equal(t, "tool_use", stepFinish.FinishReason)
+	require.Equal(t, 20, stepFinish.Usage.InputTokens)
+	require.Equal(t, 15, stepFinish.Usage.OutputTokens)
+}
+
+func TestStream_UsageFromMessageStartWhenDeltaOmitsInput(t *testing.T) {
+	srv := serveFixture(t, "fixtures/text_usage_start_only.sse")
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	ch, err := p.Stream(context.Background(), &cometsdk.Request{
+		Model:    "claude-sonnet-4-5",
+		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
+	})
+	require.NoError(t, err)
+
+	var stepFinish *cometsdk.StepFinishEvent
+	for _, e := range collectEvents(t, ch) {
+		if ev, ok := e.(cometsdk.StepFinishEvent); ok {
+			stepFinish = &ev
+		}
+	}
+	require.NotNil(t, stepFinish)
+	require.Equal(t, "stop", stepFinish.FinishReason)
+	require.Equal(t, 25, stepFinish.Usage.InputTokens)
+	require.Equal(t, 15, stepFinish.Usage.OutputTokens)
+	require.Equal(t, 8, stepFinish.Usage.CacheRead)
+	require.Equal(t, 3, stepFinish.Usage.CacheWrite)
 }
 
 func TestStream_ContextCancelled(t *testing.T) {

--- a/comet-sdk/provider/openai/convert.go
+++ b/comet-sdk/provider/openai/convert.go
@@ -305,10 +305,46 @@ type openAIDelta struct {
 			} `json:"tool_calls"`
 		} `json:"delta"`
 	} `json:"choices"`
-	Usage *struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-	} `json:"usage"`
+	Usage *openAIUsage `json:"usage"`
+}
+
+type openAIUsage struct {
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens        int `json:"cached_tokens"`
+		CacheWriteTokens    int `json:"cache_write_tokens"`
+		CacheCreationTokens int `json:"cache_creation_tokens"`
+	} `json:"prompt_tokens_details"`
+}
+
+func tokenUsageFrom(u *openAIUsage) cometsdk.TokenUsage {
+	if u == nil {
+		return cometsdk.TokenUsage{}
+	}
+	usage := cometsdk.TokenUsage{
+		InputTokens:  u.PromptTokens,
+		OutputTokens: u.CompletionTokens,
+	}
+	if d := u.PromptTokensDetails; d != nil {
+		usage.CacheRead = d.CachedTokens
+		if d.CacheWriteTokens > 0 {
+			usage.CacheWrite = d.CacheWriteTokens
+		} else {
+			usage.CacheWrite = d.CacheCreationTokens
+		}
+	}
+	return usage
+}
+
+func applyUsage(state *streamState, u *openAIUsage) {
+	if u == nil {
+		return
+	}
+	state.pendingUsage = tokenUsageFrom(u)
+	if state.pendingFinish != nil {
+		state.pendingFinish.Usage = state.pendingUsage
+	}
 }
 
 // inProgressReasoning tracks reasoning content being streamed.
@@ -369,17 +405,9 @@ func toSDKEvents(data string, state *streamState) ([]cometsdk.Event, error) {
 		return nil, fmt.Errorf("openai: parse delta: %w", err)
 	}
 
-	if len(delta.Choices) == 0 && delta.Usage != nil {
-		state.pendingUsage = cometsdk.TokenUsage{
-			InputTokens:  delta.Usage.PromptTokens,
-			OutputTokens: delta.Usage.CompletionTokens,
-		}
-		if state.pendingFinish != nil {
-			state.pendingFinish.Usage = state.pendingUsage
-		}
-		return nil, nil
-	}
-
+	// Official OpenAI usage chunks use choices:[]; some gateways (TrendAI)
+	// send usage on a later chunk that still has a non-empty empty-delta choice.
+	applyUsage(state, delta.Usage)
 	if len(delta.Choices) == 0 {
 		return nil, nil
 	}
@@ -467,6 +495,7 @@ func toSDKEvents(data string, state *streamState) ([]cometsdk.Event, error) {
 		}
 		state.pendingFinish = &cometsdk.StepFinishEvent{
 			FinishReason: cometsdk.NormalizeFinishReason(choice.FinishReason),
+			Usage:        state.pendingUsage,
 		}
 	}
 

--- a/comet-sdk/provider/openai/convert_test.go
+++ b/comet-sdk/provider/openai/convert_test.go
@@ -596,3 +596,72 @@ func TestConvertEvent_ThinkTags(t *testing.T) {
 	require.Equal(t, []string{"plan"}, reasoning)
 	require.Equal(t, []string{"answer"}, texts)
 }
+
+func stepFinishFromChunks(t *testing.T, chunks ...string) cometsdk.StepFinishEvent {
+	t.Helper()
+	state := newStreamState()
+	var finish *cometsdk.StepFinishEvent
+	for _, chunk := range chunks {
+		events, err := toSDKEvents(chunk, state)
+		require.NoError(t, err)
+		for _, e := range events {
+			if ev, ok := e.(cometsdk.StepFinishEvent); ok {
+				finish = &ev
+			}
+		}
+	}
+	require.NotNil(t, finish)
+	return *finish
+}
+
+func TestConvertEvent_UsageAfterFinishWithNonEmptyChoices(t *testing.T) {
+	finish := stepFinishFromChunks(t,
+		`{"choices":[{"index":0,"delta":{"content":"hi"}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[{"index":0,"delta":{}}],"usage":{"prompt_tokens":11,"completion_tokens":5}}`,
+		`[DONE]`,
+	)
+	require.Equal(t, "stop", finish.FinishReason)
+	require.Equal(t, 11, finish.Usage.InputTokens)
+	require.Equal(t, 5, finish.Usage.OutputTokens)
+}
+
+func TestConvertEvent_UsageOnEmptyChoices(t *testing.T) {
+	finish := stepFinishFromChunks(t,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}`,
+		`[DONE]`,
+	)
+	require.Equal(t, 10, finish.Usage.InputTokens)
+	require.Equal(t, 5, finish.Usage.OutputTokens)
+}
+
+func TestConvertEvent_UsageOnSameChunkAsFinish(t *testing.T) {
+	finish := stepFinishFromChunks(t,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":3}}`,
+		`[DONE]`,
+	)
+	require.Equal(t, 8, finish.Usage.InputTokens)
+	require.Equal(t, 3, finish.Usage.OutputTokens)
+}
+
+func TestConvertEvent_UsageCacheDetails(t *testing.T) {
+	finish := stepFinishFromChunks(t,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[{"index":0,"delta":{}}],"usage":{"prompt_tokens":20,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":8,"cache_write_tokens":3,"cache_creation_tokens":1}}}`,
+		`[DONE]`,
+	)
+	require.Equal(t, 20, finish.Usage.InputTokens)
+	require.Equal(t, 4, finish.Usage.OutputTokens)
+	require.Equal(t, 8, finish.Usage.CacheRead)
+	require.Equal(t, 3, finish.Usage.CacheWrite)
+}
+
+func TestConvertEvent_UsageCacheCreationFallback(t *testing.T) {
+	finish := stepFinishFromChunks(t,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":1,"prompt_tokens_details":{"cached_tokens":0,"cache_creation_tokens":4}}}`,
+		`[DONE]`,
+	)
+	require.Equal(t, 4, finish.Usage.CacheWrite)
+}

--- a/comet-sdk/provider/openai/fixtures/text_usage_nonempty_choices.sse
+++ b/comet-sdk/provider/openai/fixtures/text_usage_nonempty_choices.sse
@@ -1,0 +1,11 @@
+data: {"id":"","created":1787108202,"model":"gpt-5.6-luna","object":"chat.completion.chunk","choices":[]}
+
+data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1787108202,"model":"gpt-5.6-luna","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}
+
+data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1787108202,"model":"gpt-5.6-luna","choices":[{"index":0,"delta":{"content":"hi"}}]}
+
+data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1787108202,"model":"gpt-5.6-luna","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl-01","created":1787108202,"model":"gpt-5.6-luna","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":5,"prompt_tokens":11,"total_tokens":16,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":2,"cache_write_tokens":1,"cache_creation_tokens":0}}}
+
+data: [DONE]

--- a/comet-sdk/provider/openai/fixtures/tool_calls_usage_nonempty_choices.sse
+++ b/comet-sdk/provider/openai/fixtures/tool_calls_usage_nonempty_choices.sse
@@ -1,0 +1,9 @@
+data: {"id":"chatcmpl-02","created":1787108213,"model":"gpt-5.6-luna","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call_01","function":{"arguments":"","name":"get_time"},"type":"function","index":0}]}}]}
+
+data: {"id":"chatcmpl-02","created":1787108213,"model":"gpt-5.6-luna","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"{}"},"type":"function","index":0}]}}]}
+
+data: {"id":"chatcmpl-02","object":"chat.completion.chunk","created":1787108213,"model":"gpt-5.6-luna","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"id":"chatcmpl-02","created":1787108213,"model":"gpt-5.6-luna","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":14,"prompt_tokens":121,"total_tokens":135,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
+
+data: [DONE]

--- a/comet-sdk/provider/openai/stream_test.go
+++ b/comet-sdk/provider/openai/stream_test.go
@@ -129,6 +129,44 @@ func TestStream_MultipleToolCalls(t *testing.T) {
 	require.True(t, names["list_dir"])
 }
 
+func streamStepFinish(t *testing.T, fixturePath string) cometsdk.StepFinishEvent {
+	t.Helper()
+	srv := serveFixture(t, fixturePath)
+	t.Cleanup(srv.Close)
+
+	p := newTestProvider(t, srv)
+	ch, err := p.Stream(context.Background(), &cometsdk.Request{
+		Model:    "gpt-5.6-luna",
+		Messages: []cometsdk.Message{{Role: cometsdk.RoleUser, Content: []cometsdk.Block{cometsdk.TextBlock{Text: "Hi"}}}},
+	})
+	require.NoError(t, err)
+
+	var stepFinish *cometsdk.StepFinishEvent
+	for _, e := range collectEvents(t, ch) {
+		if ev, ok := e.(cometsdk.StepFinishEvent); ok {
+			stepFinish = &ev
+		}
+	}
+	require.NotNil(t, stepFinish)
+	return *stepFinish
+}
+
+func TestStream_UsageWithNonEmptyChoices(t *testing.T) {
+	finish := streamStepFinish(t, "fixtures/text_usage_nonempty_choices.sse")
+	require.Equal(t, "stop", finish.FinishReason)
+	require.Equal(t, 11, finish.Usage.InputTokens)
+	require.Equal(t, 5, finish.Usage.OutputTokens)
+	require.Equal(t, 2, finish.Usage.CacheRead)
+	require.Equal(t, 1, finish.Usage.CacheWrite)
+}
+
+func TestStream_ToolCallsUsageWithNonEmptyChoices(t *testing.T) {
+	finish := streamStepFinish(t, "fixtures/tool_calls_usage_nonempty_choices.sse")
+	require.Equal(t, "tool_use", finish.FinishReason)
+	require.Equal(t, 121, finish.Usage.InputTokens)
+	require.Equal(t, 14, finish.Usage.OutputTokens)
+}
+
 func TestStream_ContextCancelled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/cometline/src/lib/components/usage/UsagePage.svelte
+++ b/cometline/src/lib/components/usage/UsagePage.svelte
@@ -12,6 +12,7 @@
 		type Workspace
 	} from '$lib/client/cometmind';
 	import UsageStackedArea from '$lib/components/usage/UsageStackedArea.svelte';
+	import { seriesColor } from '$lib/usage/chart';
 	import { truncateWorkspacePath } from '$lib/jobs/group-jobs';
 	import {
 		formatEventTime,
@@ -19,6 +20,7 @@
 		formatRangeLabel,
 		formatTokens,
 		formatUSD,
+		legendRowsForSeries,
 		rangeForPreset,
 		type RangePreset
 	} from '$lib/usage/format';
@@ -45,6 +47,15 @@
 		to: range.to,
 		...(workspaceId ? { workspace_id: workspaceId } : {})
 	});
+
+	const legendRows = $derived(
+		legendRowsForSeries(
+			series?.keys ?? [],
+			groupBy === 'kind' ? (summary?.by_kind ?? []) : (summary?.by_model ?? []),
+			groupBy
+		)
+	);
+	const legendCosts = $derived(Object.fromEntries(legendRows.map((row) => [row.key, row.cost])));
 
 	async function refresh(nextOffset = 0) {
 		const seq = ++refreshSeq;
@@ -128,6 +139,7 @@
 	<p class="usage-desc">Usage is kept for one year. Older events are removed automatically.</p>
 	<header class="usage-toolbar">
 		<div class="chips" role="group" aria-label="Date range">
+			<button type="button" class:active={preset === 'today'} onclick={() => applyPreset('today')}>Today</button>
 			<button type="button" class:active={preset === '7d'} onclick={() => applyPreset('7d')}>Last 7 days</button>
 			<button type="button" class:active={preset === '30d'} onclick={() => applyPreset('30d')}>Last 30 days</button>
 			<button type="button" class:active={preset === 'month'} onclick={() => applyPreset('month')}>Last month</button>
@@ -192,13 +204,22 @@
 					</select>
 				</label>
 			</div>
-			<UsageStackedArea points={series?.points ?? []} keys={series?.keys ?? []} />
+			<UsageStackedArea points={series?.points ?? []} keys={series?.keys ?? []} costs={legendCosts} />
 			<div class="legend">
-				{#each series?.keys ?? [] as key, index (key)}
-					<span>
-						<i class={`swatch series-${index % 6}`}></i>
-						{groupBy === 'kind' ? formatKind(key) : key}
-					</span>
+				<div class="legend-head">
+					<span>{groupBy === 'kind' ? 'Kind' : 'Model'}</span>
+					<span>Tokens</span>
+					<span>Cost</span>
+				</div>
+				{#each legendRows as row, index (row.key)}
+					<div class="legend-row">
+						<span class="legend-name">
+							<i class="swatch" style:background={seriesColor(index, legendRows.length)}></i>
+							{row.label}
+						</span>
+						<span class="legend-meta">{formatTokens(row.tokens)}</span>
+						<span class="legend-meta">{row.cost}</span>
+					</div>
 				{/each}
 			</div>
 		</section>
@@ -454,11 +475,37 @@
 	}
 
 	.legend {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px 16px;
+		display: grid;
+		gap: 6px 16px;
 		color: var(--text-muted);
 		font-size: 12px;
+	}
+
+	.legend-head,
+	.legend-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 4.5rem 4.5rem;
+		gap: 12px;
+		align-items: center;
+	}
+
+	.legend-head {
+		color: var(--text-muted);
+		font-weight: 550;
+	}
+
+	.legend-head span:not(:first-child),
+	.legend-meta {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.legend-name {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--text-main);
 	}
 
 	.swatch {
@@ -467,25 +514,6 @@
 		height: 8px;
 		margin-right: 6px;
 		border-radius: 99px;
-	}
-
-	.series-0 {
-		background: var(--status-success);
-	}
-	.series-1 {
-		background: var(--intro-blue);
-	}
-	.series-2 {
-		background: var(--accent);
-	}
-	.series-3 {
-		background: var(--status-warning);
-	}
-	.series-4 {
-		background: var(--text-soft);
-	}
-	.series-5 {
-		background: var(--status-error);
 	}
 
 	.table-wrap {

--- a/cometline/src/lib/components/usage/UsageStackedArea.svelte
+++ b/cometline/src/lib/components/usage/UsageStackedArea.svelte
@@ -4,6 +4,8 @@
 		nearestPointIndex,
 		PAD_LEFT,
 		PAD_RIGHT,
+		seriesColor,
+		seriesStroke,
 		stackedAreaPaths,
 		xLabels,
 		yLabels,
@@ -12,10 +14,12 @@
 
 	let {
 		points = [],
-		keys = []
+		keys = [],
+		costs = {}
 	}: {
 		points?: SeriesPoint[];
 		keys?: string[];
+		costs?: Record<string, string>;
 	} = $props();
 
 	const height = 220;
@@ -26,9 +30,17 @@
 	const xs = $derived(xLabels(points, width));
 	const ys = $derived(yLabels(points, keys, height));
 	const hover = $derived(hoverIndex >= 0 ? points[hoverIndex] : undefined);
+	const showRangeCost = $derived(points.length === 1);
+
 	const summaryLabel = $derived(
 		hover
-			? `${hover.date}: ${keys.map((key) => `${key} ${formatTokens(hover.cumulative[key] ?? 0)}`).join(', ')}`
+			? `${hover.date}: ${keys
+					.map((key) => {
+						const tokens = formatTokens(hover.cumulative[key] ?? 0);
+						const cost = showRangeCost && costs[key] ? ` ${costs[key]}` : '';
+						return `${key} ${tokens}${cost}`;
+					})
+					.join(', ')}`
 			: 'Cumulative token usage. Use arrow keys to inspect each day.'
 	);
 
@@ -93,7 +105,12 @@
 			<text class="axis" x="4" y={tick.y + 3}>{formatTokens(tick.label)}</text>
 		{/each}
 		{#each paths as path, index (path.key)}
-			<path class={`area series-${index % 6}`} d={path.d} />
+			<path
+				class="area"
+				style:fill={seriesColor(index, keys.length)}
+				style:stroke={seriesStroke(index, keys.length)}
+				d={path.d}
+			/>
 		{/each}
 		{#each xs as tick (tick.label + tick.x)}
 			<text class={['axis', 'x', tick.anchor]} x={tick.x} y={height - 6}>{tick.label}</text>
@@ -104,8 +121,12 @@
 		<div class="hover">
 			<strong>{hover.date}</strong>
 			{#each keys as key, index (key)}
-				<span class={`swatch series-${index % 6}`}></span>
-				<span>{key}: {formatTokens(hover.cumulative[key] ?? 0)}</span>
+				<span class="swatch" style:background={seriesColor(index, keys.length)}></span>
+				<span>
+					{key}: {formatTokens(hover.cumulative[key] ?? 0)}{showRangeCost && costs[key]
+						? ` · ${costs[key]}`
+						: ''}
+				</span>
 			{/each}
 		</div>
 	{/if}
@@ -177,45 +198,8 @@
 	}
 
 	.area {
-		opacity: 0.72;
-	}
-
-	.area.series-0 {
-		fill: var(--status-success);
-	}
-	.area.series-1 {
-		fill: var(--intro-blue);
-	}
-	.area.series-2 {
-		fill: var(--accent);
-	}
-	.area.series-3 {
-		fill: var(--status-warning);
-	}
-	.area.series-4 {
-		fill: var(--text-soft);
-	}
-	.area.series-5 {
-		fill: var(--status-error);
-	}
-
-	.swatch.series-0 {
-		background: var(--status-success);
-	}
-	.swatch.series-1 {
-		background: var(--intro-blue);
-	}
-	.swatch.series-2 {
-		background: var(--accent);
-	}
-	.swatch.series-3 {
-		background: var(--status-warning);
-	}
-	.swatch.series-4 {
-		background: var(--text-soft);
-	}
-	.swatch.series-5 {
-		background: var(--status-error);
+		opacity: 0.88;
+		stroke-width: 1;
 	}
 
 	.hover {

--- a/cometline/src/lib/usage/chart.test.ts
+++ b/cometline/src/lib/usage/chart.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { nearestPointIndex, PAD_RIGHT, stackedAreaPaths, xLabels } from './chart';
+import {
+	nearestPointIndex,
+	PAD_RIGHT,
+	seriesColor,
+	singleDayBarBounds,
+	stackedAreaPaths,
+	xLabels
+} from './chart';
 
 describe('usage chart', () => {
+	it('keeps adjacent series distinguishable by hue and lightness', () => {
+		const colors = Array.from({ length: 8 }, (_, index) => seriesColor(index, 8));
+		expect(new Set(colors).size).toBe(8);
+		const lights = colors.map((color) => Number(color.match(/% (\d+)%/)?.[1]));
+		for (let i = 1; i < lights.length; i += 1) {
+			expect(Math.abs((lights[i] ?? 0) - (lights[i - 1] ?? 0))).toBeGreaterThanOrEqual(10);
+		}
+	});
+
 	it('builds a closed stacked path per series', () => {
 		const paths = stackedAreaPaths(
 			[
@@ -15,6 +31,21 @@ describe('usage chart', () => {
 		expect(paths).toHaveLength(2);
 		expect(paths[0]?.d.startsWith('M ')).toBe(true);
 		expect(paths[0]?.d.endsWith('Z')).toBe(true);
+	});
+
+	it('gives a single day a centered stacked bar', () => {
+		const width = 400;
+		const paths = stackedAreaPaths(
+			[{ date: '2026-08-19', cumulative: { a: 10, b: 5 } }],
+			['a', 'b'],
+			width,
+			160
+		);
+		const { x0, x1 } = singleDayBarBounds(width);
+		expect(paths).toHaveLength(2);
+		const xs = [...(paths[0]?.d.matchAll(/(?:M|L) ([\d.]+)/g) ?? [])].map((match) => Number(match[1]));
+		expect(new Set(xs)).toEqual(new Set([x0, x1]));
+		expect(x1 - x0).toBeLessThan(width / 2);
 	});
 
 	it('snaps hover x to the nearest day', () => {

--- a/cometline/src/lib/usage/chart.ts
+++ b/cometline/src/lib/usage/chart.ts
@@ -16,10 +16,39 @@ export type XLabel = {
 	anchor: AxisAnchor;
 };
 
+function seriesHsl(index: number, total: number): { h: number; s: number; l: number } {
+	const count = Math.max(1, Math.trunc(total) || 1);
+	return {
+		h: (12 + (index * 360) / count) % 360,
+		s: 36,
+		l: index % 2 === 0 ? 39 : 57
+	};
+}
+
+function hsl({ h, s, l }: { h: number; s: number; l: number }): string {
+	return `hsl(${h} ${s}% ${l}%)`;
+}
+
+export function seriesColor(index: number, total: number): string {
+	return hsl(seriesHsl(index, total));
+}
+
+export function seriesStroke(index: number, total: number): string {
+	const tone = seriesHsl(index, total);
+	return hsl({ ...tone, l: Math.max(22, tone.l - 14) });
+}
+
 export const PAD_LEFT = 36;
 export const PAD_RIGHT = 20;
 const PAD_TOP = 12;
 const PAD_BOTTOM = 24;
+
+export function singleDayBarBounds(width: number): { x0: number; x1: number } {
+	const innerW = Math.max(1, width - PAD_LEFT - PAD_RIGHT);
+	const barW = Math.min(72, Math.max(36, innerW * 0.16));
+	const cx = PAD_LEFT + innerW / 2;
+	return { x0: cx - barW / 2, x1: cx + barW / 2 };
+}
 
 function xAt(index: number, count: number, width: number): number {
 	const innerW = Math.max(1, width - PAD_LEFT - PAD_RIGHT);
@@ -53,14 +82,23 @@ export function stackedAreaPaths(
 	return keys.map((key, seriesIndex) => {
 		const tops: Array<{ x: number; y: number }> = [];
 		const bottoms: Array<{ x: number; y: number }> = [];
-		for (let i = 0; i < points.length; i += 1) {
+		const count = points.length;
+		for (let i = 0; i < count; i += 1) {
 			let below = 0;
 			for (let j = 0; j < seriesIndex; j += 1) {
 				below += points[i]?.cumulative[keys[j] ?? ''] ?? 0;
 			}
 			const value = points[i]?.cumulative[key] ?? 0;
-			tops.push({ x: xAt(i, points.length, width), y: yAt(below + value) });
-			bottoms.push({ x: xAt(i, points.length, width), y: yAt(below) });
+			const yTop = yAt(below + value);
+			const yBottom = yAt(below);
+			if (count === 1) {
+				const { x0, x1 } = singleDayBarBounds(width);
+				tops.push({ x: x0, y: yTop }, { x: x1, y: yTop });
+				bottoms.push({ x: x0, y: yBottom }, { x: x1, y: yBottom });
+				continue;
+			}
+			tops.push({ x: xAt(i, count, width), y: yTop });
+			bottoms.push({ x: xAt(i, count, width), y: yBottom });
 		}
 		const d = [
 			`M ${tops[0]?.x ?? 0} ${tops[0]?.y ?? 0}`,

--- a/cometline/src/lib/usage/format.test.ts
+++ b/cometline/src/lib/usage/format.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { clampUsageRange, formatKind, formatRangeLabel, formatTokens, formatUSD, rangeForPreset } from './format';
+import {
+	clampUsageRange,
+	formatKind,
+	formatRangeLabel,
+	formatTokens,
+	formatUSD,
+	legendRowsForSeries,
+	rangeForPreset,
+	seriesKeyForBucket
+} from './format';
 
 describe('usage format', () => {
 	it('formats token counts', () => {
@@ -20,10 +29,60 @@ describe('usage format', () => {
 		expect(formatKind('embedding')).toBe('Embedding');
 	});
 
+	it('builds today as the current local day', () => {
+		const now = new Date(2026, 7, 19, 11, 8, 37);
+		const range = rangeForPreset('today', now);
+		expect(range.from).toBe(new Date(2026, 7, 19).getTime());
+		expect(range.to).toBe(now.getTime() + 1);
+		expect(formatRangeLabel(range.from, range.to)).toBe(
+			new Date(2026, 7, 19).toLocaleDateString(undefined, {
+				month: 'short',
+				day: 'numeric',
+				year: 'numeric'
+			})
+		);
+	});
+
 	it('builds last-month as the previous calendar month', () => {
 		const range = rangeForPreset('month', new Date(2026, 7, 18));
 		expect(new Date(range.from).getMonth()).toBe(6);
 		expect(new Date(range.to).getMonth()).toBe(7);
+	});
+
+	it('maps summary buckets onto series keys with estimated spend', () => {
+		expect(
+			seriesKeyForBucket(
+				{ key: 'gpt-5.6-luna', provider_id: 'codex', model_id: 'gpt-5.6-luna', tokens: 1, estimated_usd: 0.12, priced: true },
+				'model'
+			)
+		).toBe('codex/gpt-5.6-luna');
+		expect(
+			legendRowsForSeries(
+				['codex/gpt-5.6-luna', 'xai/grok-4.6'],
+				[
+					{
+						key: 'gpt-5.6-luna',
+						provider_id: 'codex',
+						model_id: 'gpt-5.6-luna',
+						tokens: 8800,
+						estimated_usd: 0.12,
+						priced: true
+					},
+					{
+						key: 'grok-4.6',
+						provider_id: 'xai',
+						model_id: 'grok-4.6',
+						tokens: 528800,
+						estimated_usd: 0,
+						priced: false
+					}
+				],
+				'model'
+			)
+		).toEqual([
+			{ key: 'codex/gpt-5.6-luna', label: 'codex/gpt-5.6-luna', tokens: 8800, cost: '$0.12' },
+			{ key: 'xai/grok-4.6', label: 'xai/grok-4.6', tokens: 528800, cost: '—' }
+		]);
 	});
 
 	it('clamps custom ranges to one year', () => {

--- a/cometline/src/lib/usage/format.ts
+++ b/cometline/src/lib/usage/format.ts
@@ -44,7 +44,18 @@ function trimFloat(n: number): string {
 	return n.toFixed(1).replace(/\.0$/, '');
 }
 
-export type RangePreset = '7d' | '30d' | 'month' | 'year';
+export type RangePreset = 'today' | '7d' | '30d' | 'month' | 'year';
+export type UsageGroupBy = 'model' | 'kind';
+
+export type UsageSeriesBucket = {
+	key: string;
+	provider_id?: string;
+	model_id?: string;
+	call_kind?: string;
+	tokens: number;
+	estimated_usd: number;
+	priced: boolean;
+};
 
 export const MAX_RANGE_DAYS = 366;
 
@@ -52,7 +63,10 @@ export function formatRangeLabel(from: number, to: number): string {
 	const start = new Date(from);
 	const end = new Date(to - 1);
 	const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
-	return `${start.toLocaleDateString(undefined, opts)} – ${end.toLocaleDateString(undefined, opts)}`;
+	const startLabel = start.toLocaleDateString(undefined, opts);
+	const endLabel = end.toLocaleDateString(undefined, opts);
+	if (startLabel === endLabel) return startLabel;
+	return `${startLabel} – ${endLabel}`;
 }
 
 export function clampUsageRange(from: number, to: number, now = new Date()): { from: number; to: number } {
@@ -69,6 +83,10 @@ export function clampUsageRange(from: number, to: number, now = new Date()): { f
 
 export function rangeForPreset(preset: RangePreset, now = new Date()): { from: number; to: number } {
 	const to = now.getTime() + 1;
+	if (preset === 'today') {
+		const from = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+		return { from, to };
+	}
 	if (preset === 'month') {
 		const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
 		const end = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -80,4 +98,55 @@ export function rangeForPreset(preset: RangePreset, now = new Date()): { from: n
 	const days = preset === '30d' ? 30 : 7;
 	const from = new Date(now.getFullYear(), now.getMonth(), now.getDate() - (days - 1)).getTime();
 	return { from, to };
+}
+
+export function seriesKeyForBucket(bucket: UsageSeriesBucket, groupBy: UsageGroupBy): string {
+	if (groupBy === 'kind') {
+		return bucket.call_kind || bucket.key;
+	}
+	const provider = bucket.provider_id?.trim() ?? '';
+	const model = (bucket.model_id || bucket.key).trim();
+	if (!provider) return model;
+	if (!model) return provider;
+	return `${provider}/${model}`;
+}
+
+export function indexSeriesBuckets(
+	buckets: UsageSeriesBucket[],
+	groupBy: UsageGroupBy
+): Record<string, UsageSeriesBucket> {
+	const indexed: Record<string, UsageSeriesBucket> = {};
+	for (const bucket of buckets) {
+		indexed[seriesKeyForBucket(bucket, groupBy)] = bucket;
+	}
+	return indexed;
+}
+
+export function formatBucketCost(bucket?: Pick<UsageSeriesBucket, 'priced' | 'estimated_usd'>): string {
+	if (!bucket?.priced) return '—';
+	return formatUSD(bucket.estimated_usd);
+}
+
+export type UsageLegendRow = {
+	key: string;
+	label: string;
+	tokens: number;
+	cost: string;
+};
+
+export function legendRowsForSeries(
+	keys: string[],
+	buckets: UsageSeriesBucket[],
+	groupBy: UsageGroupBy
+): UsageLegendRow[] {
+	const indexed = indexSeriesBuckets(buckets, groupBy);
+	return keys.map((key) => {
+		const bucket = indexed[key];
+		return {
+			key,
+			label: groupBy === 'kind' ? formatKind(key) : key,
+			tokens: bucket?.tokens ?? 0,
+			cost: formatBucketCost(bucket)
+		};
+	});
 }


### PR DESCRIPTION
## Background

Some OpenAI and Anthropic streams dropped token usage, so the dashboard undercounted. The usage page also needed a today view and per-model spend.

[a96e7aa](https://github.com/Cometline/cometline/commit/a96e7aabf3828a1b253c03ee89cb426a8b5e5d74): OpenAI chat completions now keep usage when a chunk still has choices.

[9931358](https://github.com/Cometline/cometline/commit/9931358f6728f1e2fec62c459cf6ef54f08f47ef): Anthropic usage from message_start and message_delta is merged so a start-only stream still records tokens.

[4be97f3](https://github.com/Cometline/cometline/commit/4be97f318552754bca6ad4c836d3648aaaf86245): /usage shows estimated spend per model, adds a Today range, and draws a single-day stacked bar.