### PR TITLE
[main] fix: move paintWhenInitiallyHidden to window options

### DIFF
--- a/cometline/electron/src/domains/windows.test.ts
+++ b/cometline/electron/src/domains/windows.test.ts
@@ -207,6 +207,7 @@ describe('window lifecycle factory', () => {
 			fullscreenable: false,
 			width: 480,
 			height: 668,
+			paintWhenInitiallyHidden: true,
 			webPreferences: {
 				backgroundThrottling: false
 			}

--- a/cometline/electron/src/domains/windows.ts
+++ b/cometline/electron/src/domains/windows.ts
@@ -308,6 +308,8 @@ export function createWindows(dependencies: WindowsDependencies) {
 				: {}),
 			...(appIcon ? { icon: appIcon } : {}),
 			show: false,
+			// Hidden prewarm still paints so the first shortcut can reveal a ready view.
+			paintWhenInitiallyHidden: true,
 			webPreferences: {
 				preload: path.join(runtimeDirectory, 'dist', 'preload.cjs'),
 				contextIsolation: true,
@@ -318,7 +320,6 @@ export function createWindows(dependencies: WindowsDependencies) {
 				// Keep the hidden prewarmed renderer warm so shortcut toggles
 				// do not pay Chromium's background-throttle wake-up hitch.
 				backgroundThrottling: false,
-				paintWhenInitiallyHidden: true,
 				devTools: !app.isPackaged
 			}
 		});


### PR DESCRIPTION
## Background

Hidden mini prewarm put `paintWhenInitiallyHidden` on `webPreferences`. Electron 42 types that field on the BrowserWindow options object, so `pnpm run check` fails after the prewarm work landed.

[3961df0](https://github.com/Cometline/cometline/commit/3961df0eb501617d20268b7e441981b486b70d7e): Moves the option next to `show: false` and keeps background throttling disabled on the renderer.