### PR TITLE
[main] fix: dismiss stale selection popup

### DIFF
--- a/cometline/src/lib/components/SelectionAddToChat.svelte
+++ b/cometline/src/lib/components/SelectionAddToChat.svelte
@@ -16,6 +16,7 @@
 
 	function handlePointerDown(event: PointerEvent) {
 		if (button?.contains(event.target as Node)) return;
+		window.getSelection()?.removeAllRanges();
 		onDismiss();
 	}
 

--- a/cometline/src/lib/components/SelectionAddToChat.svelte.test.ts
+++ b/cometline/src/lib/components/SelectionAddToChat.svelte.test.ts
@@ -21,6 +21,30 @@ describe('SelectionAddToChat', () => {
 		expect(onDismiss).toHaveBeenCalledOnce();
 	});
 
+	it('clears the old DOM range before dismissing outside the popup', async () => {
+		const { onDismiss } = renderPopup();
+		const selectionHost = document.createElement('p');
+		selectionHost.textContent = 'Selected response';
+		document.body.append(selectionHost);
+		const selection = window.getSelection();
+		const range = document.createRange();
+		range.selectNodeContents(selectionHost);
+		selection?.removeAllRanges();
+		selection?.addRange(range);
+
+		try {
+			expect(selection?.toString()).toBe('Selected response');
+
+			await fireEvent.pointerDown(document.body);
+
+			expect(selection?.rangeCount).toBe(0);
+			expect(onDismiss).toHaveBeenCalledOnce();
+		} finally {
+			selection?.removeAllRanges();
+			selectionHost.remove();
+		}
+	});
+
 	it('keeps the popup open through its own pointer down and adds context on click', async () => {
 		const { onAdd, onDismiss } = renderPopup();
 		const button = screen.getByRole('button', { name: 'Add to chat' });


### PR DESCRIPTION
## Background

Clicking beside selected content could dismiss and immediately recreate the Add to chat popup because the old DOM selection remained active through the parent mouseup handler. Clearing that stale range before dismissal makes the first outside click authoritative while still allowing a new drag selection to create another popup.

[947e7c3](https://github.com/Cometline/cometline/commit/947e7c31d5c76b6937c2da13444a2d7794da1a66): Clears the old browser selection on outside pointer down and adds regression coverage for the dismissal invariant.