### PR TITLE
[main] feat: add collapsible user messages

### DIFF
--- a/cometline/src/app.css
+++ b/cometline/src/app.css
@@ -77,6 +77,7 @@
 	--thread-turn-bottom-clearance: 96px;
 	/* Set on .thread at runtime from viewport height; used by active turn scroll-margin. */
 	--thread-user-pin-offset-followup: 0px;
+	--user-message-collapsed-height: min(18rem, 42dvh);
 
 	/* Motion */
 	--ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);

--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -486,6 +486,7 @@
 		height: 100vh;
 		min-height: 100vh;
 		--mini-titlebar-height: 46px;
+		--user-message-collapsed-height: min(15rem, 36dvh);
 		background:
 			radial-gradient(
 				circle at top,

--- a/cometline/src/lib/components/UserBubbleFlight.svelte
+++ b/cometline/src/lib/components/UserBubbleFlight.svelte
@@ -6,6 +6,7 @@
 	} from '$lib/first-turn-flight';
 	import { imageDataURL } from '$lib/files/images';
 	import AssistantMarkdown from '$lib/components/AssistantMarkdown.svelte';
+	import UserMessageViewport from '$lib/components/chat/UserMessageViewport.svelte';
 	import type { ImageAttachment } from '$lib/types';
 
 	interface RunOptions {
@@ -100,16 +101,18 @@
 
 {#if showUserFlight}
 	<div class="flight-particle bubble user-bubble" style={userFlightStyle}>
-		{#if userFlightImages?.length}
-			<div class="user-images" class:text-following={Boolean(userFlightText)}>
-				{#each userFlightImages as image, index (`${image.id ?? index}`)}
-					<img src={imageDataURL(image)} alt={image.name ?? 'Attached image'} />
-				{/each}
-			</div>
-		{/if}
-		{#if userFlightText.trim()}
-			<AssistantMarkdown source={userFlightText.trim()} mode="user" />
-		{/if}
+		<UserMessageViewport interactive={false}>
+			{#if userFlightImages?.length}
+				<div class="user-images" class:text-following={Boolean(userFlightText)}>
+					{#each userFlightImages as image, index (`${image.id ?? index}`)}
+						<img src={imageDataURL(image)} alt={image.name ?? 'Attached image'} />
+					{/each}
+				</div>
+			{/if}
+			{#if userFlightText.trim()}
+				<AssistantMarkdown source={userFlightText.trim()} mode="user" />
+			{/if}
+		</UserMessageViewport>
 	</div>
 {/if}
 

--- a/cometline/src/lib/components/chat/UserMessageRow.svelte
+++ b/cometline/src/lib/components/chat/UserMessageRow.svelte
@@ -6,6 +6,7 @@
 	import ThreadAvatar from '$lib/components/chat/ThreadAvatar.svelte';
 	import ThreadRow from '$lib/components/chat/ThreadRow.svelte';
 	import ImageLightbox from '$lib/components/chat/ImageLightbox.svelte';
+	import UserMessageViewport from '$lib/components/chat/UserMessageViewport.svelte';
 	import { imageDataURL } from '$lib/files/images';
 	import type { ChatItem } from '$lib/stores/chat.svelte';
 
@@ -43,25 +44,27 @@
 </script>
 
 {#snippet bubbleBody()}
-	{#if item.images?.length}
-		<div class="user-images" class:text-following={Boolean(item.text)}>
-			{#each item.images as image, imageIndex (`${item.id}-image-${image.id ?? imageIndex}`)}
-				{@const src = imageDataURL(image)}
-				{@const alt = image.name ?? 'Attached image'}
-				<button
-					type="button"
-					class="image-open"
-					aria-label={`View ${alt}`}
-					onclick={() => (lightbox = { src, alt })}
-				>
-					<img {src} {alt} />
-				</button>
-			{/each}
-		</div>
-	{/if}
-	{#if item.text?.trim()}
-		<AssistantMarkdown source={item.text.trim()} mode="user" />
-	{/if}
+	<UserMessageViewport contentId={`user-message-content-${item.id}`}>
+		{#if item.images?.length}
+			<div class="user-images" class:text-following={Boolean(item.text)}>
+				{#each item.images as image, imageIndex (`${item.id}-image-${image.id ?? imageIndex}`)}
+					{@const src = imageDataURL(image)}
+					{@const alt = image.name ?? 'Attached image'}
+					<button
+						type="button"
+						class="image-open"
+						aria-label={`View ${alt}`}
+						onclick={() => (lightbox = { src, alt })}
+					>
+						<img {src} {alt} />
+					</button>
+				{/each}
+			</div>
+		{/if}
+		{#if item.text?.trim()}
+			<AssistantMarkdown source={item.text.trim()} mode="user" />
+		{/if}
+	</UserMessageViewport>
 {/snippet}
 
 <ThreadRow variant="user" {continuationRow} data-user-item-id={item.id}>

--- a/cometline/src/lib/components/chat/UserMessageRow.svelte.test.ts
+++ b/cometline/src/lib/components/chat/UserMessageRow.svelte.test.ts
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import UserMessageRow from './UserMessageRow.svelte';
 
 describe('UserMessageRow', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('renders user message text', () => {
 		render(UserMessageRow, {
 			props: {
@@ -14,5 +18,35 @@ describe('UserMessageRow', () => {
 			}
 		});
 		expect(screen.getByText('Hello Cometline')).toBeTruthy();
+		expect(screen.queryByRole('button', { name: 'Expand user message' })).toBeNull();
+	});
+
+	it('toggles an overflowing message between collapsed and expanded', async () => {
+		vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(640);
+		vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(240);
+
+		render(UserMessageRow, {
+			props: {
+				item: { id: 'u-long', type: 'user', text: 'A long user message '.repeat(80) },
+				avatarSrc: '/project_avatar_192.png',
+				copiedId: null,
+				onCopyMessage: () => {}
+			}
+		});
+
+		const expand = await screen.findByRole('button', { name: 'Expand user message' });
+		expect(expand.getAttribute('aria-expanded')).toBe('false');
+		expect(expand.getAttribute('aria-controls')).toBe('user-message-content-u-long');
+
+		await fireEvent.click(expand);
+		const collapse = await screen.findByRole('button', { name: 'Collapse user message' });
+		expect(collapse.getAttribute('aria-expanded')).toBe('true');
+
+		await fireEvent.click(collapse);
+		expect(
+			(await screen.findByRole('button', { name: 'Expand user message' })).getAttribute(
+				'aria-expanded'
+			)
+		).toBe('false');
 	});
 });

--- a/cometline/src/lib/components/chat/UserMessageViewport.svelte
+++ b/cometline/src/lib/components/chat/UserMessageViewport.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { ChevronDown } from '@lucide/svelte';
+
+	let {
+		contentId,
+		interactive = true,
+		children
+	}: {
+		contentId?: string;
+		interactive?: boolean;
+		children: Snippet;
+	} = $props();
+
+	let viewport = $state<HTMLDivElement | null>(null);
+	let content = $state<HTMLDivElement | null>(null);
+	let expanded = $state(false);
+	let overflowing = $state(false);
+	let contentHeight = $state(0);
+
+	function measure() {
+		if (!viewport || !content) return;
+		contentHeight = content.scrollHeight;
+		if (!expanded) {
+			overflowing = content.scrollHeight - viewport.clientHeight > 1;
+		}
+	}
+
+	$effect(() => {
+		if (!viewport || !content) return;
+		measure();
+		if (typeof ResizeObserver === 'undefined') return;
+
+		const observer = new ResizeObserver(measure);
+		observer.observe(viewport);
+		observer.observe(content);
+		return () => observer.disconnect();
+	});
+
+	function toggleExpanded() {
+		if (!interactive || !overflowing) return;
+		measure();
+		expanded = !expanded;
+	}
+</script>
+
+<div
+	bind:this={viewport}
+	id={contentId}
+	data-user-message-viewport
+	class="user-message-viewport"
+	class:expanded
+	class:overflowing
+	style:max-height={expanded && contentHeight > 0 ? `${contentHeight}px` : undefined}
+>
+	<div bind:this={content} class="user-message-content" class:reserve-control={overflowing}>
+		{@render children()}
+	</div>
+</div>
+
+{#if overflowing}
+	{#if interactive}
+		<button
+			type="button"
+			data-user-message-expand
+			class="user-message-expand"
+			class:expanded
+			aria-label={expanded ? 'Collapse user message' : 'Expand user message'}
+			aria-expanded={expanded}
+			aria-controls={contentId}
+			onclick={toggleExpanded}
+		>
+			<ChevronDown size={15} stroke-width={2} />
+		</button>
+	{:else}
+		<span class="user-message-expand" aria-hidden="true">
+			<ChevronDown size={15} stroke-width={2} />
+		</span>
+	{/if}
+{/if}
+
+<style>
+	.user-message-viewport {
+		max-height: var(--user-message-collapsed-height, min(18rem, 42dvh));
+		overflow: clip;
+		transition: max-height var(--duration-fast) var(--ease-smooth);
+	}
+
+	.user-message-viewport.overflowing:not(.expanded) {
+		-webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 76%, transparent 100%);
+		mask-image: linear-gradient(to bottom, #000 0%, #000 76%, transparent 100%);
+	}
+
+	.user-message-content {
+		min-width: 0;
+	}
+
+	.user-message-content.reserve-control {
+		padding-bottom: 30px;
+	}
+
+	.user-message-expand {
+		position: absolute;
+		right: 8px;
+		bottom: 7px;
+		z-index: 2;
+		display: grid;
+		place-items: center;
+		width: 28px;
+		height: 28px;
+		padding: 0;
+		border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--panel-bg) 90%, transparent);
+		box-shadow: 0 3px 10px var(--user-bubble-shadow);
+		color: var(--text-muted);
+	}
+
+	button.user-message-expand {
+		cursor: pointer;
+		transition:
+			background var(--duration-fast) var(--ease-smooth),
+			color var(--duration-fast) var(--ease-smooth),
+			border-color var(--duration-fast) var(--ease-smooth);
+	}
+
+	button.user-message-expand:hover,
+	button.user-message-expand:focus-visible {
+		border-color: color-mix(in srgb, var(--hero-composer-glow-color) 48%, var(--border-soft));
+		background: var(--panel-bg);
+		color: var(--text-main);
+		outline: none;
+	}
+
+	.user-message-expand :global(svg) {
+		transition: transform var(--duration-fast) var(--ease-smooth);
+	}
+
+	.user-message-expand.expanded :global(svg) {
+		transform: rotate(180deg);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.user-message-viewport,
+		button.user-message-expand,
+		.user-message-expand :global(svg) {
+			transition: none;
+		}
+	}
+</style>

--- a/cometline/src/lib/conversation/session-find.svelte.test.ts
+++ b/cometline/src/lib/conversation/session-find.svelte.test.ts
@@ -91,7 +91,7 @@ describe('createSessionFindController', () => {
 		const message = root.querySelector<HTMLElement>('[data-session-find-text]')!;
 		const order: string[] = [];
 		vi.spyOn(expand, 'click').mockImplementation(() => order.push('expand'));
-		vi.mocked(HTMLElement.prototype.scrollIntoView).mockImplementation(function () {
+		vi.mocked(HTMLElement.prototype.scrollIntoView).mockImplementation(function (this: HTMLElement) {
 			if (this === message) order.push('scroll');
 		});
 		let controller!: ReturnType<typeof createSessionFindController>;

--- a/cometline/src/lib/conversation/session-find.svelte.test.ts
+++ b/cometline/src/lib/conversation/session-find.svelte.test.ts
@@ -79,4 +79,30 @@ describe('createSessionFindController', () => {
 		disconnect();
 		cleanup();
 	});
+
+	it('expands a collapsed user message before scrolling to its active match', async () => {
+		root.innerHTML = `
+			<div data-session-find-text>
+				<div data-user-message-viewport>hidden match</div>
+				<button data-user-message-expand aria-expanded="false">Expand</button>
+			</div>
+		`;
+		const expand = root.querySelector<HTMLButtonElement>('[data-user-message-expand]')!;
+		const message = root.querySelector<HTMLElement>('[data-session-find-text]')!;
+		const order: string[] = [];
+		vi.spyOn(expand, 'click').mockImplementation(() => order.push('expand'));
+		vi.mocked(HTMLElement.prototype.scrollIntoView).mockImplementation(function () {
+			if (this === message) order.push('scroll');
+		});
+		let controller!: ReturnType<typeof createSessionFindController>;
+		const cleanup = $effect.root(() => {
+			controller = createSessionFindController(() => root);
+		});
+
+		controller.openFind();
+		controller.setQuery('hidden');
+		await vi.waitFor(() => expect(order).toEqual(['expand', 'scroll']));
+
+		cleanup();
+	});
 });

--- a/cometline/src/lib/conversation/session-find.svelte.ts
+++ b/cometline/src/lib/conversation/session-find.svelte.ts
@@ -1,3 +1,4 @@
+import { tick } from 'svelte';
 import {
 	findSessionTextMatches,
 	SESSION_FIND_ACTIVE_HIGHLIGHT,
@@ -18,9 +19,7 @@ function highlightRegistry(): HighlightRegistry | null {
 }
 
 function highlightConstructor(): HighlightConstructor | null {
-	return (
-		(globalThis as unknown as { Highlight?: HighlightConstructor }).Highlight ?? null
-	);
+	return (globalThis as unknown as { Highlight?: HighlightConstructor }).Highlight ?? null;
 }
 
 export function createSessionFindController(getRoot: () => HTMLElement | null) {
@@ -50,11 +49,19 @@ export function createSessionFindController(getRoot: () => HTMLElement | null) {
 		if (active) registry.set(SESSION_FIND_ACTIVE_HIGHLIGHT, new Highlight(active.range));
 	}
 
-	function scrollActiveIntoView() {
+	async function scrollActiveIntoView() {
 		const active = matches[activeIndex];
 		if (!active) return;
 		const scroller = getRoot();
 		if (!scroller) return;
+		const expandButton = active.root.querySelector<HTMLButtonElement>(
+			'[data-user-message-expand][aria-expanded="false"]'
+		);
+		if (expandButton) {
+			expandButton.click();
+			await tick();
+			if (matches[activeIndex] !== active) return;
+		}
 		const rangeRect = active.range.getBoundingClientRect?.();
 		const scrollerRect = scroller.getBoundingClientRect();
 		if (rangeRect && (rangeRect.width > 0 || rangeRect.height > 0)) {
@@ -74,7 +81,7 @@ export function createSessionFindController(getRoot: () => HTMLElement | null) {
 		else if (!options.preserveIndex || activeIndex < 0) activeIndex = 0;
 		else activeIndex = Math.min(activeIndex, matches.length - 1);
 		paintHighlights();
-		if (options.scroll && activeIndex >= 0) scrollActiveIntoView();
+		if (options.scroll && activeIndex >= 0) void scrollActiveIntoView();
 	}
 
 	function openFind() {
@@ -103,7 +110,7 @@ export function createSessionFindController(getRoot: () => HTMLElement | null) {
 		if (matches.length === 0) return;
 		activeIndex = (activeIndex + direction + matches.length) % matches.length;
 		paintHighlights();
-		scrollActiveIntoView();
+		void scrollActiveIntoView();
 	}
 
 	function observe() {

--- a/cometline/src/lib/styles/chat-bubble.css
+++ b/cometline/src/lib/styles/chat-bubble.css
@@ -11,6 +11,7 @@
 }
 
 .user-bubble {
+	position: relative;
 	width: fit-content;
 	max-width: 100%;
 	word-break: normal;

--- a/cometline/src/stories/UserMessageRow.stories.ts
+++ b/cometline/src/stories/UserMessageRow.stories.ts
@@ -15,3 +15,19 @@ export const Default: Story = {};
 export const Copied: Story = {
 	args: { copied: true }
 };
+
+export const LongMessage: Story = {
+	args: {
+		text: Array.from(
+			{ length: 18 },
+			(_, index) =>
+				`Paragraph ${index + 1}: Explain how a long user message should stay readable.`
+		).join('\n')
+	}
+};
+
+export const LongUnbrokenMessage: Story = {
+	args: {
+		text: `A long token should still stay inside the bubble: ${'cometline'.repeat(90)}`
+	}
+};

--- a/cometline/src/stories/wrappers/UserMessageRowStory.svelte
+++ b/cometline/src/stories/wrappers/UserMessageRowStory.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import UserMessageRow from '$lib/components/chat/UserMessageRow.svelte';
 
-	let { copied = false }: { copied?: boolean } = $props();
+	let {
+		copied = false,
+		text = 'Explain how thread folding works.'
+	}: { copied?: boolean; text?: string } = $props();
 </script>
 
 <UserMessageRow
-	item={{ id: 'user-1', type: 'user', text: 'Explain how thread folding works.' }}
+	item={{ id: 'user-1', type: 'user', text }}
 	avatarSrc="/project_avatar_192.png"
 	copiedId={copied ? 'user-1' : null}
 	onCopyMessage={() => {}}


### PR DESCRIPTION
## Background

Long user messages could grow beyond the available chat viewport and destabilize the composer-to-thread transition in main and mini windows. They need bounded initial geometry without preventing access to the full content.

[d0cf81f](https://github.com/Cometline/cometline/commit/d0cf81fd3a432ecf5b38ce710279efb902040fb1): Adds a responsive collapsible user-message viewport shared by rendered bubbles and flight particles, with accessible expansion controls, find-in-chat expansion, regression tests, and long-message Storybook coverage.