### PR TITLE
[main] feat: prewarm mini window and keep toggles instant

### DIFF
--- a/cometline/electron/src/domains/runtime.ts
+++ b/cometline/electron/src/domains/runtime.ts
@@ -50,7 +50,7 @@ const runtimeDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url
 type Windows = ReturnType<typeof createWindows>;
 type CometMindLifecycle = ReturnType<typeof createCometMindLifecycle>;
 
-const MINI_WINDOW_PREWARM_DELAY_MS = 1000;
+const MINI_WINDOW_PREWARM_DELAY_MS = 300;
 
 let initialized = false;
 
@@ -359,7 +359,7 @@ export function initializeRuntime() {
 		shouldKeepWindowsAlive: () => !stoppingForQuit && !stoppedForQuit,
 		shortcuts,
 		windowChrome,
-		writeMiniWindowState: settingsDomain.writeMiniWindowState
+		touchMiniWindowActivity: settingsDomain.touchMiniWindowActivity
 	});
 	const pdfPreview = createPdfPreviewRegistry({
 		fs,
@@ -450,9 +450,9 @@ export function initializeRuntime() {
 				void cometMind.syncDiscordGateway(startupSettings);
 			}
 		});
-		void Promise.all([windowReady, healthReady])
-			.then(([, healthy]) => {
-				if (!healthy || stoppingForQuit || stoppedForQuit) return;
+		void windowReady
+			.then(() => {
+				if (stoppingForQuit || stoppedForQuit) return;
 				miniWindowPrewarmTimer = setTimeout(() => {
 					miniWindowPrewarmTimer = null;
 					if (stoppingForQuit || stoppedForQuit) return;
@@ -481,6 +481,7 @@ export function initializeRuntime() {
 		}
 		event.preventDefault();
 		stoppingForQuit = true;
+		settingsDomain.flushMiniWindowActivity();
 		if (miniWindowPrewarmTimer) {
 			clearTimeout(miniWindowPrewarmTimer);
 			miniWindowPrewarmTimer = null;

--- a/cometline/electron/src/domains/runtime.ts
+++ b/cometline/electron/src/domains/runtime.ts
@@ -50,6 +50,8 @@ const runtimeDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url
 type Windows = ReturnType<typeof createWindows>;
 type CometMindLifecycle = ReturnType<typeof createCometMindLifecycle>;
 
+const MINI_WINDOW_PREWARM_DELAY_MS = 1000;
+
 let initialized = false;
 
 function resolveCometMindBinary() {
@@ -117,6 +119,7 @@ export function initializeRuntime() {
 	let sessionNavigationSuspended = false;
 	let workspacePanelOpen = false;
 	let inboxOpen = false;
+	let miniWindowPrewarmTimer: ReturnType<typeof setTimeout> | null = null;
 	let windows: Windows | null = null;
 
 	const shellContext: ShellWindowContext = {
@@ -437,7 +440,8 @@ export function initializeRuntime() {
 		}
 		cometMind.start();
 		const windowReady = windows.createMainWindow();
-		cometMind.waitForHealth().then((healthy) => {
+		const healthReady = cometMind.waitForHealth();
+		healthReady.then((healthy) => {
 			if (!healthy) {
 				console.error('CometMind failed to become healthy');
 				return;
@@ -446,6 +450,20 @@ export function initializeRuntime() {
 				void cometMind.syncDiscordGateway(startupSettings);
 			}
 		});
+		void Promise.all([windowReady, healthReady])
+			.then(([, healthy]) => {
+				if (!healthy || stoppingForQuit || stoppedForQuit) return;
+				miniWindowPrewarmTimer = setTimeout(() => {
+					miniWindowPrewarmTimer = null;
+					if (stoppingForQuit || stoppedForQuit) return;
+					void windows?.prepareMiniWindow().catch((error) => {
+						console.error('Mini window failed to prewarm:', error);
+					});
+				}, MINI_WINDOW_PREWARM_DELAY_MS);
+			})
+			.catch((error) => {
+				console.error('Mini window prewarm could not be scheduled:', error);
+			});
 		await windowReady;
 		updater.configure();
 		app.on('second-instance', () => windows?.showMainWindow());
@@ -463,6 +481,10 @@ export function initializeRuntime() {
 		}
 		event.preventDefault();
 		stoppingForQuit = true;
+		if (miniWindowPrewarmTimer) {
+			clearTimeout(miniWindowPrewarmTimer);
+			miniWindowPrewarmTimer = null;
+		}
 		applicationMenuTray.destroyTray();
 		updater.stop();
 		await browserSearch.stop();

--- a/cometline/electron/src/domains/settings-domain.test.ts
+++ b/cometline/electron/src/domains/settings-domain.test.ts
@@ -226,6 +226,9 @@ describe('settings domain factory', () => {
 		settings.app.miniWindowSessionId = 'persisted-mini-session';
 		domain.writeProviderSettings(settings);
 		expect(domain.readMiniWindowState().sessionId).toBe('persisted-mini-session');
+		domain.touchMiniWindowActivity();
+		expect(domain.readMiniWindowState().lastActiveAt).toBe(1_700_000_000_000);
+		expect(domain.flushMiniWindowActivity().lastActiveAt).toBe(1_700_000_000_000);
 		expect(domain.writeStoredWorkspacePath(workspace)).toBe(workspace);
 		expect(domain.listRecentWorkspacePaths()).toEqual([workspace]);
 		expect(domain.appendComposerHistoryEntry({ display: 'run tests', project: workspace })).toMatchObject({

--- a/cometline/electron/src/domains/settings.ts
+++ b/cometline/electron/src/domains/settings.ts
@@ -300,17 +300,47 @@ export function createSettingsDomain(dependencies: SettingsDomainDependencies) {
 		return next;
 	}
 
+	let liveMiniWindowLastActiveAt = 0;
+
 	function readMiniWindowState(): MiniWindowState {
-		return miniWindowStateFromSettings(readProviderSettings());
+		const state = miniWindowStateFromSettings(readProviderSettings());
+		return {
+			...state,
+			lastActiveAt: Math.max(state.lastActiveAt, liveMiniWindowLastActiveAt)
+		};
+	}
+
+	function touchMiniWindowActivity() {
+		liveMiniWindowLastActiveAt = Math.max(liveMiniWindowLastActiveAt, dependencies.now());
 	}
 
 	function writeMiniWindowState(partial: {
 		sessionId?: unknown;
 		lastActiveAt?: unknown;
 	}): MiniWindowState {
+		if (Number.isFinite(partial?.lastActiveAt)) {
+			liveMiniWindowLastActiveAt = Math.max(
+				liveMiniWindowLastActiveAt,
+				Math.floor(Number(partial.lastActiveAt))
+			);
+		}
 		return miniWindowStateFromSettings(
-			writeProviderSettings(withMiniWindowState(readProviderSettings(), partial))
+			writeProviderSettings(
+				withMiniWindowState(readProviderSettings(), {
+					...partial,
+					lastActiveAt: Number.isFinite(partial?.lastActiveAt)
+						? partial.lastActiveAt
+						: liveMiniWindowLastActiveAt > 0
+							? liveMiniWindowLastActiveAt
+							: undefined
+				})
+			)
 		);
+	}
+
+	function flushMiniWindowActivity() {
+		if (liveMiniWindowLastActiveAt <= 0) return readMiniWindowState();
+		return writeMiniWindowState({ lastActiveAt: liveMiniWindowLastActiveAt });
 	}
 
 	function parseComposerHistoryEntry(value: unknown): ComposerHistoryEntry | null {
@@ -403,12 +433,14 @@ export function createSettingsDomain(dependencies: SettingsDomainDependencies) {
 		listRecentWorkspacePaths,
 		loadComposerHistoryEntries,
 		pruneWorkspaceStore,
+		flushMiniWindowActivity,
 		readMiniWindowState,
 		readProviderSettings,
 		readSavedProviderSettings,
 		removeRecentWorkspacePath,
 		browseWorkspacePath,
 		selectWorkspacePath,
+		touchMiniWindowActivity,
 		writeMiniWindowState,
 		writeProviderSettings,
 		writeStoredWorkspacePath

--- a/cometline/electron/src/domains/windows.test.ts
+++ b/cometline/electron/src/domains/windows.test.ts
@@ -24,14 +24,27 @@ class FakeWindow {
 		setWindowOpenHandler: vi.fn(),
 		send: vi.fn()
 	};
+	visible = false;
+	focused = false;
 	readonly destroy = vi.fn();
-	readonly focus = vi.fn();
-	readonly hide = vi.fn();
+	readonly focus = vi.fn(() => {
+		this.focused = true;
+	});
+	readonly hide = vi.fn(() => {
+		this.visible = false;
+		this.focused = false;
+	});
 	readonly isDestroyed = vi.fn(() => false);
-	readonly isFocused = vi.fn(() => false);
+	readonly isFocused = vi.fn(() => this.focused);
 	readonly isFullScreen = vi.fn(() => false);
 	readonly isMinimized = vi.fn(() => false);
-	readonly isVisible = vi.fn(() => false);
+	readonly isVisible = vi.fn(() => this.visible);
+	readonly show = vi.fn(() => {
+		this.visible = true;
+	});
+	readonly showInactive = vi.fn(() => {
+		this.visible = true;
+	});
 	readonly loadURL = vi.fn((url: string) => FakeWindow.loadURLImplementation(url));
 	readonly once = vi.fn((event: string, handler: EventHandler) =>
 		this.handlers.set(`once:${event}`, handler)
@@ -47,7 +60,6 @@ class FakeWindow {
 	readonly setBounds = vi.fn();
 	readonly setVisibleOnAllWorkspaces = vi.fn();
 	readonly setWindowButtonVisibility = vi.fn();
-	readonly show = vi.fn();
 
 	constructor(readonly options: BrowserWindowConstructorOptions) {
 		FakeWindow.instances.push(this);
@@ -63,7 +75,7 @@ function createController(options: { packaged?: boolean; platform?: NodeJS.Platf
 	FakeWindow.loadURLImplementation = async () => undefined;
 	const openExternal = vi.fn(async () => undefined);
 	const setLoginItemSettings = vi.fn();
-	const writeMiniWindowState = vi.fn();
+	const touchMiniWindowActivity = vi.fn();
 	const getLoginItemSettings = vi.fn(() => ({ openAtLogin: true, status: 'not-registered' }));
 	const controller = createWindows({
 		app: {
@@ -104,37 +116,37 @@ function createController(options: { packaged?: boolean; platform?: NodeJS.Platf
 			sendFullScreenState: vi.fn(),
 			setWindowButtonPosition: vi.fn()
 		},
-		writeMiniWindowState
+		touchMiniWindowActivity
 	});
 	return {
 		controller,
 		getLoginItemSettings,
 		openExternal,
 		setLoginItemSettings,
-		writeMiniWindowState
+		touchMiniWindowActivity
 	};
 }
 
 describe('window lifecycle factory', () => {
 	it('prewarms the mini renderer without showing it, then activates the same window', async () => {
-		const { controller, writeMiniWindowState } = createController();
+		const { controller, touchMiniWindowActivity } = createController();
 
 		await controller.prepareMiniWindow();
 		const [mini] = FakeWindow.instances;
 		expect(mini.loadURL).toHaveBeenCalledWith('app://bundle/mini?prewarm=1');
-		expect(mini.show).not.toHaveBeenCalled();
+		expect(mini.showInactive).not.toHaveBeenCalled();
 		expect(mini.focus).not.toHaveBeenCalled();
 		expect(mini.webContents.send).not.toHaveBeenCalledWith('cometline:activate-mini-window');
-		expect(writeMiniWindowState).not.toHaveBeenCalled();
+		expect(touchMiniWindowActivity).not.toHaveBeenCalled();
 
 		await controller.toggleMiniWindow();
 		expect(FakeWindow.instances).toHaveLength(1);
 		expect(mini.webContents.send).toHaveBeenCalledWith('cometline:activate-mini-window');
-		expect(mini.show).toHaveBeenCalledOnce();
+		expect(mini.showInactive).toHaveBeenCalledOnce();
 		expect(mini.focus).toHaveBeenCalledOnce();
 	});
 
-	it('waits for an in-flight prewarm before showing the mini window', async () => {
+	it('reuses one in-flight prewarm and can reveal the window before load finishes', async () => {
 		const { controller } = createController();
 		let finishLoading: (() => void) | undefined;
 		FakeWindow.loadURLImplementation = () =>
@@ -143,15 +155,15 @@ describe('window lifecycle factory', () => {
 			});
 
 		const preparing = controller.prepareMiniWindow();
-		const toggling = controller.toggleMiniWindow();
 		await Promise.resolve();
-		const [mini] = FakeWindow.instances;
-		expect(mini.show).not.toHaveBeenCalled();
+		expect(FakeWindow.instances).toHaveLength(1);
+
+		const toggling = controller.toggleMiniWindow();
+		expect(FakeWindow.instances[0].showInactive).toHaveBeenCalledOnce();
 
 		finishLoading?.();
 		await Promise.all([preparing, toggling]);
 		expect(FakeWindow.instances).toHaveLength(1);
-		expect(mini.show).toHaveBeenCalledOnce();
 	});
 
 	it('discards a failed prewarm so the next attempt can recover', async () => {
@@ -194,7 +206,10 @@ describe('window lifecycle factory', () => {
 			type: 'panel',
 			fullscreenable: false,
 			width: 480,
-			height: 668
+			height: 668,
+			webPreferences: {
+				backgroundThrottling: false
+			}
 		});
 		expect(mini.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
 			visibleOnFullScreen: true,
@@ -204,6 +219,26 @@ describe('window lifecycle factory', () => {
 		expect(mini.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating');
 		expect(settings.options.webPreferences?.webviewTag).toBe(false);
 		expect(settings.loadURL).toHaveBeenCalledWith('app://bundle/settings');
+	});
+
+	it('toggles a ready mini window with show/hide only', async () => {
+		const { controller, touchMiniWindowActivity } = createController();
+		await controller.prepareMiniWindow();
+		const [mini] = FakeWindow.instances;
+
+		await controller.toggleMiniWindow();
+		expect(mini.showInactive).toHaveBeenCalledOnce();
+		expect(mini.webContents.send).toHaveBeenCalledOnce();
+		expect(mini.setVisibleOnAllWorkspaces).toHaveBeenCalledOnce();
+
+		await controller.toggleMiniWindow();
+		expect(mini.hide).toHaveBeenCalledOnce();
+		expect(touchMiniWindowActivity).toHaveBeenCalledOnce();
+
+		await controller.toggleMiniWindow();
+		expect(mini.showInactive).toHaveBeenCalledTimes(2);
+		expect(mini.webContents.send).toHaveBeenCalledOnce();
+		expect(mini.setVisibleOnAllWorkspaces).toHaveBeenCalledOnce();
 	});
 
 	it('uses the macOS main-app login item and opens System Settings for approval', () => {

--- a/cometline/electron/src/domains/windows.test.ts
+++ b/cometline/electron/src/domains/windows.test.ts
@@ -15,6 +15,7 @@ type EventHandler = (...args: unknown[]) => void;
 
 class FakeWindow {
 	static instances: FakeWindow[] = [];
+	static loadURLImplementation: (url: string) => Promise<void> = async () => undefined;
 	readonly handlers = new Map<string, EventHandler>();
 	readonly webContents = {
 		on: vi.fn((event: string, handler: EventHandler) =>
@@ -23,6 +24,7 @@ class FakeWindow {
 		setWindowOpenHandler: vi.fn(),
 		send: vi.fn()
 	};
+	readonly destroy = vi.fn();
 	readonly focus = vi.fn();
 	readonly hide = vi.fn();
 	readonly isDestroyed = vi.fn(() => false);
@@ -30,7 +32,7 @@ class FakeWindow {
 	readonly isFullScreen = vi.fn(() => false);
 	readonly isMinimized = vi.fn(() => false);
 	readonly isVisible = vi.fn(() => false);
-	readonly loadURL = vi.fn(async () => undefined);
+	readonly loadURL = vi.fn((url: string) => FakeWindow.loadURLImplementation(url));
 	readonly once = vi.fn((event: string, handler: EventHandler) =>
 		this.handlers.set(`once:${event}`, handler)
 	);
@@ -58,8 +60,10 @@ class FakeWindow {
 
 function createController(options: { packaged?: boolean; platform?: NodeJS.Platform } = {}) {
 	FakeWindow.instances = [];
+	FakeWindow.loadURLImplementation = async () => undefined;
 	const openExternal = vi.fn(async () => undefined);
 	const setLoginItemSettings = vi.fn();
+	const writeMiniWindowState = vi.fn();
 	const getLoginItemSettings = vi.fn(() => ({ openAtLogin: true, status: 'not-registered' }));
 	const controller = createWindows({
 		app: {
@@ -100,12 +104,70 @@ function createController(options: { packaged?: boolean; platform?: NodeJS.Platf
 			sendFullScreenState: vi.fn(),
 			setWindowButtonPosition: vi.fn()
 		},
-		writeMiniWindowState: vi.fn()
+		writeMiniWindowState
 	});
-	return { controller, getLoginItemSettings, openExternal, setLoginItemSettings };
+	return {
+		controller,
+		getLoginItemSettings,
+		openExternal,
+		setLoginItemSettings,
+		writeMiniWindowState
+	};
 }
 
 describe('window lifecycle factory', () => {
+	it('prewarms the mini renderer without showing it, then activates the same window', async () => {
+		const { controller, writeMiniWindowState } = createController();
+
+		await controller.prepareMiniWindow();
+		const [mini] = FakeWindow.instances;
+		expect(mini.loadURL).toHaveBeenCalledWith('app://bundle/mini?prewarm=1');
+		expect(mini.show).not.toHaveBeenCalled();
+		expect(mini.focus).not.toHaveBeenCalled();
+		expect(mini.webContents.send).not.toHaveBeenCalledWith('cometline:activate-mini-window');
+		expect(writeMiniWindowState).not.toHaveBeenCalled();
+
+		await controller.toggleMiniWindow();
+		expect(FakeWindow.instances).toHaveLength(1);
+		expect(mini.webContents.send).toHaveBeenCalledWith('cometline:activate-mini-window');
+		expect(mini.show).toHaveBeenCalledOnce();
+		expect(mini.focus).toHaveBeenCalledOnce();
+	});
+
+	it('waits for an in-flight prewarm before showing the mini window', async () => {
+		const { controller } = createController();
+		let finishLoading: (() => void) | undefined;
+		FakeWindow.loadURLImplementation = () =>
+			new Promise<void>((resolve) => {
+				finishLoading = resolve;
+			});
+
+		const preparing = controller.prepareMiniWindow();
+		const toggling = controller.toggleMiniWindow();
+		await Promise.resolve();
+		const [mini] = FakeWindow.instances;
+		expect(mini.show).not.toHaveBeenCalled();
+
+		finishLoading?.();
+		await Promise.all([preparing, toggling]);
+		expect(FakeWindow.instances).toHaveLength(1);
+		expect(mini.show).toHaveBeenCalledOnce();
+	});
+
+	it('discards a failed prewarm so the next attempt can recover', async () => {
+		const { controller } = createController();
+		FakeWindow.loadURLImplementation = async () => {
+			throw new Error('load failed');
+		};
+
+		await expect(controller.prepareMiniWindow()).rejects.toThrow('load failed');
+		expect(FakeWindow.instances[0].destroy).toHaveBeenCalledOnce();
+
+		FakeWindow.loadURLImplementation = async () => undefined;
+		await controller.prepareMiniWindow();
+		expect(FakeWindow.instances).toHaveLength(2);
+	});
+
 	it('creates isolated main, mini, and settings windows with their established presentation', async () => {
 		const { controller } = createController();
 		await controller.createMainWindow();
@@ -128,7 +190,12 @@ describe('window lifecycle factory', () => {
 			}
 		});
 		expect(main.loadURL).toHaveBeenCalledWith('app://bundle/');
-		expect(mini.options).toMatchObject({ type: 'panel', fullscreenable: false, width: 480, height: 668 });
+		expect(mini.options).toMatchObject({
+			type: 'panel',
+			fullscreenable: false,
+			width: 480,
+			height: 668
+		});
 		expect(mini.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
 			visibleOnFullScreen: true,
 			skipTransformProcessType: true

--- a/cometline/electron/src/domains/windows.ts
+++ b/cometline/electron/src/domains/windows.ts
@@ -14,7 +14,11 @@ import type os from 'node:os';
 import type path from 'node:path';
 
 import { APP_ORIGIN } from './app-protocol.js';
-import { mainWindowMinWidthForWorkArea, miniWindowOriginForWorkArea, miniWindowSizeForWorkArea } from './window-bounds.js';
+import {
+	mainWindowMinWidthForWorkArea,
+	miniWindowOriginForWorkArea,
+	miniWindowSizeForWorkArea
+} from './window-bounds.js';
 import { isExternallyOpenableUrl } from './workspace-preview.js';
 
 const MACOS_LOGIN_ITEMS_SETTINGS_URL =
@@ -103,6 +107,7 @@ export function createWindows(dependencies: WindowsDependencies) {
 	} = dependencies;
 	let mainWindow: BrowserWindow | null = null;
 	let miniWindow: BrowserWindow | null = null;
+	let miniWindowReady: Promise<BrowserWindow> | null = null;
 	let settingsWindow: BrowserWindow | null = null;
 	let ignoreActivateUntil = 0;
 
@@ -150,7 +155,11 @@ export function createWindows(dependencies: WindowsDependencies) {
 			display.workArea.height,
 			MINI_WINDOW_SCREEN_MARGIN
 		);
-		const origin = miniWindowOriginForWorkArea(display.workArea, size, MINI_WINDOW_SCREEN_MARGIN);
+		const origin = miniWindowOriginForWorkArea(
+			display.workArea,
+			size,
+			MINI_WINDOW_SCREEN_MARGIN
+		);
 		window.setBounds({ ...origin, ...size }, false);
 	}
 
@@ -303,13 +312,6 @@ export function createWindows(dependencies: WindowsDependencies) {
 		attachExternalNavigationGuards(window);
 		shortcuts.attachMiniWindowShortcuts(window.webContents);
 		layoutMiniWindowOnCursorDisplay();
-		await loadAppRoute(window, '/mini');
-		window.once('ready-to-show', () => {
-			layoutMiniWindowOnCursorDisplay();
-			applyMiniWindowPresentation();
-			miniWindow?.show();
-			miniWindow?.focus();
-		});
 		window.on('hide', () => {
 			writeMiniWindowState({ lastActiveAt: Date.now() });
 		});
@@ -322,7 +324,23 @@ export function createWindows(dependencies: WindowsDependencies) {
 		window.on('closed', () => {
 			if (miniWindow === window) miniWindow = null;
 		});
-		return window;
+		try {
+			await loadAppRoute(window, '/mini?prewarm=1');
+			return window;
+		} catch (error) {
+			if (miniWindow === window) miniWindow = null;
+			window.destroy();
+			throw error;
+		}
+	}
+
+	async function prepareMiniWindow() {
+		if (miniWindowReady) return miniWindowReady;
+		if (windowCanShow(miniWindow)) return miniWindow;
+		miniWindowReady = createMiniWindow().finally(() => {
+			miniWindowReady = null;
+		});
+		return miniWindowReady;
 	}
 
 	async function createSettingsWindow() {
@@ -381,15 +399,13 @@ export function createWindows(dependencies: WindowsDependencies) {
 	}
 
 	async function showMiniWindow() {
-		const window = miniWindow;
-		if (!windowCanShow(window)) {
-			await createMiniWindow();
-			return;
-		}
+		const window = await prepareMiniWindow();
+		if (!windowCanShow(window)) return;
 		if (window.isMinimized()) window.restore();
 		layoutMiniWindowOnCursorDisplay();
 		applyMiniWindowPresentation();
 		window.show();
+		window.webContents.send('cometline:activate-mini-window');
 		window.focus();
 	}
 
@@ -541,6 +557,7 @@ export function createWindows(dependencies: WindowsDependencies) {
 		hideMiniWindow,
 		hideSettingsWindow,
 		openSessionInMainWindow,
+		prepareMiniWindow,
 		readLoginItemState,
 		showMainWindow,
 		showSettingsWindow,

--- a/cometline/electron/src/domains/windows.ts
+++ b/cometline/electron/src/domains/windows.ts
@@ -77,7 +77,7 @@ interface WindowsDependencies {
 	shouldKeepWindowsAlive(): boolean;
 	shortcuts: Shortcuts;
 	windowChrome: WindowChrome;
-	writeMiniWindowState(state: { lastActiveAt: number }): unknown;
+	touchMiniWindowActivity(): void;
 }
 
 function windowCanShow(window: BrowserWindow | null): window is BrowserWindow {
@@ -103,13 +103,14 @@ export function createWindows(dependencies: WindowsDependencies) {
 		shouldKeepWindowsAlive,
 		shortcuts,
 		windowChrome,
-		writeMiniWindowState
+		touchMiniWindowActivity
 	} = dependencies;
 	let mainWindow: BrowserWindow | null = null;
 	let miniWindow: BrowserWindow | null = null;
 	let miniWindowReady: Promise<BrowserWindow> | null = null;
 	let settingsWindow: BrowserWindow | null = null;
 	let ignoreActivateUntil = 0;
+	let miniNeedsActivation = true;
 
 	function loadAppRoute(window: BrowserWindow, route = '/') {
 		const requestedRoute = String(route || '/');
@@ -160,7 +161,17 @@ export function createWindows(dependencies: WindowsDependencies) {
 			size,
 			MINI_WINDOW_SCREEN_MARGIN
 		);
-		window.setBounds({ ...origin, ...size }, false);
+		const next = { ...origin, ...size };
+		const current = window.getBounds();
+		if (
+			current.x === next.x &&
+			current.y === next.y &&
+			current.width === next.width &&
+			current.height === next.height
+		) {
+			return;
+		}
+		window.setBounds(next, false);
 	}
 
 	function suppressSpuriousActivate() {
@@ -205,7 +216,7 @@ export function createWindows(dependencies: WindowsDependencies) {
 	function hideMiniWindow() {
 		const window = miniWindow;
 		if (!windowCanShow(window)) return;
-		writeMiniWindowState({ lastActiveAt: Date.now() });
+		touchMiniWindowActivity();
 		suppressSpuriousActivate();
 		window.hide();
 	}
@@ -304,17 +315,19 @@ export function createWindows(dependencies: WindowsDependencies) {
 				sandbox: true,
 				allowRunningInsecureContent: false,
 				webviewTag: true,
+				// Keep the hidden prewarmed renderer warm so shortcut toggles
+				// do not pay Chromium's background-throttle wake-up hitch.
+				backgroundThrottling: false,
+				paintWhenInitiallyHidden: true,
 				devTools: !app.isPackaged
 			}
 		});
 		miniWindow = window;
+		miniNeedsActivation = true;
 		applyMiniWindowPresentation(window);
 		attachExternalNavigationGuards(window);
 		shortcuts.attachMiniWindowShortcuts(window.webContents);
 		layoutMiniWindowOnCursorDisplay();
-		window.on('hide', () => {
-			writeMiniWindowState({ lastActiveAt: Date.now() });
-		});
 		window.on('close', (event) => {
 			if (shouldKeepWindowsAlive()) {
 				event.preventDefault();
@@ -322,7 +335,10 @@ export function createWindows(dependencies: WindowsDependencies) {
 			}
 		});
 		window.on('closed', () => {
-			if (miniWindow === window) miniWindow = null;
+			if (miniWindow === window) {
+				miniWindow = null;
+				miniNeedsActivation = true;
+			}
 		});
 		try {
 			await loadAppRoute(window, '/mini?prewarm=1');
@@ -398,15 +414,28 @@ export function createWindows(dependencies: WindowsDependencies) {
 		getTray()?.setToolTip('Cometline');
 	}
 
-	async function showMiniWindow() {
-		const window = await prepareMiniWindow();
-		if (!windowCanShow(window)) return;
+	function revealMiniWindow(window: BrowserWindow) {
 		if (window.isMinimized()) window.restore();
 		layoutMiniWindowOnCursorDisplay();
-		applyMiniWindowPresentation();
-		window.show();
-		window.webContents.send('cometline:activate-mini-window');
+		// showInactive avoids the app-activation hitch that window.show()
+		// pays on macOS; focus() then puts keystrokes in the composer.
+		if (typeof window.showInactive === 'function') window.showInactive();
+		else window.show();
+		if (miniNeedsActivation) {
+			window.webContents.send('cometline:activate-mini-window');
+			miniNeedsActivation = false;
+		}
 		window.focus();
+	}
+
+	async function showMiniWindow() {
+		if (windowCanShow(miniWindow)) {
+			revealMiniWindow(miniWindow);
+			return;
+		}
+		const window = await prepareMiniWindow();
+		if (!windowCanShow(window)) return;
+		revealMiniWindow(window);
 	}
 
 	async function showSettingsWindow() {
@@ -463,15 +492,12 @@ export function createWindows(dependencies: WindowsDependencies) {
 
 	async function toggleMiniWindow() {
 		const window = miniWindow;
-		if (!windowCanShow(window) || !window.isVisible()) {
-			await showMiniWindow();
+		if (windowCanShow(window) && window.isVisible()) {
+			if (window.isFocused()) hideMiniWindow();
+			else window.focus();
 			return;
 		}
-		if (window.isFocused()) {
-			hideMiniWindow();
-			return;
-		}
-		window.focus();
+		await showMiniWindow();
 	}
 
 	function isMacOS13OrLater() {

--- a/cometline/electron/src/preload.ts
+++ b/cometline/electron/src/preload.ts
@@ -69,6 +69,8 @@ const electronAPI: ElectronAPI = {
 	openSettingsWindow: () => ipcRenderer.invoke('cometline:open-settings-window'),
 	replayIntroInMainWindow: () => ipcRenderer.invoke('cometline:replay-intro'),
 	runSetupWizardInMainWindow: () => ipcRenderer.invoke('cometline:run-setup-wizard'),
+	onMiniWindowActivated: (callback) =>
+		subscribeSignal('cometline:activate-mini-window', callback),
 	getMiniWindowState: () => ipcRenderer.invoke('cometline:get-mini-window-state'),
 	saveMiniWindowState: (state) => ipcRenderer.invoke('cometline:save-mini-window-state', state),
 	fetchProviderModels: (config) => ipcRenderer.invoke('cometline:fetch-provider-models', config),

--- a/cometline/electron/src/shared/api.ts
+++ b/cometline/electron/src/shared/api.ts
@@ -114,6 +114,7 @@ export interface ElectronAPI {
 	onPersonaAvatarChanged(callback: (personaId: string) => void): () => void;
 	onReplayIntro(callback: () => void): () => void;
 	onRunSetupWizard(callback: () => void): () => void;
+	onMiniWindowActivated(callback: () => void): () => void;
 	getMiniWindowState(): Promise<MiniWindowState>;
 	saveMiniWindowState(state: {
 		sessionId?: string;

--- a/cometline/src/lib/components/MiniShell.svelte
+++ b/cometline/src/lib/components/MiniShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { tick } from 'svelte';
+	import { onMount, tick } from 'svelte';
+	import { page } from '$app/state';
 	import { cubicOut } from 'svelte/easing';
 	import { fly, fade } from 'svelte/transition';
 	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
@@ -14,6 +15,17 @@
 	let { children } = $props();
 	let creatingSession = $state(false);
 	let sidebarRef = $state<{ focusSearch: () => void } | null>(null);
+
+	onMount(() => {
+		const revealOverlayIfStillBooting = () => {
+			if (document.visibilityState !== 'visible') return;
+			if (page.url.pathname === '/mini' || page.url.pathname === '/mini/') {
+				miniShellStore.ensureOpening();
+			}
+		};
+		document.addEventListener('visibilitychange', revealOverlayIfStillBooting);
+		return () => document.removeEventListener('visibilitychange', revealOverlayIfStillBooting);
+	});
 
 	async function createSession() {
 		if (creatingSession) return;

--- a/cometline/src/lib/components/MiniShell.svelte
+++ b/cometline/src/lib/components/MiniShell.svelte
@@ -2,6 +2,7 @@
 	import { tick } from 'svelte';
 	import { cubicOut } from 'svelte/easing';
 	import { fly, fade } from 'svelte/transition';
+	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
 	import { matchesShortcut } from '$lib/keyboard-shortcuts';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 	import { settingsStore } from '$lib/stores/settings.svelte';
@@ -74,10 +75,29 @@
 
 <div class="mini-shell">
 	{@render children()}
+	{#if miniShellStore.opening}
+		<div class="mini-loading-overlay" transition:fade={{ duration: 160 }}>
+			<ThinkingIndicator size={28} label="Opening mini chat" />
+		</div>
+	{/if}
 	{#if miniShellStore.sidebarOpen}
-		<button class="mini-sidebar-backdrop" type="button" aria-label="Close chats" onclick={() => miniShellStore.closeSidebar()} transition:fade={{ duration: 180, easing: cubicOut }}></button>
-		<div class="mini-sidebar-drawer" transition:fly={{ x: -260, opacity: 0, duration: 220, easing: cubicOut }}>
-			<MiniSessionSidebar bind:this={sidebarRef} onClose={() => miniShellStore.closeSidebar()} onSelectSession={selectSession} onNewChat={() => void createSession()} />
+		<button
+			class="mini-sidebar-backdrop"
+			type="button"
+			aria-label="Close chats"
+			onclick={() => miniShellStore.closeSidebar()}
+			transition:fade={{ duration: 180, easing: cubicOut }}
+		></button>
+		<div
+			class="mini-sidebar-drawer"
+			transition:fly={{ x: -260, opacity: 0, duration: 220, easing: cubicOut }}
+		>
+			<MiniSessionSidebar
+				bind:this={sidebarRef}
+				onClose={() => miniShellStore.closeSidebar()}
+				onSelectSession={selectSession}
+				onNewChat={() => void createSession()}
+			/>
 		</div>
 	{/if}
 </div>
@@ -88,6 +108,19 @@
 		width: 100vw;
 		height: 100vh;
 		overflow: hidden;
+	}
+
+	.mini-loading-overlay {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		z-index: 90;
+		background: color-mix(in srgb, var(--app-bg) 38%, transparent);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		-webkit-app-region: no-drag;
 	}
 
 	.mini-sidebar-backdrop {

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -15,7 +15,11 @@ const mocks = vi.hoisted(() => ({
 	requestNewSession: vi.fn(),
 	clearNewSessionRequest: vi.fn(),
 	startOpening: vi.fn(),
-	resetOpening: vi.fn()
+	resetOpening: vi.fn(),
+	sessionState: {
+		sessions: [] as Session[],
+		loaded: false
+	}
 }));
 
 vi.mock('$app/navigation', () => ({ goto: mocks.goto }));
@@ -32,8 +36,12 @@ vi.mock('$lib/stores/session.svelte', () => ({
 		selectSession: mocks.selectSession,
 		upsertSession: vi.fn(),
 		appendSession: vi.fn(),
-		sessions: [] as Session[],
-		loaded: false
+		get sessions() {
+			return mocks.sessionState.sessions;
+		},
+		get loaded() {
+			return mocks.sessionState.loaded;
+		}
 	}
 }));
 vi.mock('$lib/stores/settings.svelte', () => ({ settingsStore: { load: vi.fn() } }));
@@ -58,7 +66,6 @@ vi.mock('$lib/stores/mini-shell.svelte', () => ({
 	}
 }));
 
-import { sessionStore } from '$lib/stores/session.svelte';
 import {
 	activateMiniWindow,
 	createMiniWindowSession,
@@ -85,8 +92,8 @@ const session: Session = {
 describe('mini window sessions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		sessionStore.loaded = false;
-		sessionStore.sessions = [];
+		mocks.sessionState.loaded = false;
+		mocks.sessionState.sessions = [];
 		mocks.createNewSession.mockResolvedValue(session);
 		mocks.listAllSessions.mockResolvedValue({ sessions: [session] });
 		vi.stubGlobal('window', {
@@ -158,8 +165,8 @@ describe('mini window sessions', () => {
 	});
 
 	it('reuses a loaded session without listing from the API', async () => {
-		sessionStore.loaded = true;
-		sessionStore.sessions = [session];
+		mocks.sessionState.loaded = true;
+		mocks.sessionState.sessions = [session];
 		vi.stubGlobal('window', {
 			electronAPI: {
 				getMiniWindowState: vi.fn().mockResolvedValue({

--- a/cometline/src/lib/mini-window-session.test.ts
+++ b/cometline/src/lib/mini-window-session.test.ts
@@ -13,7 +13,9 @@ const mocks = vi.hoisted(() => ({
 	requestComposerFocus: vi.fn(),
 	recordVisit: vi.fn(),
 	requestNewSession: vi.fn(),
-	clearNewSessionRequest: vi.fn()
+	clearNewSessionRequest: vi.fn(),
+	startOpening: vi.fn(),
+	resetOpening: vi.fn()
 }));
 
 vi.mock('$app/navigation', () => ({ goto: mocks.goto }));
@@ -26,7 +28,13 @@ vi.mock('$lib/stores/model.svelte', () => ({
 	modelStore: { options: [], selected: null, selectDefault: vi.fn(), selectFromSession: mocks.selectFromSession }
 }));
 vi.mock('$lib/stores/session.svelte', () => ({
-	sessionStore: { selectSession: mocks.selectSession, upsertSession: vi.fn(), appendSession: vi.fn() }
+	sessionStore: {
+		selectSession: mocks.selectSession,
+		upsertSession: vi.fn(),
+		appendSession: vi.fn(),
+		sessions: [] as Session[],
+		loaded: false
+	}
 }));
 vi.mock('$lib/stores/settings.svelte', () => ({ settingsStore: { load: vi.fn() } }));
 vi.mock('$lib/stores/shell.svelte', () => ({
@@ -44,11 +52,15 @@ vi.mock('$lib/stores/session-visit-history.svelte', () => ({
 vi.mock('$lib/stores/mini-shell.svelte', () => ({
 	miniShellStore: {
 		requestNewSession: mocks.requestNewSession,
-		clearNewSessionRequest: mocks.clearNewSessionRequest
+		clearNewSessionRequest: mocks.clearNewSessionRequest,
+		startOpening: mocks.startOpening,
+		resetOpening: mocks.resetOpening
 	}
 }));
 
+import { sessionStore } from '$lib/stores/session.svelte';
 import {
+	activateMiniWindow,
 	createMiniWindowSession,
 	ensureMiniWindowSession,
 	navigateMiniToSession
@@ -73,6 +85,8 @@ const session: Session = {
 describe('mini window sessions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		sessionStore.loaded = false;
+		sessionStore.sessions = [];
 		mocks.createNewSession.mockResolvedValue(session);
 		mocks.listAllSessions.mockResolvedValue({ sessions: [session] });
 		vi.stubGlobal('window', {
@@ -101,6 +115,10 @@ describe('mini window sessions', () => {
 	it('creates a default-model session and opens it in the mini route', async () => {
 		await expect(createMiniWindowSession()).resolves.toEqual(session);
 
+		expect(mocks.startOpening).toHaveBeenCalledOnce();
+		expect(mocks.startOpening.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.createNewSession.mock.invocationCallOrder[0]
+		);
 		expect(mocks.createNewSession).toHaveBeenCalledOnce();
 		expect(window.electronAPI?.saveMiniWindowState).toHaveBeenCalledWith({
 			sessionId: 'mini-session'
@@ -119,6 +137,7 @@ describe('mini window sessions', () => {
 		await expect(createMiniWindowSession()).rejects.toThrow('navigation failed');
 
 		expect(mocks.clearNewSessionRequest).toHaveBeenCalledWith('mini-session');
+		expect(mocks.resetOpening).toHaveBeenCalledOnce();
 	});
 
 	it('reuses a preferred session from another workspace', async () => {
@@ -136,5 +155,56 @@ describe('mini window sessions', () => {
 		);
 
 		expect(mocks.createNewSession).not.toHaveBeenCalled();
+	});
+
+	it('reuses a loaded session without listing from the API', async () => {
+		sessionStore.loaded = true;
+		sessionStore.sessions = [session];
+		vi.stubGlobal('window', {
+			electronAPI: {
+				getMiniWindowState: vi.fn().mockResolvedValue({
+					sessionId: 'mini-session',
+					lastActiveAt: Date.now(),
+					inactivityTimeoutMinutes: 30
+				}),
+				saveMiniWindowState: vi.fn().mockResolvedValue(undefined)
+			}
+		});
+
+		await expect(ensureMiniWindowSession()).resolves.toBe('mini-session');
+		expect(mocks.listAllSessions).not.toHaveBeenCalled();
+	});
+
+	it('shares one in-flight activation across repeated shortcut shows', async () => {
+		let resolveList: ((value: { sessions: Session[] }) => void) | undefined;
+		mocks.listAllSessions.mockReturnValue(
+			new Promise<{ sessions: Session[] }>((resolve) => {
+				resolveList = resolve;
+			})
+		);
+		vi.stubGlobal('window', {
+			electronAPI: {
+				getMiniWindowState: vi.fn().mockResolvedValue({
+					sessionId: 'mini-session',
+					lastActiveAt: Date.now(),
+					inactivityTimeoutMinutes: 30
+				}),
+				getWorkspacePath: vi.fn().mockResolvedValue('/'),
+				saveMiniWindowState: vi.fn().mockResolvedValue(undefined)
+			}
+		});
+
+		const first = activateMiniWindow();
+		const second = activateMiniWindow();
+		resolveList?.({ sessions: [session] });
+
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			'mini-session',
+			'mini-session'
+		]);
+		expect(mocks.goto).toHaveBeenCalledOnce();
+		expect(mocks.goto).toHaveBeenCalledWith('/mini/session/mini-session', {
+			replaceState: true
+		});
 	});
 });

--- a/cometline/src/lib/mini-window-session.ts
+++ b/cometline/src/lib/mini-window-session.ts
@@ -43,6 +43,15 @@ export async function ensureMiniWindowSession(preferredSessionId = '') {
 	const workspacePath = (await window.electronAPI?.getWorkspacePath?.()) ?? '/';
 
 	if (sessionId && shouldReuseSession) {
+		const cached = sessionStore.loaded
+			? sessionStore.sessions.find((item) => item.id === sessionId)
+			: undefined;
+		if (cached) {
+			if (cached.id !== state.sessionId) {
+				await window.electronAPI?.saveMiniWindowState?.({ sessionId: cached.id });
+			}
+			return cached.id;
+		}
 		// Mini sessions may be pinned or belong to another workspace. The route ID
 		// is authoritative, so do not filter it through Electron's default workspace.
 		const sessions = await listAllSessions();
@@ -70,6 +79,31 @@ export async function ensureMiniWindowSession(preferredSessionId = '') {
 	return session.id;
 }
 
+let activateInFlight: Promise<string> | null = null;
+
+/** Resolve and open the mini session once; later shortcut shows reuse this work. */
+function documentIsVisible() {
+	return typeof document !== 'undefined' && document.visibilityState === 'visible';
+}
+
+export async function activateMiniWindow() {
+	if (activateInFlight) return activateInFlight;
+	if (documentIsVisible()) miniShellStore.startOpening();
+	activateInFlight = (async () => {
+		try {
+			const sessionId = await ensureMiniWindowSession();
+			await goto(`/mini/session/${sessionId}`, { replaceState: true });
+			return sessionId;
+		} catch (error) {
+			miniShellStore.resetOpening();
+			throw error;
+		} finally {
+			activateInFlight = null;
+		}
+	})();
+	return activateInFlight;
+}
+
 /** Select a session without leaving the mini-window route namespace. */
 export async function navigateMiniToSession(session: Session) {
 	sessionStore.selectSession(session);
@@ -90,6 +124,7 @@ export async function navigateMiniToSession(session: Session) {
 /** Create and open a persisted mini-window session using the configured default model. */
 export async function createMiniWindowSession() {
 	let createdSessionId = '';
+	miniShellStore.startOpening();
 	try {
 		const session = await createNewSession();
 		createdSessionId = session.id;
@@ -100,6 +135,7 @@ export async function createMiniWindowSession() {
 		return session;
 	} catch (error) {
 		miniShellStore.clearNewSessionRequest(createdSessionId);
+		miniShellStore.resetOpening();
 		throw error;
 	}
 }

--- a/cometline/src/lib/stores/mini-shell.svelte.test.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.test.ts
@@ -1,8 +1,57 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { miniShellStore } from './mini-shell.svelte';
+
+describe('mini shell opening transition', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		miniShellStore.resetOpening();
+	});
+
+	it('keeps the initial overlay visible until the opening has lasted 320ms', async () => {
+		const opening = miniShellStore.startOpening();
+		const finishing = miniShellStore.finishOpening(opening);
+
+		expect(miniShellStore.opening).toBe(true);
+		await vi.advanceTimersByTimeAsync(319);
+		expect(miniShellStore.opening).toBe(true);
+		await vi.advanceTimersByTimeAsync(1);
+		await finishing;
+		expect(miniShellStore.opening).toBe(false);
+	});
+
+	it('starts the minimum visible time when a prepared window is activated', async () => {
+		miniShellStore.prepareOpening();
+		await vi.advanceTimersByTimeAsync(5000);
+
+		const opening = miniShellStore.startOpening();
+		const finishing = miniShellStore.finishOpening(opening);
+		await vi.advanceTimersByTimeAsync(319);
+		expect(miniShellStore.opening).toBe(true);
+		await vi.advanceTimersByTimeAsync(1);
+		await finishing;
+		expect(miniShellStore.opening).toBe(false);
+	});
+
+	it('does not let a stale opening completion hide a newer overlay', async () => {
+		const first = miniShellStore.startOpening();
+		miniShellStore.resetOpening();
+		const second = miniShellStore.startOpening();
+		const finishing = miniShellStore.finishOpening(first);
+
+		await vi.runAllTimersAsync();
+		await finishing;
+		expect(miniShellStore.opening).toBe(true);
+
+		const secondFinishing = miniShellStore.finishOpening(second);
+		await vi.runAllTimersAsync();
+		await secondFinishing;
+		expect(miniShellStore.opening).toBe(false);
+	});
+});
 
 describe('mini shell new-session requests', () => {
 	beforeEach(() => {
+		vi.useRealTimers();
 		miniShellStore.clearNewSessionRequest();
 	});
 

--- a/cometline/src/lib/stores/mini-shell.svelte.test.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.test.ts
@@ -7,7 +7,7 @@ describe('mini shell opening transition', () => {
 		miniShellStore.resetOpening();
 	});
 
-	it('keeps the initial overlay visible until the opening has lasted 320ms', async () => {
+	it('keeps a visible overlay until the opening has lasted 320ms', async () => {
 		const opening = miniShellStore.startOpening();
 		const finishing = miniShellStore.finishOpening(opening);
 
@@ -19,17 +19,17 @@ describe('mini shell opening transition', () => {
 		expect(miniShellStore.opening).toBe(false);
 	});
 
-	it('starts the minimum visible time when a prepared window is activated', async () => {
-		miniShellStore.prepareOpening();
-		await vi.advanceTimersByTimeAsync(5000);
-
-		const opening = miniShellStore.startOpening();
-		const finishing = miniShellStore.finishOpening(opening);
-		await vi.advanceTimersByTimeAsync(319);
-		expect(miniShellStore.opening).toBe(true);
-		await vi.advanceTimersByTimeAsync(1);
-		await finishing;
-		expect(miniShellStore.opening).toBe(false);
+	it('does not delay finish when the overlay was never shown', async () => {
+		vi.stubGlobal('document', { visibilityState: 'hidden' });
+		try {
+			const opening = miniShellStore.startOpening();
+			expect(miniShellStore.opening).toBe(false);
+			const finishing = miniShellStore.finishOpening(opening);
+			await finishing;
+			expect(miniShellStore.opening).toBe(false);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 
 	it('does not let a stale opening completion hide a newer overlay', async () => {

--- a/cometline/src/lib/stores/mini-shell.svelte.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.ts
@@ -1,10 +1,53 @@
+const MINI_OPENING_MIN_VISIBLE_MS = 320;
+
 function createMiniShellStore() {
 	let sidebarOpen = $state(false);
+	let opening = $state(false);
+	let openingRun = 0;
+	let openingStartedAt: number | null = null;
 	let requestedNewSessionId = '';
+
+	function startOpening() {
+		openingRun += 1;
+		openingStartedAt = performance.now();
+		opening = true;
+		return openingRun;
+	}
 
 	return {
 		get sidebarOpen() {
 			return sidebarOpen;
+		},
+		get opening() {
+			return opening;
+		},
+		get openingRun() {
+			return openingRun;
+		},
+		prepareOpening() {
+			opening = true;
+			openingStartedAt = null;
+		},
+		startOpening,
+		ensureOpening() {
+			if (opening && openingStartedAt !== null) return openingRun;
+			return startOpening();
+		},
+		async finishOpening(run: number) {
+			if (!run || run !== openingRun || openingStartedAt === null) return;
+			const remaining = Math.max(
+				0,
+				MINI_OPENING_MIN_VISIBLE_MS - (performance.now() - openingStartedAt)
+			);
+			if (remaining > 0) {
+				await new Promise((resolve) => setTimeout(resolve, remaining));
+			}
+			if (run === openingRun) opening = false;
+		},
+		resetOpening() {
+			openingRun += 1;
+			openingStartedAt = null;
+			opening = false;
 		},
 		toggleSidebar() {
 			sidebarOpen = !sidebarOpen;

--- a/cometline/src/lib/stores/mini-shell.svelte.ts
+++ b/cometline/src/lib/stores/mini-shell.svelte.ts
@@ -1,5 +1,9 @@
 const MINI_OPENING_MIN_VISIBLE_MS = 320;
 
+function documentIsVisible() {
+	return typeof document === 'undefined' || document.visibilityState === 'visible';
+}
+
 function createMiniShellStore() {
 	let sidebarOpen = $state(false);
 	let opening = $state(false);
@@ -9,8 +13,13 @@ function createMiniShellStore() {
 
 	function startOpening() {
 		openingRun += 1;
-		openingStartedAt = performance.now();
-		opening = true;
+		if (documentIsVisible()) {
+			openingStartedAt = performance.now();
+			opening = true;
+		} else {
+			openingStartedAt = null;
+			opening = false;
+		}
 		return openingRun;
 	}
 
@@ -23,10 +32,6 @@ function createMiniShellStore() {
 		},
 		get openingRun() {
 			return openingRun;
-		},
-		prepareOpening() {
-			opening = true;
-			openingStartedAt = null;
 		},
 		startOpening,
 		ensureOpening() {

--- a/cometline/src/routes/mini/+page.svelte
+++ b/cometline/src/routes/mini/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 
@@ -18,7 +19,15 @@
 	}
 
 	onMount(() => {
-		void openMiniWindow();
+		if (page.url.searchParams.get('prewarm') !== '1') {
+			void openMiniWindow();
+			return;
+		}
+
+		miniShellStore.prepareOpening();
+		return window.electronAPI?.onMiniWindowActivated?.(() => {
+			void openMiniWindow();
+		});
 	});
 </script>
 

--- a/cometline/src/routes/mini/+page.svelte
+++ b/cometline/src/routes/mini/+page.svelte
@@ -1,30 +1,19 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import { onMount } from 'svelte';
-	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 
 	let error = $state('');
 
 	async function openMiniWindow() {
-		miniShellStore.startOpening();
 		try {
-			const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
-			const sessionId = await ensureMiniWindowSession();
-			await goto(`/mini/session/${sessionId}`, { replaceState: true });
+			const { activateMiniWindow } = await import('$lib/mini-window-session');
+			await activateMiniWindow();
 		} catch (err) {
-			miniShellStore.resetOpening();
 			error = err instanceof Error ? err.message : 'Failed to open mini chat';
 		}
 	}
 
 	onMount(() => {
-		if (page.url.searchParams.get('prewarm') !== '1') {
-			void openMiniWindow();
-			return;
-		}
-
-		miniShellStore.prepareOpening();
+		void openMiniWindow();
 		return window.electronAPI?.onMiniWindowActivated?.(() => {
 			void openMiniWindow();
 		});

--- a/cometline/src/routes/mini/+page.svelte
+++ b/cometline/src/routes/mini/+page.svelte
@@ -1,52 +1,32 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import { fade } from 'svelte/transition';
-	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
-
-	const MIN_LOADING_MS = 320;
-	const LOADING_FADE_MS = 160;
+	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 
 	let error = $state('');
 
+	async function openMiniWindow() {
+		miniShellStore.startOpening();
+		try {
+			const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
+			const sessionId = await ensureMiniWindowSession();
+			await goto(`/mini/session/${sessionId}`, { replaceState: true });
+		} catch (err) {
+			miniShellStore.resetOpening();
+			error = err instanceof Error ? err.message : 'Failed to open mini chat';
+		}
+	}
+
 	onMount(() => {
-		const startedAt = performance.now();
-		void (async () => {
-			try {
-				const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
-				const sessionId = await ensureMiniWindowSession();
-				const remaining = Math.max(0, MIN_LOADING_MS - (performance.now() - startedAt));
-				if (remaining > 0) await new Promise((resolve) => setTimeout(resolve, remaining));
-				await goto(`/mini/session/${sessionId}`, { replaceState: true });
-			} catch (err) {
-				error = err instanceof Error ? err.message : 'Failed to open mini chat';
-			}
-		})();
+		void openMiniWindow();
 	});
 </script>
 
 {#if error}
 	<div class="mini-loading-error" role="alert">{error}</div>
-{:else}
-	<div class="mini-loading-overlay" transition:fade={{ duration: LOADING_FADE_MS }}>
-		<ThinkingIndicator size={28} label="Opening mini chat" />
-	</div>
 {/if}
 
 <style>
-	.mini-loading-overlay {
-		position: absolute;
-		inset: 0;
-		display: grid;
-		place-items: center;
-		padding: 24px;
-		z-index: 90;
-		background: color-mix(in srgb, var(--app-bg) 38%, transparent);
-		backdrop-filter: blur(10px);
-		-webkit-backdrop-filter: blur(10px);
-		-webkit-app-region: no-drag;
-	}
-
 	.mini-loading-error {
 		position: absolute;
 		inset: 0;

--- a/cometline/src/routes/mini/session/[id]/+page.svelte
+++ b/cometline/src/routes/mini/session/[id]/+page.svelte
@@ -3,20 +3,14 @@
 	import { page } from '$app/state';
 	import { untrack } from 'svelte';
 	import ChatView from '$lib/components/ChatView.svelte';
-	import ThinkingIndicator from '$lib/components/ThinkingIndicator.svelte';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
-
-	const MIN_LOADING_MS = 320;
 
 	let sessionId = $derived(page.params.id ?? '');
 	let resolvedSessionId = $state('');
 	let resolvingRun = 0;
-	let resolving = $state(true);
-	let showLoading = $state(true);
 	let error = $state('');
 
-	async function resolveSession(id: string, run: number) {
-		const startedAt = performance.now();
+	async function resolveSession(id: string, run: number, openingRun: number) {
 		try {
 			const { ensureMiniWindowSession } = await import('$lib/mini-window-session');
 			const ensuredSessionId = await ensureMiniWindowSession(id);
@@ -25,29 +19,27 @@
 				await goto(`/mini/session/${ensuredSessionId}`, { replaceState: true });
 				return;
 			}
-			const remaining = Math.max(0, MIN_LOADING_MS - (performance.now() - startedAt));
-			if (remaining > 0) await new Promise((resolve) => setTimeout(resolve, remaining));
-			if (run !== resolvingRun) return;
 			resolvedSessionId = ensuredSessionId;
 			error = '';
-			resolving = false;
+			void miniShellStore.finishOpening(openingRun);
 		} catch (err) {
 			if (run !== resolvingRun) return;
+			miniShellStore.resetOpening();
 			error = err instanceof Error ? err.message : 'Failed to open mini chat';
 			resolvedSessionId = '';
-			resolving = false;
 		}
 	}
 
 	$effect(() => {
 		if (!sessionId) return;
 		const existingSession = untrack(() => Boolean(resolvedSessionId));
-		showLoading = !existingSession || miniShellStore.consumeNewSessionRequest(sessionId);
+		const showLoading = !existingSession || miniShellStore.consumeNewSessionRequest(sessionId);
+		const openingRun =
+			showLoading || miniShellStore.opening ? miniShellStore.ensureOpening() : 0;
 		resolvedSessionId = sessionId;
 		error = '';
-		resolving = true;
 		const run = ++resolvingRun;
-		void resolveSession(sessionId, run);
+		void resolveSession(sessionId, run, openingRun);
 	});
 </script>
 
@@ -57,26 +49,7 @@
 	<div class="mini-session-error" role="alert">{error}</div>
 {/if}
 
-{#if showLoading && resolving && !error}
-	<div class="mini-loading-overlay">
-		<ThinkingIndicator size={28} label="Opening mini chat" />
-	</div>
-{/if}
-
 <style>
-	.mini-loading-overlay {
-		position: absolute;
-		inset: 0;
-		display: grid;
-		place-items: center;
-		padding: 24px;
-		z-index: 90;
-		background: color-mix(in srgb, var(--app-bg) 38%, transparent);
-		backdrop-filter: blur(10px);
-		-webkit-backdrop-filter: blur(10px);
-		-webkit-app-region: no-drag;
-	}
-
 	.mini-session-error {
 		position: absolute;
 		inset: 0;


### PR DESCRIPTION
## Background

The mini window still felt slow on first open, and Cmd+Shift+L lagged when opening and closing it. Show/hide was paying session resolve, settings writes, and a loading overlay that belonged only to New Session.

[9a9844d](https://github.com/Cometline/cometline/commit/9a9844d40b05e2c1a93fe1ff18ef67a65a13a2e0): Unifies the mini loading transition so opening state lives in one store instead of split route overlays.

[f012f0f](https://github.com/Cometline/cometline/commit/f012f0f693de84eccc4e7e1c14dc66a13e91e1a2): Prewarms a hidden mini BrowserWindow after the main window is up so the first shortcut does not create and load the renderer from scratch.

[1f99251](https://github.com/Cometline/cometline/commit/1f99251ccade208111ae58f7336238bd4ab9cbce): Warm toggles only show or hide the existing panel. Last-active time stays in memory until quit, so repeated shortcut presses do not rewrite settings.

[82bfea2](https://github.com/Cometline/cometline/commit/82bfea2dbd49f843ced5e67fea34b808ea994bd5): New chat still shows the opening indicator, holds it briefly, then fades it out. Hidden prewarm and warm shortcut shows stay instant.

[8a9ae88](https://github.com/Cometline/cometline/commit/8a9ae8879c64643dd829f13e8783d14d89d411ed): Tests mutate a hoisted session mock instead of assigning the store's read-only loaded and sessions getters, so svelte-check passes.