### PR TITLE
[main] fix: preserve queued messages across run completion

### DIFF
--- a/cometline/src/lib/conversation/conversation-controller.test.ts
+++ b/cometline/src/lib/conversation/conversation-controller.test.ts
@@ -630,6 +630,57 @@ describe('createConversationController', () => {
 		expect(onTurnRejected).toHaveBeenCalledWith('sess-1', payload);
 	});
 
+	it('retries the complete turn after an explicit session-running conflict', async () => {
+		const onTurnRejected = vi.fn();
+		const send = vi
+			.fn()
+			.mockResolvedValueOnce('session_running')
+			.mockResolvedValueOnce(undefined);
+		const payload = {
+			text: 'expanded prompt',
+			displayText: '/skill original',
+			images: [{ media_type: 'image/png' as const, data: 'abc' }],
+			filePaths: ['README.md'],
+			webContexts: [
+				{
+					kind: 'page' as const,
+					title: 'Reference',
+					source: 'https://example.com',
+					content: 'context'
+				}
+			],
+			reasoningEffort: 'high',
+			agentMode: 'plan' as const
+		};
+		const onUserMessageFlight = vi.fn().mockImplementation((_payload, ctx: FlightContext) => {
+			ctx.stageUser(payload.displayText, payload.images);
+			ctx.revealStagedUser();
+		});
+		const { controller } = createDeps({
+			send,
+			onTurnRejected,
+			hasVisibleConversation: true,
+			flight: { onUserMessageFlight }
+		});
+
+		await controller.enqueue(payload);
+
+		expect(send).toHaveBeenCalledTimes(2);
+		expect(send).toHaveBeenNthCalledWith(
+			1,
+			'sess-1',
+			payload,
+			expect.objectContaining({ skipUser: true })
+		);
+		expect(send).toHaveBeenNthCalledWith(
+			2,
+			'sess-1',
+			payload,
+			expect.objectContaining({ skipUser: false })
+		);
+		expect(onTurnRejected).not.toHaveBeenCalled();
+	});
+
 	it('does not keep processing true while refreshSession is in flight', async () => {
 		let releaseRefresh: (() => void) | undefined;
 		const refreshGate = new Promise<void>((resolve) => {

--- a/cometline/src/lib/conversation/conversation-controller.ts
+++ b/cometline/src/lib/conversation/conversation-controller.ts
@@ -45,7 +45,7 @@ export interface ConversationControllerDeps {
 		sessionId: string,
 		payload: ChatTurnPayload | string,
 		opts?: { skipUser?: boolean; onConflict?: () => void }
-	) => Promise<void>;
+	) => Promise<void | 'session_running'>;
 	refreshSession: (sessionId: string) => Promise<void>;
 	flight?: ConversationFlightAdapter;
 	onQueueChange?: () => void;
@@ -93,15 +93,24 @@ async function runTurn(
 	let stagedUserId: string | undefined;
 	let flightPromise: Promise<void> | undefined;
 	let sendPromise: Promise<void> | undefined;
+	let sendAttempts = 0;
 	const startSend = () => {
 		if (!sendPromise) {
-			const opts: { skipUser?: boolean; onConflict?: () => void } = {
-				skipUser: usesFlight ? true : firstTurn
-			};
-			if (deps.onTurnRejected) {
-				opts.onConflict = () => deps.onTurnRejected?.(turnSessionId, payload);
-			}
-			sendPromise = deps.send(turnSessionId, payloadOrText, opts);
+			sendPromise = (async () => {
+				// session_running rejects before persistence. Once send has followed that
+				// run to completion, retry the same payload and restage its user row.
+				while (true) {
+					const opts: { skipUser?: boolean; onConflict?: () => void } = {
+						skipUser: sendAttempts === 0 ? (usesFlight ? true : firstTurn) : false
+					};
+					if (deps.onTurnRejected) {
+						opts.onConflict = () => deps.onTurnRejected?.(turnSessionId, payload);
+					}
+					sendAttempts += 1;
+					const outcome = await deps.send(turnSessionId, payloadOrText, opts);
+					if (outcome !== 'session_running') return;
+				}
+			})();
 			void sendPromise.catch(() => undefined);
 		}
 		return sendPromise;

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -594,6 +594,28 @@ describe('chatStore session switching', () => {
 		]);
 	});
 
+	it('returns explicit session-running conflicts for queue retry without restoring a draft', async () => {
+		const onConflict = vi.fn();
+		vi.mocked(streamMessage).mockImplementation(async function* () {
+			throw { status: 409, code: 'session_running' };
+			yield { type: 'done' };
+		});
+		vi.mocked(getSessionMessages).mockResolvedValue(
+			mockTranscript('sess-a', 'existing question')
+		);
+		vi.mocked(streamSessionEvents).mockImplementation(async function* () {
+			yield { type: 'text_delta', delta: 'existing answer' };
+			yield { type: 'done' };
+		});
+
+		chatStore.bindSession('sess-a');
+		const outcome = await chatStore.send('sess-a', 'queued question', { onConflict });
+
+		expect(outcome).toBe('session_running');
+		expect(onConflict).not.toHaveBeenCalled();
+		expect(chatStore.isStreamingFor('sess-a')).toBe(false);
+	});
+
 	it('does not clobber in-flight cache when loadTranscript returns user-only server data', async () => {
 		let releaseA: (() => void) | undefined;
 		const aGate = new Promise<void>((resolve) => {

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -75,6 +75,17 @@ function createChatStore() {
 		return Boolean(err && typeof err === 'object' && 'status' in err && err.status === 409);
 	}
 
+	function isSessionRunningConflict(err: unknown) {
+		return Boolean(
+			err &&
+				typeof err === 'object' &&
+				'status' in err &&
+				err.status === 409 &&
+				'code' in err &&
+				err.code === 'session_running'
+		);
+	}
+
 	function cachedItemCount(targetSessionID: string) {
 		return sessionCache.get(targetSessionID)?.length ?? 0;
 	}
@@ -626,7 +637,7 @@ function createChatStore() {
 		nextSessionID: string,
 		payloadOrText: ChatTurnPayload | string,
 		opts?: { skipUser?: boolean; onConflict?: () => void }
-	) {
+	): Promise<void | 'session_running'> {
 		const payload = typeof payloadOrText === 'string' ? { text: payloadOrText } : payloadOrText;
 		const text = payload.text;
 		const displayText = payload.displayText ?? text;
@@ -722,13 +733,14 @@ function createChatStore() {
 				return;
 			}
 			if (isRunConflict(err)) {
-				opts?.onConflict?.();
+				const sessionRunning = isSessionRunningConflict(err);
+				if (!sessionRunning) opts?.onConflict?.();
 				flushBatchForSession(nextSessionID, ctx, handle);
 				applyEventToSession(nextSessionID, { type: 'done' }, ctx);
 				unmarkStreaming(nextSessionID);
 				await refreshTranscript(nextSessionID);
 				await resumeRun(nextSessionID);
-				return;
+				return sessionRunning ? 'session_running' : undefined;
 			}
 			streamOutcome = 'error';
 			applyStreamEventForSession(

--- a/cometmind/server/messages.go
+++ b/cometmind/server/messages.go
@@ -126,9 +126,17 @@ func (a *App) handlePostMessage(c *gin.Context) {
 		writeError(c, http.StatusConflict, "session_running", err.Error())
 		return
 	}
+	runFinished := false
+	finishRun := func() {
+		if runFinished {
+			return
+		}
+		runFinished = true
+		finish()
+	}
 	runID, _, running := a.runs.Current(c.Request.Context(), sess.ID)
 	if !running {
-		finish()
+		finishRun()
 		writeError(c, http.StatusInternalServerError, "run_state_failed", "failed to read the active session run")
 		return
 	}
@@ -136,7 +144,7 @@ func (a *App) handlePostMessage(c *gin.Context) {
 	if a.events != nil {
 		a.events.Publish(event.RunStarted(sess.ID))
 	}
-	defer finish()
+	defer finishRun()
 
 	if a.jobs != nil {
 		if job, ok, _ := a.jobs.JobForSession(c.Request.Context(), sess.ID); ok {
@@ -217,9 +225,11 @@ func (a *App) handlePostMessage(c *gin.Context) {
 				flusher.Flush()
 			}
 		}
+		finishRun()
 		publishDone(c, a.sessionEvents, sess.ID, runID, flusher, clientGone)
 		return
 	}
+	finishRun()
 	publishDone(c, a.sessionEvents, sess.ID, runID, flusher, clientGone)
 	logging.L().Info("message.completed", "session", sess.ID, "duration_ms", time.Since(started).Milliseconds())
 }

--- a/cometmind/server/server_test.go
+++ b/cometmind/server/server_test.go
@@ -35,6 +35,18 @@ func (f fakeRunner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- e
 	return f(ctx, turn, ch)
 }
 
+type flushObserverRecorder struct {
+	*httptest.ResponseRecorder
+	onFlush func(body string)
+}
+
+func (r *flushObserverRecorder) Flush() {
+	r.ResponseRecorder.Flush()
+	if r.onFlush != nil {
+		r.onFlush(r.Body.String())
+	}
+}
+
 func TestCreateSessionAutoRegistersWorkspacePath(t *testing.T) {
 	t.Parallel()
 
@@ -1116,6 +1128,78 @@ func TestPostMessageStreamsSSEAndPersistsUserTurn(t *testing.T) {
 	}
 	if updated.Title != "hello from api" {
 		t.Fatalf("session title = %q, want %q", updated.Title, "hello from api")
+	}
+}
+
+func TestPostMessageReleasesRunBeforeDoneIsFlushed(t *testing.T) {
+	t.Parallel()
+
+	engine, svc, cleanup := newTestEngine(t, func(sess session.Session, workspacePath string, mode session.AgentMode) (Runner, error) {
+		return fakeRunner(func(ctx context.Context, turn session.AgentTurn, ch chan<- event.Event) error {
+			ch <- event.TextDelta("complete")
+			ch <- event.Done()
+			return nil
+		}), nil
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+	workspace, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureWorkspace() error = %v", err)
+	}
+	sess, err := svc.NewSession(ctx, workspace.ID, "test-model", "test-provider")
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	var observedDone bool
+	var runningAtDone bool
+	var observationErr error
+	rec := &flushObserverRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		onFlush: func(body string) {
+			if observedDone || !strings.Contains(body, `"type":"done"`) {
+				return
+			}
+			observedDone = true
+			sessionRec := httptest.NewRecorder()
+			engine.ServeHTTP(
+				sessionRec,
+				httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+sess.ID, nil),
+			)
+			if sessionRec.Code != http.StatusOK {
+				observationErr = fmt.Errorf("session status = %d body=%s", sessionRec.Code, sessionRec.Body.String())
+				return
+			}
+			var resource sessionResource
+			if err := json.Unmarshal(sessionRec.Body.Bytes(), &resource); err != nil {
+				observationErr = fmt.Errorf("decode session: %w", err)
+				return
+			}
+			runningAtDone = resource.Running
+		},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sessions/"+sess.ID+"/messages",
+		bytes.NewBufferString(`{"text":"hello"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if observationErr != nil {
+		t.Fatal(observationErr)
+	}
+	if !observedDone {
+		t.Fatalf("stream body missing done event:\n%s", rec.Body.String())
+	}
+	if runningAtDone {
+		t.Fatal("session was still running when done was flushed")
 	}
 }
 


### PR DESCRIPTION
## Background

Queued turns could be rejected immediately after the previous SSE `done` event because the backend run lease remained active until after the event was flushed. The client then reconciled the transcript without retrying the rejected turn, silently dropping the queued message.

[c3dc7f3](https://github.com/Cometline/cometline/commit/c3dc7f32f68d9d2c385b5a2e3d3521704b1ad393): Releases the session run before the terminal `done` event is flushed and adds a deterministic regression test for the ordering guarantee.

[5b39cd2](https://github.com/Cometline/cometline/commit/5b39cd23824354c60af0adb560421668744c0322): Treats an explicit `session_running` conflict as retryable, follows the active run to completion, and resends the complete queued turn without triggering generic conflict restoration.