### PR TITLE
[main] fix: use product icon in confirm modal

### DIFF
--- a/cometline/src/lib/components/ConfirmActionModal.svelte
+++ b/cometline/src/lib/components/ConfirmActionModal.svelte
@@ -84,7 +84,7 @@
 		aria-labelledby="confirm-modal-title"
 		aria-describedby="confirm-modal-description"
 	>
-		<img class="app-icon" src="/project_avatar_96.png" alt="" width="56" height="56" />
+		<img class="app-icon" src="/app_icon.png" alt="" width="56" height="56" />
 		<h2 id="confirm-modal-title">{title}</h2>
 		<p id="confirm-modal-description">{description}</p>
 		{#if showInput}

--- a/cometline/src/lib/components/ConfirmActionModal.svelte.test.ts
+++ b/cometline/src/lib/components/ConfirmActionModal.svelte.test.ts
@@ -71,6 +71,13 @@ describe('ConfirmActionModal', () => {
 		expect(screen.getByRole('dialog')).toHaveProperty('open', true);
 	});
 
+	it('uses the product app icon instead of a persona avatar', () => {
+		const { container } = renderModal();
+		const icon = container.querySelector('img.app-icon');
+
+		expect(icon).toHaveAttribute('src', '/app_icon.png');
+	});
+
 	it('cancels when the native dialog is dismissed', async () => {
 		const { onCancel } = renderModal();
 


### PR DESCRIPTION
## Background

Confirm dialogs still showed the Minako persona avatar after Dock and tray switched to the product mark. Persona switches should only change chat avatars and SOUL.

[242a205](https://github.com/Cometline/cometline/commit/242a205df1e536e4950fc898e01dc15856cc30db): The confirm modal now uses the product app icon, and a test locks that source so it does not regress back to a persona avatar.