### PR TITLE
[main] feat: polish composer attachments and titlebar

### DIFF
--- a/cometline/src/lib/components/AppShell.svelte
+++ b/cometline/src/lib/components/AppShell.svelte
@@ -1226,7 +1226,7 @@
 		top: 50%;
 		transform: translate(-50%, -50%);
 		min-width: 0;
-		max-width: min(36vw, 14rem);
+		max-width: min(calc(100% - 88px), 14rem);
 		margin: 0;
 		padding: 0;
 		border: none;
@@ -1248,13 +1248,13 @@
 
 	@media (min-width: 900px) {
 		.shell-titlebar-title {
-			max-width: min(42vw, 22rem);
+			max-width: min(calc(100% - 88px), 22rem);
 		}
 	}
 
 	@media (min-width: 1280px) {
 		.shell-titlebar-title {
-			max-width: min(48vw, 32rem);
+			max-width: min(calc(100% - 88px), 32rem);
 		}
 	}
 

--- a/cometline/src/lib/components/composer/Composer.svelte
+++ b/cometline/src/lib/components/composer/Composer.svelte
@@ -577,6 +577,8 @@
 		/>
 	{/if}
 
+	<ImageAttachments {images} onRemove={attachments.removeImage} />
+
 	<RichComposerInput
 		bind:this={input}
 		bind:value
@@ -593,8 +595,6 @@
 		onfiles={(files) => void attachments.addImageFiles(files)}
 		onmentionquery={mentions.onMentionQuery}
 	/>
-
-	<ImageAttachments {images} onRemove={attachments.removeImage} />
 
 	{#if images.length > 0 && modelStore.selected?.visionKnown && modelStore.selected?.vision === false}
 		<p class="vision-capability-hint" role="status">

--- a/cometline/src/lib/components/composer/ImageAttachments.svelte
+++ b/cometline/src/lib/components/composer/ImageAttachments.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { X } from '@lucide/svelte';
+	import ImageLightbox from '$lib/components/chat/ImageLightbox.svelte';
 	import { imageDataURL } from '$lib/files/images';
 	import type { ImageAttachment } from '$lib/types';
 
@@ -10,13 +11,24 @@
 		images: ImageAttachment[];
 		onRemove: (id: string) => void;
 	} = $props();
+
+	let lightbox = $state<{ src: string; alt: string } | null>(null);
 </script>
 
 {#if images.length > 0}
 	<div class="image-attachments" aria-label="Attached images">
 		{#each images as image (image.id)}
+			{@const src = imageDataURL(image)}
+			{@const alt = image.name ?? 'Attached image'}
 			<div class="image-attachment">
-				<img src={imageDataURL(image)} alt={image.name ?? 'Attached image'} />
+				<button
+					type="button"
+					class="image-open"
+					aria-label={`View ${alt}`}
+					onclick={() => (lightbox = { src, alt })}
+				>
+					<img {src} {alt} />
+				</button>
 				<button
 					type="button"
 					class="image-remove"
@@ -28,6 +40,10 @@
 			</div>
 		{/each}
 	</div>
+{/if}
+
+{#if lightbox}
+	<ImageLightbox open src={lightbox.src} alt={lightbox.alt} onClose={() => (lightbox = null)} />
 {/if}
 
 <style>
@@ -48,7 +64,22 @@
 		overflow: hidden;
 	}
 
-	.image-attachment img {
+	.image-open {
+		display: block;
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		border: none;
+		background: transparent;
+		cursor: zoom-in;
+	}
+
+	.image-open:focus-visible {
+		outline: 2px solid color-mix(in srgb, var(--accent) 70%, white);
+		outline-offset: -2px;
+	}
+
+	.image-open img {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;

--- a/cometline/src/lib/components/composer/ImageAttachments.svelte.test.ts
+++ b/cometline/src/lib/components/composer/ImageAttachments.svelte.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import ImageAttachments from './ImageAttachments.svelte';
+
+const originalShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
+const originalClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
+
+describe('ImageAttachments', () => {
+	beforeEach(() => {
+		Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+			configurable: true,
+			value(this: HTMLDialogElement) {
+				this.open = true;
+			}
+		});
+		Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+			configurable: true,
+			value(this: HTMLDialogElement) {
+				this.open = false;
+			}
+		});
+	});
+
+	afterAll(() => {
+		if (originalShowModal) {
+			Object.defineProperty(HTMLDialogElement.prototype, 'showModal', originalShowModal);
+		} else {
+			Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+		}
+		if (originalClose) {
+			Object.defineProperty(HTMLDialogElement.prototype, 'close', originalClose);
+		} else {
+			Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
+		}
+	});
+
+	it('opens the shared image preview when an attachment is clicked', async () => {
+		render(ImageAttachments, {
+			props: {
+				images: [
+					{
+						id: 'image-1',
+						media_type: 'image/png',
+						data: 'iVBORw0KGgo=',
+						name: 'sample.png'
+					}
+				],
+				onRemove: vi.fn()
+			}
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'View sample.png' }));
+
+		expect(screen.getByRole('dialog', { name: 'Image preview' })).toHaveProperty('open', true);
+	});
+});


### PR DESCRIPTION
## Background

Composer attachments should stay grouped above the prompt and support the same full-image preview used elsewhere in the app. Narrow chat panes should also keep long session titles clear of adjacent titlebar controls.

[1bc5e43](https://github.com/Cometline/cometline/commit/1bc5e4348e5c6359da6106bc5c42cdd8cab4dcc6): Image attachments now render between pending context and the prompt, and each thumbnail opens the shared zoomable image lightbox with keyboard-accessible controls.

[69aa9eb](https://github.com/Cometline/cometline/commit/69aa9eb06905bc58c2121bc8272ca30656a2ab34): Session titles now size against the available titlebar width so they truncate before overlapping sidebar or workspace panel controls.