### PR TITLE
[main] fix: keep popup menus visible

### DIFF
--- a/cometline/src/lib/components/Sidebar.svelte
+++ b/cometline/src/lib/components/Sidebar.svelte
@@ -211,6 +211,7 @@
 	class="sidebar"
 	class:collapsed
 	class:modal-open={Boolean(pendingDelete || terminalDeleteSession || pendingRename)}
+	class:context-menu-open={Boolean(contextMenu)}
 	aria-hidden={collapsed}
 	data-workspace-path={orderWorkspacePath}
 >
@@ -424,6 +425,11 @@
 	}
 
 	.sidebar.modal-open {
+		overflow: visible;
+	}
+
+	.sidebar.context-menu-open {
+		z-index: 2;
 		overflow: visible;
 	}
 

--- a/cometline/src/lib/components/composer/ComposerToolbar.svelte
+++ b/cometline/src/lib/components/composer/ComposerToolbar.svelte
@@ -135,6 +135,7 @@
 
 <style>
 	.composer-footer {
+		position: relative;
 		display: flex;
 		align-items: center;
 		gap: 8px;

--- a/cometline/src/lib/components/composer/ModelPicker.svelte
+++ b/cometline/src/lib/components/composer/ModelPicker.svelte
@@ -115,7 +115,9 @@
 							<span class="model-option-copy">
 								<strong>
 									<span class="model-option-label">
-										{option.label}
+										<span class="model-option-name" title={option.label}
+											>{option.label}</span
+										>
 										<ModelCapabilityIcons
 											modalities={option.inputModalities}
 											known={option.visionKnown}
@@ -271,9 +273,11 @@
 
 	.model-option-copy {
 		display: flex;
+		flex: 1 1 auto;
 		flex-direction: column;
 		gap: 2px;
 		min-width: 0;
+		overflow: hidden;
 	}
 
 	.model-option-copy strong {
@@ -281,6 +285,8 @@
 		align-items: center;
 		flex-wrap: wrap;
 		gap: 4px;
+		min-width: 0;
+		max-width: 100%;
 		font-size: 12px;
 		font-weight: 600;
 		color: var(--text-main);
@@ -291,6 +297,15 @@
 		align-items: center;
 		gap: 5px;
 		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	.model-option-name {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.model-context-hint {
@@ -311,5 +326,16 @@
 		padding: 10px 8px;
 		font-size: 12px;
 		color: var(--text-muted);
+	}
+
+	@media (max-width: 600px) {
+		.model-picker {
+			position: static;
+		}
+
+		.model-menu {
+			left: 0;
+			width: min(320px, 100%);
+		}
 	}
 </style>


### PR DESCRIPTION
## Background

Popup menus could escape narrow renderer bounds or be clipped when they crossed from the sidebar into the main pane. These changes keep both menus visible without changing their interaction behavior.

[fccdcd3](https://github.com/Cometline/cometline/commit/fccdcd39c8b4db1ba1f2a155a633726e9cbbcf56): The composer anchors its model picker to the toolbar on narrow windows and truncates long model labels so the menu stays within the mini window.

[ff19748](https://github.com/Cometline/cometline/commit/ff19748a2da294833e2974900574a8b57c089f2a): The sidebar relaxes clipping and raises its stacking level while a session context menu is open so the main pane cannot cover it.