### PR TITLE
[main] fix: stop stale refresh from reverting agent mode

### DIFF
--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -33,6 +33,17 @@
 	import { getReasoningEffort, setReasoningEffort } from '$lib/stores/reasoning-effort.svelte';
 	import { updateSession } from '$lib/client/cometmind';
 	import type { AgentMode } from '$lib/types';
+	import { normalizeAgentMode } from '$lib/sessions/session-metadata';
+	import {
+		agentModeAnnouncement,
+		beginAgentModeRequest,
+		completeAgentModeRequest,
+		createInitialAgentModeState,
+		nextAgentMode,
+		sameAgentModeSwitchState,
+		bindAgentModeForSession,
+		type AgentModeSwitchState
+	} from '$lib/components/composer/agent-mode-switch';
 
 	let {
 		onSend,
@@ -75,13 +86,13 @@
 	let trackedSessionId = $state<string | null>(null);
 	let skippingEmptyStash = $state(false);
 	let lastNonEmptyDraft = $state('');
-	// Agent mode: sourced from the persisted session (source of truth). Auto is
-	// the default for every new session; Plan only appears after an explicit
-	// Tab/control action in this session's composer.
-	let agentMode = $state<AgentMode>('auto');
-	let agentModeKnown = $state(false);
-	let agentModePending = $state(false);
+	// Agent mode: persisted on the session, with a local switch machine so Tab
+	// can queue the latest request and stale store snapshots cannot snap back.
+	let agentModeState = $state<AgentModeSwitchState>(createInitialAgentModeState());
+	let boundAgentModeFromStore = $state(false);
 	let modeAnnouncement = $state('');
+	const agentMode = $derived(agentModeState.mode);
+	const agentModeKnown = $derived(agentModeState.known);
 	const heroPlaceholders = [
 		'Type something. Anything.',
 		'Ask a question.',
@@ -209,7 +220,8 @@
 	const canSubmit = $derived(inputController.canSubmit());
 	const contextWindowUsage = $derived.by(() => {
 		const items = sessionId && chatStore.sessionID === sessionId ? chatStore.items : [];
-		const budget = sessionId && chatStore.sessionID === sessionId ? chatStore.contextBudget : null;
+		const budget =
+			sessionId && chatStore.sessionID === sessionId ? chatStore.contextBudget : null;
 		const selected = modelStore.selected;
 		return resolveContextWindowUsage({
 			budget,
@@ -243,50 +255,70 @@
 			composerHistoryStore.stashUnsent(prev, { text: value, images });
 		}
 		trackedSessionId = nextSessionId;
+		boundAgentModeFromStore = false;
 		resetHistoryBrowse();
 		lastNonEmptyDraft = '';
 		applyComposerText('');
 	});
 
-	// Keep the composer mode in sync with the persisted session record. The
-	// backend session value is authoritative; no renderer-local preference map.
+	function applyAgentModeState(next: AgentModeSwitchState) {
+		if (sameAgentModeSwitchState(agentModeState, next)) return;
+		agentModeState = next;
+	}
+
+	// Bind persisted mode when entering a session, or when that session first
+	// appears in the store. Later store writes do not own the chip.
 	$effect(() => {
 		const id = sessionId;
-		if (!id) {
-			agentMode = 'auto';
-			agentModeKnown = false;
+		const session = id ? sessionStore.sessions.find((item) => item.id === id) : undefined;
+		if (id && !session) {
+			boundAgentModeFromStore = false;
 			return;
 		}
-		if (agentModePending) return;
-		const session = sessionStore.sessions.find((item) => item.id === id);
-		agentMode = session?.agent_mode === 'plan' ? 'plan' : 'auto';
-		agentModeKnown = true;
+		if (boundAgentModeFromStore) return;
+		applyAgentModeState(bindAgentModeForSession(session, id));
+		boundAgentModeFromStore = Boolean(id);
 	});
 
-	async function setAgentMode(next: AgentMode) {
-		if (agentModePending || next === agentMode) return;
-		const id = sessionId;
-		const previous = agentMode;
-		agentMode = next;
-		if (!id) {
-			modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
-			return;
-		}
-		agentModePending = true;
+	async function persistAgentMode(id: string, next: AgentMode) {
 		try {
 			const updated = await updateSession(id, { agent_mode: next });
-			sessionStore.upsertSession(updated);
-			modeAnnouncement = next === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
+			sessionStore.updateSession(updated);
+			if (sessionId !== id) return;
+			const settled = completeAgentModeRequest(agentModeState, next, {
+				ok: true,
+				mode: normalizeAgentMode(updated.agent_mode)
+			});
+			applyAgentModeState(settled.state);
+			modeAnnouncement = agentModeAnnouncement(agentModeState.mode);
+			if (settled.shouldPersist) {
+				void persistAgentMode(id, settled.shouldPersist);
+			}
 		} catch {
-			agentMode = previous;
+			if (sessionId !== id) return;
+			const settled = completeAgentModeRequest(agentModeState, next, { ok: false });
+			applyAgentModeState(settled.state);
+			if (settled.shouldPersist) {
+				modeAnnouncement = agentModeAnnouncement(agentModeState.mode);
+				void persistAgentMode(id, settled.shouldPersist);
+				return;
+			}
 			modeAnnouncement = 'Failed to change mode';
-		} finally {
-			agentModePending = false;
 		}
 	}
 
+	function setAgentMode(next: AgentMode) {
+		const started = beginAgentModeRequest(agentModeState, next);
+		if (started.state === agentModeState && !started.shouldPersist) return;
+		applyAgentModeState(started.state);
+		modeAnnouncement = agentModeAnnouncement(started.state.mode);
+		const id = sessionId;
+		if (!id || !started.shouldPersist) return;
+		void persistAgentMode(id, next);
+	}
+
 	function cycleAgentMode() {
-		void setAgentMode(agentMode === 'plan' ? 'auto' : 'plan');
+		setAgentMode(nextAgentMode(agentModeState.mode));
 	}
 
 	$effect(() => {
@@ -323,7 +355,6 @@
 		const action = slash.resolveSubmitAction(trimmed);
 		if (action.kind === 'handled') return;
 		if (!canSubmit || disabled || resolvingWebContext || !modelStore.selected) return;
-		if (agentModePending) return;
 		const filePaths = input?.getFilePaths() ?? [];
 		const contextsBeforeResolve = pendingWebContexts.length;
 		resolvingWebContext = contextsBeforeResolve > 0;
@@ -382,9 +413,7 @@
 		historyAppliedText = text;
 		const pending = composerHistoryStore.getPending(sessionId);
 		const recallImages =
-			pending?.text.trim() === text.trim() && pending.images?.length
-				? pending.images
-				: [];
+			pending?.text.trim() === text.trim() && pending.images?.length ? pending.images : [];
 		applyComposerText(text, recallImages);
 	}
 
@@ -575,9 +604,9 @@
 		reasoningEffort={currentReasoningEffort()}
 		reasoningEffortOptions={modelStore.selected?.reasoningEffortOptions ?? []}
 		onCycleReasoningEffort={cycleReasoningEffort}
-		agentMode={agentMode}
-		agentModeKnown={agentModeKnown}
-		onSwitchToAuto={() => void setAgentMode('auto')}
+		{agentMode}
+		{agentModeKnown}
+		onSwitchToAuto={() => setAgentMode('auto')}
 		onOpenChangeWorkspace={slash.openChangeWorkspace}
 		{onStop}
 		onSubmit={() => void submit()}

--- a/cometline/src/lib/components/composer/agent-mode-switch.test.ts
+++ b/cometline/src/lib/components/composer/agent-mode-switch.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from '$lib/types';
+import {
+	beginAgentModeRequest,
+	bindAgentModeForSession,
+	completeAgentModeRequest,
+	createInitialAgentModeState,
+	nextAgentMode
+} from './agent-mode-switch';
+
+function session(agent_mode: Session['agent_mode'], id = 'sess-1'): Session {
+	return {
+		id,
+		workspace_id: 'ws',
+		workspace_path: '/ws',
+		title: 'Chat',
+		model_id: 'm',
+		provider_id: 'p',
+		status: 'active',
+		origin: 'user',
+		token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+		pinned: false,
+		agent_mode,
+		created_at: 0,
+		updated_at: 1
+	};
+}
+
+describe('nextAgentMode', () => {
+	it('toggles plan and auto', () => {
+		expect(nextAgentMode('auto')).toBe('plan');
+		expect(nextAgentMode('plan')).toBe('auto');
+	});
+});
+
+describe('bindAgentModeForSession', () => {
+	it('resets when the composer has no session', () => {
+		expect(bindAgentModeForSession(session('plan'), '')).toEqual(createInitialAgentModeState());
+	});
+
+	it('copies the persisted mode when entering a session', () => {
+		expect(bindAgentModeForSession(session('plan'), 'sess-1')).toEqual({
+			sessionId: 'sess-1',
+			mode: 'plan',
+			known: true,
+			pending: false,
+			queued: null,
+			baseline: 'plan'
+		});
+	});
+});
+
+describe('beginAgentModeRequest', () => {
+	it('starts a persist when idle and the mode changed', () => {
+		const started = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan');
+		expect(started.shouldPersist).toBe(true);
+		expect(started.state).toEqual({
+			sessionId: 'sess-1',
+			mode: 'plan',
+			known: true,
+			pending: true,
+			queued: null,
+			baseline: 'auto'
+		});
+	});
+
+	it('queues the latest Tab while a PATCH is in flight', () => {
+		const inFlight = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan').state;
+		const queued = beginAgentModeRequest(inFlight, 'auto');
+		expect(queued.shouldPersist).toBe(false);
+		expect(queued.state.mode).toBe('auto');
+		expect(queued.state.queued).toBe('auto');
+		expect(queued.state.pending).toBe(true);
+	});
+
+	it('ignores a no-op when idle', () => {
+		const idle = bindAgentModeForSession(session('auto'), 'sess-1');
+		const started = beginAgentModeRequest(idle, 'auto');
+		expect(started.shouldPersist).toBe(false);
+		expect(started.state).toBe(idle);
+	});
+});
+
+describe('completeAgentModeRequest', () => {
+	it('settles on the persisted mode when nothing else was queued', () => {
+		const inFlight = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan').state;
+		const done = completeAgentModeRequest(inFlight, 'plan', { ok: true, mode: 'plan' });
+		expect(done.shouldPersist).toBeNull();
+		expect(done.state).toEqual({
+			sessionId: 'sess-1',
+			mode: 'plan',
+			known: true,
+			pending: false,
+			queued: null,
+			baseline: 'plan'
+		});
+	});
+
+	it('persists the queued opposite mode after the first PATCH returns', () => {
+		const inFlight = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan').state;
+		const queued = beginAgentModeRequest(inFlight, 'auto').state;
+		const done = completeAgentModeRequest(queued, 'plan', { ok: true, mode: 'plan' });
+		expect(done.shouldPersist).toBe('auto');
+		expect(done.state.pending).toBe(true);
+		expect(done.state.mode).toBe('auto');
+		expect(done.state.baseline).toBe('plan');
+	});
+
+	it('reverts to the last acked mode when the PATCH fails and nothing is queued', () => {
+		const inFlight = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan').state;
+		const done = completeAgentModeRequest(inFlight, 'plan', { ok: false });
+		expect(done.shouldPersist).toBeNull();
+		expect(done.state.mode).toBe('auto');
+		expect(done.state.pending).toBe(false);
+	});
+
+	it('still persists a later Tab when the in-flight PATCH fails', () => {
+		const inFlight = beginAgentModeRequest(createInitialAgentModeState('sess-1'), 'plan').state;
+		const queued = beginAgentModeRequest(inFlight, 'auto').state;
+		const done = completeAgentModeRequest(queued, 'plan', { ok: false });
+		expect(done.shouldPersist).toBe('auto');
+		expect(done.state.mode).toBe('auto');
+		expect(done.state.pending).toBe(true);
+	});
+});

--- a/cometline/src/lib/components/composer/agent-mode-switch.ts
+++ b/cometline/src/lib/components/composer/agent-mode-switch.ts
@@ -1,0 +1,139 @@
+import type { AgentMode, Session } from '$lib/types';
+import { normalizeAgentMode } from '$lib/sessions/session-metadata';
+
+export interface AgentModeSwitchState {
+	sessionId: string;
+	mode: AgentMode;
+	known: boolean;
+	pending: boolean;
+	queued: AgentMode | null;
+	baseline: AgentMode;
+}
+
+export function createInitialAgentModeState(sessionId = ''): AgentModeSwitchState {
+	return {
+		sessionId,
+		mode: 'auto',
+		known: false,
+		pending: false,
+		queued: null,
+		baseline: 'auto'
+	};
+}
+
+export function nextAgentMode(current: AgentMode): AgentMode {
+	return current === 'plan' ? 'auto' : 'plan';
+}
+
+export function sameAgentModeSwitchState(
+	left: AgentModeSwitchState,
+	right: AgentModeSwitchState
+): boolean {
+	return (
+		left.sessionId === right.sessionId &&
+		left.mode === right.mode &&
+		left.known === right.known &&
+		left.pending === right.pending &&
+		left.queued === right.queued &&
+		left.baseline === right.baseline
+	);
+}
+
+/** Bind persisted mode only when the composer enters a session. */
+export function bindAgentModeForSession(
+	session: Session | undefined,
+	sessionId: string
+): AgentModeSwitchState {
+	if (!sessionId) return createInitialAgentModeState();
+	const mode = normalizeAgentMode(session?.agent_mode);
+	return {
+		sessionId,
+		mode,
+		known: true,
+		pending: false,
+		queued: null,
+		baseline: mode
+	};
+}
+
+export function beginAgentModeRequest(
+	state: AgentModeSwitchState,
+	next: AgentMode
+): { state: AgentModeSwitchState; shouldPersist: boolean } {
+	if (state.pending) {
+		return {
+			state: { ...state, mode: next, queued: next, known: true },
+			shouldPersist: false
+		};
+	}
+	if (next === state.mode) {
+		return { state, shouldPersist: false };
+	}
+	return {
+		state: { ...state, mode: next, pending: true, queued: null, known: true },
+		shouldPersist: true
+	};
+}
+
+export function completeAgentModeRequest(
+	state: AgentModeSwitchState,
+	attempted: AgentMode,
+	result: { ok: true; mode: AgentMode } | { ok: false }
+): { state: AgentModeSwitchState; shouldPersist: AgentMode | null } {
+	if (result.ok) {
+		const baseline = result.mode;
+		if (state.queued && state.queued !== baseline) {
+			return {
+				state: {
+					...state,
+					mode: state.queued,
+					known: true,
+					pending: true,
+					queued: null,
+					baseline
+				},
+				shouldPersist: state.queued
+			};
+		}
+		return {
+			state: {
+				...state,
+				mode: baseline,
+				known: true,
+				pending: false,
+				queued: null,
+				baseline
+			},
+			shouldPersist: null
+		};
+	}
+
+	if (state.queued && state.queued !== attempted) {
+		return {
+			state: {
+				...state,
+				mode: state.queued,
+				pending: true,
+				queued: null,
+				known: true
+			},
+			shouldPersist: state.queued
+		};
+	}
+
+	return {
+		state: {
+			...state,
+			mode: state.baseline,
+			known: true,
+			pending: false,
+			queued: null,
+			baseline: state.baseline
+		},
+		shouldPersist: null
+	};
+}
+
+export function agentModeAnnouncement(mode: AgentMode): string {
+	return mode === 'plan' ? 'Plan mode enabled' : 'Auto mode enabled';
+}

--- a/cometline/src/lib/conversation/conversation-controller.test.ts
+++ b/cometline/src/lib/conversation/conversation-controller.test.ts
@@ -558,10 +558,14 @@ describe('createConversationController', () => {
 });
 
 describe('refreshConversationSession', () => {
-	it('updates session store on success', async () => {
-		const updateSpy = vi.spyOn(sessionStore, 'updateSession');
+	it('patches title metadata without replacing the session', async () => {
+		const patchSpy = vi.spyOn(sessionStore, 'patchSessionMetadata');
 		await refreshConversationSession('sess-1');
-		expect(updateSpy).toHaveBeenCalledWith({ id: 'sess-1', title: 'Updated' });
-		updateSpy.mockRestore();
+		expect(patchSpy).toHaveBeenCalledWith('sess-1', {
+			title: 'Updated',
+			token_usage: undefined,
+			updated_at: undefined
+		});
+		patchSpy.mockRestore();
 	});
 });

--- a/cometline/src/lib/conversation/conversation-controller.ts
+++ b/cometline/src/lib/conversation/conversation-controller.ts
@@ -263,7 +263,12 @@ export function createConversationController(
 /** Refresh session metadata after a turn (title, etc.). */
 export async function refreshConversationSession(sessionId: string): Promise<void> {
 	const apply = async () => {
-		sessionStore.updateSession(await getSession(sessionId));
+		const latest = await getSession(sessionId);
+		sessionStore.patchSessionMetadata(sessionId, {
+			title: latest.title,
+			token_usage: latest.token_usage,
+			updated_at: latest.updated_at
+		});
 	};
 	try {
 		await apply();

--- a/cometline/src/lib/sessions/session-metadata.test.ts
+++ b/cometline/src/lib/sessions/session-metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from '$lib/types';
+import { applySessionMetadata, normalizeAgentMode } from './session-metadata';
+
+function session(overrides: Partial<Session> = {}): Session {
+	return {
+		id: 'sess-1',
+		workspace_id: 'ws',
+		workspace_path: '/ws',
+		title: 'Chat',
+		model_id: 'm',
+		provider_id: 'p',
+		status: 'active',
+		origin: 'user',
+		token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+		pinned: false,
+		agent_mode: 'auto',
+		created_at: 0,
+		updated_at: 100,
+		...overrides
+	};
+}
+
+describe('normalizeAgentMode', () => {
+	it('treats only plan as plan', () => {
+		expect(normalizeAgentMode('plan')).toBe('plan');
+		expect(normalizeAgentMode('auto')).toBe('auto');
+		expect(normalizeAgentMode(undefined)).toBe('auto');
+	});
+});
+
+describe('applySessionMetadata', () => {
+	it('updates title and usage without touching agent mode', () => {
+		const existing = session({ agent_mode: 'plan', title: '', updated_at: 300 });
+		expect(
+			applySessionMetadata(existing, {
+				title: 'Named',
+				token_usage: { input_tokens: 1, output_tokens: 2, cache_read: 0, cache_write: 0 },
+				updated_at: 100
+			})
+		).toEqual({
+			...existing,
+			title: 'Named',
+			token_usage: { input_tokens: 1, output_tokens: 2, cache_read: 0, cache_write: 0 },
+			updated_at: 100
+		});
+	});
+});

--- a/cometline/src/lib/sessions/session-metadata.ts
+++ b/cometline/src/lib/sessions/session-metadata.ts
@@ -1,0 +1,19 @@
+import type { AgentMode, Session } from '$lib/types';
+
+/** Session snapshots that are not exactly `plan` behave as Auto. */
+export function normalizeAgentMode(value: Session['agent_mode'] | undefined): AgentMode {
+	return value === 'plan' ? 'plan' : 'auto';
+}
+
+/** Fields a metadata refresh may write. Agent mode is never among them. */
+export type SessionMetadataPatch = Pick<Session, 'title' | 'token_usage'> &
+	Partial<Pick<Session, 'updated_at'>>;
+
+export function applySessionMetadata(existing: Session, patch: SessionMetadataPatch): Session {
+	return {
+		...existing,
+		title: patch.title,
+		token_usage: patch.token_usage,
+		updated_at: patch.updated_at ?? existing.updated_at
+	};
+}

--- a/cometline/src/lib/stores/session.svelte.test.ts
+++ b/cometline/src/lib/stores/session.svelte.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '$lib/types';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+function session(overrides: Partial<Session> = {}): Session {
+	return {
+		id: 'sess-1',
+		workspace_id: 'ws',
+		workspace_path: '/ws',
+		title: 'Chat',
+		model_id: 'm',
+		provider_id: 'p',
+		status: 'active',
+		origin: 'user',
+		token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 },
+		pinned: false,
+		agent_mode: 'auto',
+		created_at: 0,
+		updated_at: 100,
+		...overrides
+	};
+}
+
+describe('sessionStore metadata patches', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.resetModules();
+	});
+
+	it('refreshes title without rolling back agent mode', async () => {
+		const { sessionStore } = await import('./session.svelte');
+		sessionStore.setSessions([session({ agent_mode: 'plan', title: '', updated_at: 300 })]);
+		sessionStore.patchSessionMetadata('sess-1', {
+			title: 'Named',
+			token_usage: { input_tokens: 4, output_tokens: 0, cache_read: 0, cache_write: 0 },
+			updated_at: 100
+		});
+
+		expect(sessionStore.sessions[0]).toMatchObject({
+			title: 'Named',
+			agent_mode: 'plan',
+			token_usage: { input_tokens: 4, output_tokens: 0, cache_read: 0, cache_write: 0 },
+			updated_at: 100
+		});
+	});
+
+	it('lets an explicit session write replace agent mode', async () => {
+		const { sessionStore } = await import('./session.svelte');
+		sessionStore.setSessions([session({ agent_mode: 'plan' })]);
+		sessionStore.updateSession(
+			session({ agent_mode: 'auto', title: 'Named', updated_at: 200 })
+		);
+
+		expect(sessionStore.sessions[0]).toMatchObject({
+			title: 'Named',
+			agent_mode: 'auto',
+			updated_at: 200
+		});
+	});
+});

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -3,6 +3,7 @@ import type { AgentMode, ImageAttachment, Session } from '$lib/types';
 import type { WebContext } from '$lib/actions/start-chat';
 import { publishWindowSync, subscribeWindowSync } from '$lib/window-sync';
 import { unreadSessionOutputStore } from '$lib/stores/unread-session-output.svelte';
+import { applySessionMetadata, type SessionMetadataPatch } from '$lib/sessions/session-metadata';
 
 export interface PendingMessage {
 	sessionId: string;
@@ -20,7 +21,7 @@ function createSessionStore() {
 	let current = $state<Session | null>(null);
 	let pendingMessages = $state.raw(new Map<string, Omit<PendingMessage, 'sessionId'>>());
 
-	function upsertSession(
+	function writeSession(
 		session: Session,
 		options: { selectCurrent?: boolean; prepend?: boolean; broadcast?: boolean } = {}
 	) {
@@ -39,6 +40,13 @@ function createSessionStore() {
 		}
 	}
 
+	function upsertSession(
+		session: Session,
+		options: { selectCurrent?: boolean; prepend?: boolean; broadcast?: boolean } = {}
+	) {
+		writeSession(session, options);
+	}
+
 	function selectSession(session: Session | null) {
 		current = session;
 	}
@@ -49,7 +57,15 @@ function createSessionStore() {
 		unreadSessionOutputStore.prune(list.map((session) => session.id));
 		if (current && !list.some((session) => session.id === current?.id)) {
 			current = null;
+		} else if (current) {
+			current = list.find((session) => session.id === current?.id) ?? current;
 		}
+	}
+
+	function patchSessionMetadata(sessionId: string, patch: SessionMetadataPatch) {
+		const existing = sessions.find((item) => item.id === sessionId);
+		if (!existing) return;
+		writeSession(applySessionMetadata(existing, patch), { prepend: true });
 	}
 
 	function appendSession(session: Session) {
@@ -138,6 +154,7 @@ function createSessionStore() {
 		upsertSession,
 		appendSession,
 		updateSession,
+		patchSessionMetadata,
 		removeSession,
 		discardSession,
 		queuePendingMessage,


### PR DESCRIPTION
## Background

Switching Auto and Plan in the composer could snap back after a turn. Session refresh replaced the whole session object, so a stale agent_mode overwrote the tab the user had just chosen.

[5dff4ba](https://github.com/Cometline/cometline/commit/5dff4baa815e23518cebad13e5af42c1a65308ce): Title and token refresh now patch metadata only. The composer owns Auto/Plan locally, queues rapid toggles, and binds persisted mode only when entering a session.