### PR TITLE
[main] fix: remove gateway stop test timing race

### DIFF
--- a/cometmind/internal/gateway/router_test.go
+++ b/cometmind/internal/gateway/router_test.go
@@ -698,17 +698,19 @@ func TestHandleStopSlashTimeoutAndRepeatedStop(t *testing.T) {
 	if err != nil || text != "Stop requested, but the turn is still cleaning up." {
 		t.Fatalf("first HandleStopSlash() = (%q, %v), want cleanup timeout", text, err)
 	}
-	go func() {
-		time.Sleep(5 * time.Millisecond)
-		finish()
-	}()
-	text, err = r.HandleStopSlash(ctx, msg)
-	if err != nil || text != "Stopped the active turn." {
-		t.Fatalf("second HandleStopSlash() = (%q, %v), want success", text, err)
+	done, ok := turns.Stop(sess.ID)
+	if !ok {
+		t.Fatal("repeated Stop() = false, want active cleanup")
+	}
+	finish()
+	select {
+	case <-done:
+	default:
+		t.Fatal("repeated Stop() did not observe completed cleanup")
 	}
 	text, err = r.HandleStopSlash(ctx, msg)
 	if err != nil || text != "There is no active turn to stop." {
-		t.Fatalf("third HandleStopSlash() = (%q, %v), want no active turn", text, err)
+		t.Fatalf("second HandleStopSlash() = (%q, %v), want no active turn", text, err)
 	}
 }
 


### PR DESCRIPTION
## Background

The gateway stop test relied on a cleanup goroutine sleeping for 5ms and completing within a 10ms route timeout. Under CI load, scheduler delay allowed the second stop request to time out even though the production behavior was correct.

[4af7126](https://github.com/Cometline/cometline/commit/4af7126f926456dd95b932b830a65f15bda78496): Replaces wall-clock scheduling with direct synchronization on the active turn cleanup channel, preserving coverage for timeout, repeated stop, and completed cleanup behavior.

### Reference

[Failed CI job](https://github.com/Cometline/cometline/actions/runs/32569375333/job/97022531207)