### PR TITLE
[main] feat: add detached media retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Recent example: `memory_compaction_completed` was added this way to report manua
 - **Settings:** `~/.cometmind/cometline-settings.json` (runtime; agent tools + CometMind). Desktop UI state: `~/.cometmind/cometline-desktop.json` (Electron only).
 - **Legacy config:** `~/.cometmind/config.toml` (read only when JSON settings are missing)
 - **Database:** `~/.cometmind/cometmind.db` (SQLite, pure Go via `modernc.org/sqlite`)
-- **Media:** `~/.cometmind/media/{storage_session_id}/` — gallery files stay after session or workspace delete; users remove them on the Gallery page
+- **Media:** `~/.cometmind/media/{storage_session_id}/` — gallery files stay after session or workspace delete, then follow the configurable detached-media retention period; users can also remove them on the Gallery page
 - **API:** `http://127.0.0.1:7700` (localhost only)
 - **OpenAPI spec:** `cometmind/openapi.yaml`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,7 +226,7 @@ CometMind serves a REST/SSE API on `127.0.0.1:7700`. The OpenAPI spec is `cometm
 - **Runtime and models:** health, enabled models, and catalog lookups
 - **Workspaces:** registration/pruning; previewable file read/write; Git status, diff, stage, unstage, discard, and commit; global wiki files and backlinks
 - **Sessions:** create/list/update/delete, workspace changes and forks, transcripts, one active run, child sessions, and live-session media at `/sessions/{id}/media/{mediaId}`
-- **Media:** gallery list/import/delete at `/media`; blob bytes at `/media/{id}/content` (works after the owning session is deleted)
+- **Media:** gallery list/import/delete at `/media`; blob bytes at `/media/{id}/content` work after the owning session is deleted until detached-media retention expires
 - **Streaming:** `POST /sessions/{id}/messages` returns the turn SSE stream; `GET /events` carries runtime-wide notifications
 - **Skills and MCP:** managed skills, drafts, sync runs; MCP server/tool inspection, connection tests, reconnection, and OAuth flows
 - **Memory and storage:** memory CRUD/search/settings, re-embedding, purge and compaction runs; retention and backup runs

--- a/ARCHITECTURE_GUIDE.md
+++ b/ARCHITECTURE_GUIDE.md
@@ -494,7 +494,7 @@ The SQLite schema is in `cometmind/internal/db/schema.sql`.
 | `sessions` | Workspace-scoped conversations with model/provider IDs and token usage JSON |
 | `messages` | User, assistant, tool result, and optional system rows |
 | `tool_calls` | Tool-call shells plus execution output/duration/exit code |
-| `session_media` | Gallery catalog; `session_id` / `workspace_id` SET NULL on owner delete; files live under `~/.cometmind/media/{storage_session_id}/` until `DELETE /media/{id}` |
+| `session_media` | Gallery catalog; `session_id` / `workspace_id` SET NULL on owner delete; files live under `~/.cometmind/media/{storage_session_id}/` until manual deletion or detached-media retention expires |
 
 `session.Service` is the domain layer over generated sqlc queries. It owns workspace registration, session lifecycle, message appends, assistant step persistence, tool result persistence, token usage writes, SDK-history reconstruction, and UI transcript reconstruction across `service.go` and `transcript.go`.
 

--- a/cometline/src/app.d.ts
+++ b/cometline/src/app.d.ts
@@ -127,6 +127,7 @@ declare global {
 		workspacePanelRatio: number;
 		confirmCloseOnCmdW: boolean;
 		confirmBeforeDeletingChats: boolean;
+		confirmBeforeDeletingMedia: boolean;
 		fileSearchSource: 'wiki' | 'workspace';
 		screenCapturePreferred: boolean;
 	}
@@ -233,6 +234,7 @@ declare global {
 	interface CometMindStorageSettings {
 		cleanupIntervalMinutes: number;
 		retentionDays: number;
+		detachedMediaRetentionDays: number;
 		maxSessionsPerWorkspace: number;
 		archivedMemoryPurgeDays: number;
 		vacuumAfterPurge: boolean;

--- a/cometline/src/lib/components/gallery/GalleryPage.svelte
+++ b/cometline/src/lib/components/gallery/GalleryPage.svelte
@@ -4,6 +4,7 @@
 	import { deleteMedia, listMedia, type MediaResource } from '$lib/client/cometmind';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import ImageLightbox from '$lib/components/chat/ImageLightbox.svelte';
+	import { settingsStore } from '$lib/stores/settings.svelte';
 	import {
 		copyImageToClipboard,
 		copyMediaFileToClipboard,
@@ -32,17 +33,18 @@
 
 	function downloadName(item: MediaResource) {
 		const type = item.media_type || '';
-		const ext = type.includes('jpeg') || type.includes('jpg')
-			? 'jpg'
-			: type.includes('gif')
-				? 'gif'
-				: type.includes('webp')
-					? 'webp'
-					: type.includes('webm')
-						? 'webm'
-						: item.kind === 'video'
-							? 'mp4'
-							: 'png';
+		const ext =
+			type.includes('jpeg') || type.includes('jpg')
+				? 'jpg'
+				: type.includes('gif')
+					? 'gif'
+					: type.includes('webp')
+						? 'webp'
+						: type.includes('webm')
+							? 'webm'
+							: item.kind === 'video'
+								? 'mp4'
+								: 'png';
 		return `${item.alt || item.kind}-${item.id.slice(0, 8)}.${ext}`;
 	}
 
@@ -92,6 +94,20 @@
 		}
 	}
 
+	function requestDelete(item: MediaResource) {
+		if (settingsStore.settings.app.confirmBeforeDeletingMedia) {
+			pendingDelete = item;
+			return;
+		}
+		pendingDelete = item;
+		void confirmDelete();
+	}
+
+	async function deleteWithoutFutureConfirmation() {
+		void settingsStore.saveConfirmBeforeDeletingMedia(false).catch(() => {});
+		await confirmDelete();
+	}
+
 	async function downloadItem(item: MediaResource) {
 		let url = '';
 		try {
@@ -124,9 +140,7 @@
 
 <div class="gallery-page settings-ui">
 	<header class="gallery-header">
-		<p>
-			Every generated, presented, and captured still or clip, newest first.
-		</p>
+		<p>Every generated, presented, and captured still or clip, newest first.</p>
 		{#if status}
 			<p class="gallery-status">{status}</p>
 		{/if}
@@ -217,7 +231,7 @@
 							<Download size={14} />
 							Download
 						</button>
-						<button type="button" class="danger" onclick={() => (pendingDelete = item)}>
+						<button type="button" class="danger" onclick={() => requestDelete(item)}>
 							<Trash2 size={14} />
 							Delete
 						</button>
@@ -233,7 +247,9 @@
 	title="Delete this media?"
 	description={deleteDescription(pendingDelete)}
 	confirmLabel="Delete"
+	secondaryLabel="Don't ask again"
 	onConfirm={() => void confirmDelete()}
+	onSecondary={() => void deleteWithoutFutureConfirmation()}
 	onCancel={() => (pendingDelete = null)}
 />
 

--- a/cometline/src/lib/components/gallery/GalleryPage.svelte.test.ts
+++ b/cometline/src/lib/components/gallery/GalleryPage.svelte.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import GalleryPage from './GalleryPage.svelte';
+
+const api = vi.hoisted(() => ({
+	deleteMedia: vi.fn(),
+	listMedia: vi.fn()
+}));
+const settings = vi.hoisted(() => ({
+	settings: { app: { confirmBeforeDeletingMedia: true } },
+	saveConfirmBeforeDeletingMedia: vi.fn()
+}));
+
+vi.mock('$lib/client/cometmind', () => api);
+vi.mock('$lib/stores/settings.svelte', () => ({ settingsStore: settings }));
+
+const item = {
+	id: 'media-1',
+	session_id: 'session-1',
+	storage_session_id: 'session-1',
+	workspace_id: 'workspace-1',
+	kind: 'image',
+	media_type: 'image/png',
+	alt: 'Generated image',
+	source: 'generated',
+	status: 'ready',
+	session_deleted: false,
+	byte_size: 100,
+	created_at: 1,
+	url: '/api/v1/media/media-1/content'
+};
+const originalShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
+const originalClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
+
+describe('GalleryPage media deletion', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		settings.settings.app.confirmBeforeDeletingMedia = true;
+		settings.saveConfirmBeforeDeletingMedia.mockResolvedValue(undefined);
+		api.deleteMedia.mockResolvedValue(item);
+		api.listMedia.mockResolvedValue({ items: [item] });
+		Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+			configurable: true,
+			value(this: HTMLDialogElement) {
+				this.open = true;
+			}
+		});
+		Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+			configurable: true,
+			value(this: HTMLDialogElement) {
+				this.open = false;
+			}
+		});
+	});
+
+	afterAll(() => {
+		if (originalShowModal) {
+			Object.defineProperty(HTMLDialogElement.prototype, 'showModal', originalShowModal);
+		} else {
+			Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+		}
+		if (originalClose) {
+			Object.defineProperty(HTMLDialogElement.prototype, 'close', originalClose);
+		} else {
+			Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
+		}
+	});
+
+	it('asks before deleting media by default', async () => {
+		render(GalleryPage);
+		await screen.findByText('Generated image');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+		expect(screen.getByRole('dialog')).toBeTruthy();
+		expect(api.deleteMedia).not.toHaveBeenCalled();
+	});
+
+	it('disables future confirmation and deletes from the secondary action', async () => {
+		render(GalleryPage);
+		await screen.findByText('Generated image');
+		await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+		await fireEvent.click(screen.getByRole('button', { name: "Don't ask again" }));
+
+		expect(settings.saveConfirmBeforeDeletingMedia).toHaveBeenCalledWith(false);
+		await waitFor(() => expect(api.deleteMedia).toHaveBeenCalledWith('media-1'));
+	});
+
+	it('deletes immediately when confirmation is disabled', async () => {
+		settings.settings.app.confirmBeforeDeletingMedia = false;
+		render(GalleryPage);
+		await screen.findByText('Generated image');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+		await waitFor(() => expect(api.deleteMedia).toHaveBeenCalledWith('media-1'));
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+});

--- a/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsGeneralPanel.svelte
@@ -9,6 +9,7 @@
 		screenCaptureStatus = $bindable('unknown'),
 		confirmCloseOnCmdW = $bindable(true),
 		confirmBeforeDeletingChats = $bindable(true),
+		confirmBeforeDeletingMedia = $bindable(true),
 		fileSearchSource = $bindable<FileSearchSource>('wiki'),
 		miniWindowInactivityTimeoutMinutes = $bindable(30),
 		storage = $bindable<CometMindStorageSettings>(),
@@ -17,6 +18,7 @@
 		onOpenScreenCaptureSettings,
 		onConfirmCloseOnCmdWChange,
 		onConfirmBeforeDeletingChatsChange,
+		onConfirmBeforeDeletingMediaChange,
 		onFileSearchSourceChange
 	}: {
 		openAtLogin: boolean;
@@ -24,6 +26,7 @@
 		screenCaptureStatus: string;
 		confirmCloseOnCmdW: boolean;
 		confirmBeforeDeletingChats: boolean;
+		confirmBeforeDeletingMedia: boolean;
 		fileSearchSource: FileSearchSource;
 		miniWindowInactivityTimeoutMinutes: number;
 		storage: CometMindStorageSettings;
@@ -32,6 +35,7 @@
 		onOpenScreenCaptureSettings?: () => void | Promise<void>;
 		onConfirmCloseOnCmdWChange?: (enabled: boolean) => void | Promise<void>;
 		onConfirmBeforeDeletingChatsChange?: (enabled: boolean) => void | Promise<void>;
+		onConfirmBeforeDeletingMediaChange?: (enabled: boolean) => void | Promise<void>;
 		onFileSearchSourceChange?: (source: FileSearchSource) => void | Promise<void>;
 	} = $props();
 
@@ -55,9 +59,7 @@
 	let backupRunning = $state(false);
 	let backupMessage = $state('');
 
-	const backupFolderPickerAvailable = $derived(
-		Boolean(window.electronAPI?.selectBackupFolder)
-	);
+	const backupFolderPickerAvailable = $derived(Boolean(window.electronAPI?.selectBackupFolder));
 
 	function onMiniWindowTimeoutInput(event: Event) {
 		const value = Number((event.currentTarget as HTMLInputElement).value);
@@ -81,6 +83,13 @@
 		const value = Number((event.currentTarget as HTMLInputElement).value);
 		patchStorage({
 			retentionDays: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+		});
+	}
+
+	function onDetachedMediaRetentionInput(event: Event) {
+		const value = Number((event.currentTarget as HTMLInputElement).value);
+		patchStorage({
+			detachedMediaRetentionDays: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
 		});
 	}
 
@@ -179,6 +188,12 @@
 				description="Ask for confirmation before permanently deleting a chat."
 				bind:checked={confirmBeforeDeletingChats}
 				onchange={onConfirmBeforeDeletingChatsChange}
+			/>
+			<SettingsToggle
+				label="Confirm before deleting Gallery media"
+				description="Ask for confirmation before permanently deleting an image or video from Gallery."
+				bind:checked={confirmBeforeDeletingMedia}
+				onchange={onConfirmBeforeDeletingMediaChange}
 			/>
 		</div>
 
@@ -329,6 +344,27 @@
 			</label>
 
 			<label class="field">
+				<span>Media after chat deletion (days)</span>
+				<input
+					type="number"
+					min="0"
+					step="1"
+					value={storage.detachedMediaRetentionDays}
+					oninput={onDetachedMediaRetentionInput}
+				/>
+				<small>
+					{#if storage.detachedMediaRetentionDays === 0}
+						Disabled — Gallery media stays after its chat is deleted.
+					{:else}
+						Delete Gallery media {storage.detachedMediaRetentionDays} day{storage.detachedMediaRetentionDays ===
+						1
+							? ''
+							: 's'} after its chat is deleted.
+					{/if}
+				</small>
+			</label>
+
+			<label class="field">
 				<span>Max sessions per workspace</span>
 				<input
 					type="number"
@@ -376,8 +412,8 @@
 				/>
 				<small>
 					{#if storage.toolOutputRetentionDays === 0}
-						Disabled — spilled tool output under <code>~/.cometmind/tool-output/</code> stays on
-						disk.
+						Disabled — spilled tool output under <code>~/.cometmind/tool-output/</code> stays
+						on disk.
 					{:else}
 						Delete <code>tool-output/</code> files older than {storage.toolOutputRetentionDays}
 						days.
@@ -398,7 +434,8 @@
 					{#if storage.agentTmpRetentionDays === 0}
 						Disabled — <code>~/.cometmind/agent-tmp/</code> files stay on disk.
 					{:else}
-						Delete <code>agent-tmp/</code> files older than {storage.agentTmpRetentionDays} days.
+						Delete <code>agent-tmp/</code> files older than {storage.agentTmpRetentionDays}
+						days.
 					{/if}
 				</small>
 			</label>
@@ -424,8 +461,8 @@
 			<div class="settings-section-heading">
 				<h3>Data backup</h3>
 				<p>
-					Zip the entire <code>~/.cometmind/</code> directory (wiki, database, settings,
-					skills, OAuth tokens) to a folder on your computer.
+					Zip the entire <code>~/.cometmind/</code> directory (wiki, database, settings, skills,
+					OAuth tokens) to a folder on your computer.
 				</p>
 			</div>
 			<p class="settings-field-hint backup-warning">
@@ -436,8 +473,7 @@
 				label="Enable automatic backup"
 				description="Periodically zip ~/.cometmind to the backup folder below."
 				checked={storage.backup.enabled}
-				onchange={(enabled) =>
-					patchStorage({ backup: { ...storage.backup, enabled } })}
+				onchange={(enabled) => patchStorage({ backup: { ...storage.backup, enabled } })}
 			/>
 
 			<label class="field backup-folder-field">
@@ -501,7 +537,12 @@
 			</label>
 
 			<div class="settings-row-actions">
-				<button class="secondary" type="button" disabled={backupRunning} onclick={backupNow}>
+				<button
+					class="secondary"
+					type="button"
+					disabled={backupRunning}
+					onclick={backupNow}
+				>
 					{backupRunning ? 'Backing up…' : 'Backup now'}
 				</button>
 			</div>

--- a/cometline/src/lib/components/settings/SettingsPanel.svelte
+++ b/cometline/src/lib/components/settings/SettingsPanel.svelte
@@ -433,9 +433,7 @@
 								<div class="settings-section-heading">
 									<div>
 										<h3>Persona</h3>
-										<p>
-											Chat avatar, intro animation, and SOUL system prompt
-										</p>
+										<p>Chat avatar, intro animation, and SOUL system prompt</p>
 									</div>
 									<SettingsButton onclick={openPersonaEditorForCreate}
 										>New persona</SettingsButton
@@ -664,6 +662,7 @@
 							screenCaptureStatus={panelController.screenCaptureStatus}
 							bind:confirmCloseOnCmdW={draft.app.confirmCloseOnCmdW}
 							bind:confirmBeforeDeletingChats={draft.app.confirmBeforeDeletingChats}
+							bind:confirmBeforeDeletingMedia={draft.app.confirmBeforeDeletingMedia}
 							bind:fileSearchSource={draft.app.fileSearchSource}
 							bind:miniWindowInactivityTimeoutMinutes={
 								draft.app.miniWindowInactivityTimeoutMinutes
@@ -674,6 +673,7 @@
 							onOpenScreenCaptureSettings={panelController.openScreenCaptureSettings}
 							onConfirmCloseOnCmdWChange={panelController.setConfirmCloseOnCmdW}
 							onConfirmBeforeDeletingChatsChange={panelController.setConfirmBeforeDeletingChats}
+							onConfirmBeforeDeletingMediaChange={panelController.setConfirmBeforeDeletingMedia}
 							onFileSearchSourceChange={panelController.setFileSearchSource}
 						/>
 						<section class="settings-panel-frame">

--- a/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
+++ b/cometline/src/lib/components/settings/settings-panel-controller.svelte.ts
@@ -380,11 +380,36 @@ export function createSettingsPanelController(deps: {
 				...deps.getDraft(),
 				app: {
 					...deps.getDraft().app,
-					confirmBeforeDeletingChats: settingsStore.settings.app.confirmBeforeDeletingChats
+					confirmBeforeDeletingChats:
+						settingsStore.settings.app.confirmBeforeDeletingChats
 				}
 			});
 			deps.settingsController.status =
-				err instanceof Error ? err.message : 'Failed to save delete confirmation preference';
+				err instanceof Error
+					? err.message
+					: 'Failed to save delete confirmation preference';
+		}
+	}
+
+	async function setConfirmBeforeDeletingMedia(enabled: boolean) {
+		const draft = deps.getDraft();
+		deps.setDraft({ ...draft, app: { ...draft.app, confirmBeforeDeletingMedia: enabled } });
+		try {
+			await settingsStore.saveConfirmBeforeDeletingMedia(enabled);
+			deps.settingsController.status = enabled
+				? 'Will ask for confirmation before deleting Gallery media.'
+				: 'Gallery media will delete without confirmation.';
+		} catch (err) {
+			deps.setDraft({
+				...deps.getDraft(),
+				app: {
+					...deps.getDraft().app,
+					confirmBeforeDeletingMedia:
+						settingsStore.settings.app.confirmBeforeDeletingMedia
+				}
+			});
+			deps.settingsController.status =
+				err instanceof Error ? err.message : 'Failed to save media delete preference';
 		}
 	}
 
@@ -823,6 +848,7 @@ export function createSettingsPanelController(deps: {
 		openScreenCaptureSettings,
 		setConfirmCloseOnCmdW,
 		setConfirmBeforeDeletingChats,
+		setConfirmBeforeDeletingMedia,
 		setFileSearchSource,
 		save,
 		persistDraftForRuntime,

--- a/cometline/src/lib/settings/schema.test.ts
+++ b/cometline/src/lib/settings/schema.test.ts
@@ -78,13 +78,23 @@ describe('settings schema', () => {
 		expect(settings.app.hasCompletedSetup).toBe(false);
 		expect(settings.app.hasDismissedSetupWizard).toBe(false);
 		expect(settings.app.screenCapturePreferred).toBe(false);
+		expect(settings.app.confirmBeforeDeletingMedia).toBe(true);
 		expect(settings.cometmind.systemPromptPath).toBe('');
 		expect(settings.cometmind.maxTokens).toBe(2048);
 		expect(settings.cometmind.contextWindowLimit).toBe(128_000);
 		expect(settings.cometmind.storage.retentionDays).toBe(90);
+		expect(settings.cometmind.storage.detachedMediaRetentionDays).toBe(30);
 		expect(settings.cometmind.storage.maxSessionsPerWorkspace).toBe(0);
 		expect(settings.cometmind.acp.enabled).toBe(false);
 		expect(settings.cometmind.acp.defaultHarness).toBe('opencode');
+	});
+
+	it('defaults missing Gallery delete confirmation settings to enabled', () => {
+		const base = defaultSettings();
+		const { confirmBeforeDeletingMedia: _omitted, ...legacyApp } = base.app;
+		const settings = normalizeSettings({ ...base, app: legacyApp as typeof base.app });
+
+		expect(settings.app.confirmBeforeDeletingMedia).toBe(true);
 	});
 
 	it('normalizes legacy ACP settings with the new harness defaults', () => {
@@ -307,6 +317,17 @@ describe('settings schema', () => {
 		});
 		expect(settings.cometmind.storage.retentionDays).toBe(0);
 		expect(settings.cometmind.storage.archivedMemoryPurgeDays).toBe(90);
+	});
+
+	it('defaults detached Gallery media retention and allows disabling it', () => {
+		expect(
+			normalizeCometMindSettings({ storage: {} as never }).storage.detachedMediaRetentionDays
+		).toBe(30);
+		expect(
+			normalizeCometMindSettings({
+				storage: { detachedMediaRetentionDays: 0 } as never
+			}).storage.detachedMediaRetentionDays
+		).toBe(0);
 	});
 
 	it('migrates deleted job purge from storage to jobs', () => {

--- a/cometline/src/lib/settings/schema.ts
+++ b/cometline/src/lib/settings/schema.ts
@@ -127,6 +127,8 @@ export interface CometMindStorageBackupSettings {
 export interface CometMindStorageSettings {
 	cleanupIntervalMinutes: number;
 	retentionDays: number;
+	/** Delete Gallery media after its owning session has been gone for N days. 0 disables. */
+	detachedMediaRetentionDays: number;
 	maxSessionsPerWorkspace: number;
 	archivedMemoryPurgeDays: number;
 	vacuumAfterPurge: boolean;
@@ -547,6 +549,7 @@ export function defaultCometMindStorageSettings(): CometMindStorageSettings {
 	return {
 		cleanupIntervalMinutes: 60,
 		retentionDays: 90,
+		detachedMediaRetentionDays: 30,
 		maxSessionsPerWorkspace: 0,
 		archivedMemoryPurgeDays: 90,
 		vacuumAfterPurge: true,
@@ -640,7 +643,9 @@ export function normalizeCometMindSettings(
 	const embedding: Partial<CometMindMemorySettings['embedding']> = memory.embedding ?? {};
 	const storage: Partial<CometMindStorageSettings> = input?.storage ?? {};
 	const legacyDeletedJobPurgeDays = (
-		input?.storage as (Partial<CometMindStorageSettings> & { deletedJobPurgeDays?: unknown }) | undefined
+		input?.storage as
+			| (Partial<CometMindStorageSettings> & { deletedJobPurgeDays?: unknown })
+			| undefined
 	)?.deletedJobPurgeDays;
 	const discord: Partial<CometMindDiscordGatewaySettings> = input?.gateway?.discord ?? {};
 	const mcp = normalizeCometMindMCPSettings(input?.mcp);
@@ -770,6 +775,10 @@ export function normalizeCometMindSettings(
 			retentionDays: normalizeNonNegativeInt(
 				storage.retentionDays,
 				defaults.storage.retentionDays
+			),
+			detachedMediaRetentionDays: normalizeNonNegativeInt(
+				storage.detachedMediaRetentionDays,
+				defaults.storage.detachedMediaRetentionDays
 			),
 			maxSessionsPerWorkspace: normalizeNonNegativeInt(
 				storage.maxSessionsPerWorkspace,
@@ -920,18 +929,24 @@ export function normalizeCometMindSettings(
 		},
 		generation: {
 			image: {
-				providerId: String(
-					generationInput.image?.providerId ?? defaults.generation.image.providerId
-				).trim() || defaults.generation.image.providerId,
-				model: String(generationInput.image?.model ?? defaults.generation.image.model).trim() ||
-					defaults.generation.image.model
+				providerId:
+					String(
+						generationInput.image?.providerId ?? defaults.generation.image.providerId
+					).trim() || defaults.generation.image.providerId,
+				model:
+					String(
+						generationInput.image?.model ?? defaults.generation.image.model
+					).trim() || defaults.generation.image.model
 			},
 			video: {
-				providerId: String(
-					generationInput.video?.providerId ?? defaults.generation.video.providerId
-				).trim() || defaults.generation.video.providerId,
-				model: String(generationInput.video?.model ?? defaults.generation.video.model).trim() ||
-					defaults.generation.video.model
+				providerId:
+					String(
+						generationInput.video?.providerId ?? defaults.generation.video.providerId
+					).trim() || defaults.generation.video.providerId,
+				model:
+					String(
+						generationInput.video?.model ?? defaults.generation.video.model
+					).trim() || defaults.generation.video.model
 			}
 		}
 	};
@@ -1058,6 +1073,7 @@ function defaultAppSettings(): AppSettings {
 		workspacePanelRatio: 0,
 		confirmCloseOnCmdW: true,
 		confirmBeforeDeletingChats: true,
+		confirmBeforeDeletingMedia: true,
 		fileSearchSource: 'wiki',
 		screenCapturePreferred: false
 	};
@@ -1341,6 +1357,10 @@ export function normalizeSettings(
 				typeof next.app?.confirmBeforeDeletingChats === 'boolean'
 					? next.app.confirmBeforeDeletingChats
 					: defaultAppSettings().confirmBeforeDeletingChats,
+			confirmBeforeDeletingMedia:
+				typeof next.app?.confirmBeforeDeletingMedia === 'boolean'
+					? next.app.confirmBeforeDeletingMedia
+					: defaultAppSettings().confirmBeforeDeletingMedia,
 			fileSearchSource: normalizeFileSearchSource(
 				(next.app as { fileSearchSource?: unknown } | undefined)?.fileSearchSource
 			),
@@ -1517,6 +1537,7 @@ const providerSettingsSchema = z.object({
 		workspacePanelRatio: z.number().min(0).max(WORKSPACE_PANEL_MAX_RATIO),
 		confirmCloseOnCmdW: z.boolean(),
 		confirmBeforeDeletingChats: z.boolean(),
+		confirmBeforeDeletingMedia: z.boolean(),
 		fileSearchSource: z.enum(['wiki', 'workspace']),
 		screenCapturePreferred: z.boolean()
 	}),
@@ -1569,6 +1590,7 @@ const providerSettingsSchema = z.object({
 		storage: z.object({
 			cleanupIntervalMinutes: z.number().int().min(0),
 			retentionDays: z.number().int().min(0),
+			detachedMediaRetentionDays: z.number().int().min(0),
 			maxSessionsPerWorkspace: z.number().int().min(0),
 			archivedMemoryPurgeDays: z.number().int().min(0),
 			vacuumAfterPurge: z.boolean(),

--- a/cometline/src/lib/settings/settings-draft.ts
+++ b/cometline/src/lib/settings/settings-draft.ts
@@ -54,6 +54,7 @@ export function cloneSettings(settings: ProviderSettings): ProviderSettings {
 			workspacePanelRatio: settings.app?.workspacePanelRatio ?? 0,
 			confirmCloseOnCmdW: settings.app?.confirmCloseOnCmdW ?? true,
 			confirmBeforeDeletingChats: settings.app?.confirmBeforeDeletingChats ?? true,
+			confirmBeforeDeletingMedia: settings.app?.confirmBeforeDeletingMedia ?? true,
 			fileSearchSource: settings.app?.fileSearchSource === 'workspace' ? 'workspace' : 'wiki'
 		},
 		cometmind: cloneCometMindSettings(normalizeCometMindSettings(settings.cometmind))

--- a/cometline/src/lib/stores/settings.svelte.ts
+++ b/cometline/src/lib/stores/settings.svelte.ts
@@ -348,7 +348,33 @@ function createSettingsStore() {
 			}
 			writeLocalSettings(normalized);
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to save delete confirmation preference';
+			error =
+				err instanceof Error
+					? err.message
+					: 'Failed to save delete confirmation preference';
+			throw err;
+		}
+	}
+
+	async function saveConfirmBeforeDeletingMedia(enabled: boolean) {
+		if (settings.app.confirmBeforeDeletingMedia === enabled) return;
+		error = '';
+		const normalized = normalizeSettings({
+			...settings,
+			app: { ...settings.app, confirmBeforeDeletingMedia: enabled }
+		});
+		apply(normalized);
+		try {
+			if (window.electronAPI?.saveProviderSettings) {
+				const result = await window.electronAPI.saveProviderSettings(normalized, {
+					restartCometMind: false
+				});
+				apply(result.settings);
+				return;
+			}
+			writeLocalSettings(normalized);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save media delete preference';
 			throw err;
 		}
 	}
@@ -425,8 +451,7 @@ function createSettingsStore() {
 				nextProviders.find((p) => p.enabled && p.enabledModels.length > 0) ??
 				nextProviders[0];
 			nextDefaultProviderId = fallback?.id ?? '';
-			nextDefaultModelId =
-				fallback?.enabledModels[0] ?? fallback?.selectedModel ?? '';
+			nextDefaultModelId = fallback?.enabledModels[0] ?? fallback?.selectedModel ?? '';
 		}
 		settings = {
 			...settings,
@@ -475,6 +500,7 @@ function createSettingsStore() {
 		saveShortcuts,
 		saveConfirmCloseOnCmdW,
 		saveConfirmBeforeDeletingChats,
+		saveConfirmBeforeDeletingMedia,
 		saveFileSearchSource,
 		saveWorkspacePanelLayout,
 		setDefaultProvider,

--- a/cometline/src/lib/types.ts
+++ b/cometline/src/lib/types.ts
@@ -174,6 +174,8 @@ export interface AppSettings {
 	confirmCloseOnCmdW: boolean;
 	/** When true, deleting a chat requires confirmation. */
 	confirmBeforeDeletingChats: boolean;
+	/** When true, deleting Gallery media requires confirmation. */
+	confirmBeforeDeletingMedia: boolean;
 	/** Default source for the ⌘P file search modal. */
 	fileSearchSource: 'wiki' | 'workspace';
 	/** User preference to enable screen / system-audio capture for presenting screenshots. */

--- a/cometmind/internal/config/cometline_settings.go
+++ b/cometmind/internal/config/cometline_settings.go
@@ -87,15 +87,16 @@ type cometlineStorageBackupJSON struct {
 }
 
 type cometlineStorageJSON struct {
-	CleanupIntervalMinutes  int                        `json:"cleanupIntervalMinutes"`
-	RetentionDays           int                        `json:"retentionDays"`
-	MaxSessionsPerWorkspace int                        `json:"maxSessionsPerWorkspace"`
-	ArchivedMemoryPurgeDays int                        `json:"archivedMemoryPurgeDays"`
-	DeletedJobPurgeDays     *int                       `json:"deletedJobPurgeDays"`
-	VacuumAfterPurge        bool                       `json:"vacuumAfterPurge"`
-	ToolOutputRetentionDays *int                       `json:"toolOutputRetentionDays"`
-	AgentTmpRetentionDays   *int                       `json:"agentTmpRetentionDays"`
-	Backup                  cometlineStorageBackupJSON `json:"backup"`
+	CleanupIntervalMinutes     int                        `json:"cleanupIntervalMinutes"`
+	RetentionDays              int                        `json:"retentionDays"`
+	DetachedMediaRetentionDays *int                       `json:"detachedMediaRetentionDays"`
+	MaxSessionsPerWorkspace    int                        `json:"maxSessionsPerWorkspace"`
+	ArchivedMemoryPurgeDays    int                        `json:"archivedMemoryPurgeDays"`
+	DeletedJobPurgeDays        *int                       `json:"deletedJobPurgeDays"`
+	VacuumAfterPurge           bool                       `json:"vacuumAfterPurge"`
+	ToolOutputRetentionDays    *int                       `json:"toolOutputRetentionDays"`
+	AgentTmpRetentionDays      *int                       `json:"agentTmpRetentionDays"`
+	Backup                     cometlineStorageBackupJSON `json:"backup"`
 }
 
 type cometlineMCPOAuthJSON struct {
@@ -494,6 +495,11 @@ func adaptStorageConfig(cm cometlineStorageJSON) StorageConfig {
 		s.ToolOutputRetentionDays = *cm.ToolOutputRetentionDays
 	} else if hasOther {
 		s.ToolOutputRetentionDays = def.ToolOutputRetentionDays
+	}
+	if cm.DetachedMediaRetentionDays != nil {
+		s.DetachedMediaRetentionDays = *cm.DetachedMediaRetentionDays
+	} else if hasOther {
+		s.DetachedMediaRetentionDays = def.DetachedMediaRetentionDays
 	}
 	if cm.AgentTmpRetentionDays != nil {
 		s.AgentTmpRetentionDays = *cm.AgentTmpRetentionDays

--- a/cometmind/internal/config/storage.go
+++ b/cometmind/internal/config/storage.go
@@ -16,6 +16,8 @@ type StorageConfig struct {
 	CleanupIntervalMinutes int `json:"cleanup_interval_minutes" mapstructure:"cleanup_interval_minutes"`
 	// RetentionDays deletes sessions with no activity for this many days. 0 disables.
 	RetentionDays int `json:"retention_days" mapstructure:"retention_days"`
+	// DetachedMediaRetentionDays deletes media after its owning session is deleted. 0 disables.
+	DetachedMediaRetentionDays int `json:"detached_media_retention_days" mapstructure:"detached_media_retention_days"`
 	// MaxSessionsPerWorkspace keeps only the N most recently updated sessions per workspace. 0 disables.
 	MaxSessionsPerWorkspace int `json:"max_sessions_per_workspace" mapstructure:"max_sessions_per_workspace"`
 	// ArchivedMemoryPurgeDays hard-deletes archived memories older than this many days. 0 disables.
@@ -44,15 +46,16 @@ func defaultStorageBackupConfig() StorageBackupConfig {
 
 func defaultStorageConfig() StorageConfig {
 	return StorageConfig{
-		CleanupIntervalMinutes:  60,
-		RetentionDays:           90,
-		MaxSessionsPerWorkspace: 0,
-		ArchivedMemoryPurgeDays: 90,
-		VacuumAfterPurge:        true,
-		SubagentRetentionDays:   7,
-		ToolOutputRetentionDays: 7,
-		AgentTmpRetentionDays:   3,
-		Backup:                  defaultStorageBackupConfig(),
+		CleanupIntervalMinutes:     60,
+		RetentionDays:              90,
+		DetachedMediaRetentionDays: 30,
+		MaxSessionsPerWorkspace:    0,
+		ArchivedMemoryPurgeDays:    90,
+		VacuumAfterPurge:           true,
+		SubagentRetentionDays:      7,
+		ToolOutputRetentionDays:    7,
+		AgentTmpRetentionDays:      3,
+		Backup:                     defaultStorageBackupConfig(),
 	}
 }
 
@@ -64,6 +67,11 @@ func (s StorageConfig) BackupEnabled() bool {
 // RetentionEnabled reports whether any session retention rule is active.
 func (s StorageConfig) RetentionEnabled() bool {
 	return s.RetentionDays > 0 || s.MaxSessionsPerWorkspace > 0 || s.SubagentRetentionDays > 0
+}
+
+// DetachedMediaRetentionEnabled reports whether orphaned Gallery media should expire.
+func (s StorageConfig) DetachedMediaRetentionEnabled() bool {
+	return s.DetachedMediaRetentionDays > 0
 }
 
 // MemoryPurgeEnabled reports whether archived memory purge is active.
@@ -98,6 +106,7 @@ func (c *Config) EffectiveStorageConfig() StorageConfig {
 func (c *Config) storageConfigured() bool {
 	s := c.Storage
 	return s.RetentionDays != 0 ||
+		s.DetachedMediaRetentionDays != 0 ||
 		s.CleanupIntervalMinutes != 0 ||
 		s.MaxSessionsPerWorkspace != 0 ||
 		s.ArchivedMemoryPurgeDays != 0 ||

--- a/cometmind/internal/config/storage_test.go
+++ b/cometmind/internal/config/storage_test.go
@@ -8,6 +8,9 @@ func TestEffectiveStorageConfig_DefaultsWhenUnset(t *testing.T) {
 	if got.RetentionDays != 90 {
 		t.Fatalf("retention_days=%d want 90", got.RetentionDays)
 	}
+	if got.DetachedMediaRetentionDays != 30 {
+		t.Fatalf("detached_media_retention_days=%d want 30", got.DetachedMediaRetentionDays)
+	}
 	if got.CleanupIntervalMinutes != 60 {
 		t.Fatalf("cleanup_interval_minutes=%d want 60", got.CleanupIntervalMinutes)
 	}
@@ -81,6 +84,9 @@ func TestAdaptStorageConfig_OmittedRuntimeKeysGetDefaults(t *testing.T) {
 	if got.ToolOutputRetentionDays != 7 {
 		t.Fatalf("tool_output_retention_days=%d want 7", got.ToolOutputRetentionDays)
 	}
+	if got.DetachedMediaRetentionDays != 30 {
+		t.Fatalf("detached_media_retention_days=%d want 30", got.DetachedMediaRetentionDays)
+	}
 	if got.AgentTmpRetentionDays != 3 {
 		t.Fatalf("agent_tmp_retention_days=%d want 3", got.AgentTmpRetentionDays)
 	}
@@ -89,15 +95,19 @@ func TestAdaptStorageConfig_OmittedRuntimeKeysGetDefaults(t *testing.T) {
 func TestAdaptStorageConfig_ExplicitZeroDisables(t *testing.T) {
 	zero := 0
 	got := adaptStorageConfig(cometlineStorageJSON{
-		RetentionDays:           90,
-		VacuumAfterPurge:        true,
-		ToolOutputRetentionDays: &zero,
-		AgentTmpRetentionDays:   &zero,
+		RetentionDays:              90,
+		VacuumAfterPurge:           true,
+		ToolOutputRetentionDays:    &zero,
+		AgentTmpRetentionDays:      &zero,
+		DetachedMediaRetentionDays: &zero,
 	})
 	if got.ToolOutputRetentionDays != 0 {
 		t.Fatalf("tool_output_retention_days=%d want 0", got.ToolOutputRetentionDays)
 	}
 	if got.AgentTmpRetentionDays != 0 {
 		t.Fatalf("agent_tmp_retention_days=%d want 0", got.AgentTmpRetentionDays)
+	}
+	if got.DetachedMediaRetentionDays != 0 {
+		t.Fatalf("detached_media_retention_days=%d want 0", got.DetachedMediaRetentionDays)
 	}
 }

--- a/cometmind/internal/db/migrate.go
+++ b/cometmind/internal/db/migrate.go
@@ -630,6 +630,11 @@ var alterStatements = [][]string{
 		)`,
 		"CREATE INDEX IF NOT EXISTS idx_session_runs_updated ON session_runs (updated_at)",
 	},
+	// v34 -> v35: track when Gallery media first becomes detached from a session.
+	{
+		"ALTER TABLE session_media ADD COLUMN detached_at INTEGER NOT NULL DEFAULT 0",
+		"CREATE INDEX IF NOT EXISTS idx_session_media_detached ON session_media (session_id, status, detached_at)",
+	},
 }
 
 func isForeignKeysPragma(stmt string) bool {
@@ -788,7 +793,7 @@ func splitStatements(sql string) []string {
 	return out
 }
 
-const schemaVersion = 34
+const schemaVersion = 35
 
 // EnsureSchema runs [Migrate] once per database file using PRAGMA user_version.
 // For existing databases, it applies incremental ALTER statements to upgrade

--- a/cometmind/internal/db/migrate_test.go
+++ b/cometmind/internal/db/migrate_test.go
@@ -475,3 +475,43 @@ func TestRebuildVersionRollsBackWhenAStatementFails(t *testing.T) {
 		t.Fatalf("user_version = %d, want 29", version)
 	}
 }
+
+func TestEnsureSchemaV35AddsDetachedMediaTimestamp(t *testing.T) {
+	ctx := context.Background()
+	conn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "migrate-v34.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE session_media (
+		id TEXT PRIMARY KEY,
+		session_id TEXT,
+		status TEXT NOT NULL DEFAULT 'ready'
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(ctx, `INSERT INTO session_media (id, session_id) VALUES ('media-1', NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(ctx, `PRAGMA user_version = 34`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	var detachedAt int64
+	if err := conn.QueryRowContext(ctx, `SELECT detached_at FROM session_media WHERE id = 'media-1'`).Scan(&detachedAt); err != nil {
+		t.Fatal(err)
+	}
+	if detachedAt != 0 {
+		t.Fatalf("detached_at=%d want 0", detachedAt)
+	}
+	var version int
+	if err := conn.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("user_version=%d want %d", version, schemaVersion)
+	}
+}

--- a/cometmind/internal/db/models.go
+++ b/cometmind/internal/db/models.go
@@ -211,6 +211,7 @@ type SessionMedia struct {
 	Status           string         `json:"status"`
 	ByteSize         int64          `json:"byte_size"`
 	DurationMs       sql.NullInt64  `json:"duration_ms"`
+	DetachedAt       int64          `json:"detached_at"`
 	CreatedAt        int64          `json:"created_at"`
 }
 

--- a/cometmind/internal/db/queries/session_media.sql
+++ b/cometmind/internal/db/queries/session_media.sql
@@ -69,3 +69,19 @@ RETURNING *;
 UPDATE session_media
 SET workspace_id = ?
 WHERE session_id = ?;
+
+-- name: InitializeDetachedSessionMedia :exec
+UPDATE session_media
+SET detached_at = ?
+WHERE session_id IS NULL
+  AND status = 'ready'
+  AND detached_at = 0;
+
+-- name: ListExpiredDetachedSessionMediaIDs :many
+SELECT id
+FROM session_media
+WHERE session_id IS NULL
+  AND status = 'ready'
+  AND detached_at > 0
+  AND detached_at <= ?
+ORDER BY detached_at ASC;

--- a/cometmind/internal/db/schema.sql
+++ b/cometmind/internal/db/schema.sql
@@ -369,6 +369,7 @@ CREATE TABLE session_media (
                     CHECK (status IN ('ready', 'deleted')),
     byte_size       INTEGER NOT NULL DEFAULT 0,
     duration_ms     INTEGER,
+    detached_at     INTEGER NOT NULL DEFAULT 0,
     created_at      INTEGER NOT NULL DEFAULT (unixepoch ('now', 'subsec') * 1000)
 );
 
@@ -379,6 +380,8 @@ CREATE INDEX idx_session_media_workspace ON session_media (workspace_id, status,
 CREATE INDEX idx_session_media_session ON session_media (session_id, status, created_at DESC);
 
 CREATE INDEX idx_session_media_kind ON session_media (kind, status, created_at DESC);
+
+CREATE INDEX idx_session_media_detached ON session_media (session_id, status, detached_at);
 
 CREATE TABLE usage_events (
     id            TEXT PRIMARY KEY,

--- a/cometmind/internal/db/session_media.sql.go
+++ b/cometmind/internal/db/session_media.sql.go
@@ -29,7 +29,7 @@ INSERT INTO session_media (
     duration_ms
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+RETURNING id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 `
 
 type CreateSessionMediaParams struct {
@@ -85,13 +85,14 @@ func (q *Queries) CreateSessionMedia(ctx context.Context, arg CreateSessionMedia
 		&i.Status,
 		&i.ByteSize,
 		&i.DurationMs,
+		&i.DetachedAt,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const getReadySessionMedia = `-- name: GetReadySessionMedia :one
-SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 FROM session_media
 WHERE id = ?
   AND session_id = ?
@@ -123,13 +124,14 @@ func (q *Queries) GetReadySessionMedia(ctx context.Context, arg GetReadySessionM
 		&i.Status,
 		&i.ByteSize,
 		&i.DurationMs,
+		&i.DetachedAt,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const getSessionMedia = `-- name: GetSessionMedia :one
-SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 FROM session_media
 WHERE id = ?
 LIMIT 1
@@ -154,13 +156,60 @@ func (q *Queries) GetSessionMedia(ctx context.Context, id string) (SessionMedia,
 		&i.Status,
 		&i.ByteSize,
 		&i.DurationMs,
+		&i.DetachedAt,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
+const initializeDetachedSessionMedia = `-- name: InitializeDetachedSessionMedia :exec
+UPDATE session_media
+SET detached_at = ?
+WHERE session_id IS NULL
+  AND status = 'ready'
+  AND detached_at = 0
+`
+
+func (q *Queries) InitializeDetachedSessionMedia(ctx context.Context, detachedAt int64) error {
+	_, err := q.db.ExecContext(ctx, initializeDetachedSessionMedia, detachedAt)
+	return err
+}
+
+const listExpiredDetachedSessionMediaIDs = `-- name: ListExpiredDetachedSessionMediaIDs :many
+SELECT id
+FROM session_media
+WHERE session_id IS NULL
+  AND status = 'ready'
+  AND detached_at > 0
+  AND detached_at <= ?
+ORDER BY detached_at ASC
+`
+
+func (q *Queries) ListExpiredDetachedSessionMediaIDs(ctx context.Context, detachedAt int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listExpiredDetachedSessionMediaIDs, detachedAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSessionMedia = `-- name: ListSessionMedia :many
-SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 FROM session_media
 WHERE status = 'ready'
   AND (
@@ -209,6 +258,7 @@ func (q *Queries) ListSessionMedia(ctx context.Context, arg ListSessionMediaPara
 			&i.Status,
 			&i.ByteSize,
 			&i.DurationMs,
+			&i.DetachedAt,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -225,7 +275,7 @@ func (q *Queries) ListSessionMedia(ctx context.Context, arg ListSessionMediaPara
 }
 
 const listSessionMediaBySession = `-- name: ListSessionMediaBySession :many
-SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+SELECT id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 FROM session_media
 WHERE session_id = ?
   AND status = 'ready'
@@ -257,6 +307,7 @@ func (q *Queries) ListSessionMediaBySession(ctx context.Context, sessionID sql.N
 			&i.Status,
 			&i.ByteSize,
 			&i.DurationMs,
+			&i.DetachedAt,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -277,7 +328,7 @@ UPDATE session_media
 SET status = 'deleted'
 WHERE id = ?
   AND status = 'ready'
-RETURNING id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, created_at
+RETURNING id, session_id, storage_session_id, workspace_id, kind, media_type, alt, prompt, model, provider_id, source, source_media_id, status, byte_size, duration_ms, detached_at, created_at
 `
 
 func (q *Queries) MarkSessionMediaDeleted(ctx context.Context, id string) (SessionMedia, error) {
@@ -299,6 +350,7 @@ func (q *Queries) MarkSessionMediaDeleted(ctx context.Context, id string) (Sessi
 		&i.Status,
 		&i.ByteSize,
 		&i.DurationMs,
+		&i.DetachedAt,
 		&i.CreatedAt,
 	)
 	return i, err

--- a/cometmind/internal/retention/retention.go
+++ b/cometmind/internal/retention/retention.go
@@ -19,6 +19,7 @@ import (
 type Result struct {
 	SessionsDeleted    int
 	SubagentsDeleted   int
+	MediaDeleted       int
 	MemoriesPurged     int
 	MemoryEventsPurged int
 	JobsPurged         int
@@ -64,6 +65,14 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		out.SubagentsDeleted = sub
 	}
 
+	if cfg.DetachedMediaRetentionEnabled() {
+		n, err := r.Sessions.PurgeDetachedMedia(ctx, cfg.DetachedMediaRetentionDays)
+		if err != nil {
+			return out, err
+		}
+		out.MediaDeleted = n
+	}
+
 	if r.Memory != nil && cfg.MemoryPurgeEnabled() {
 		memories, events, err := r.Memory.PurgeArchived(ctx, cfg.ArchivedMemoryPurgeDays)
 		if err != nil {
@@ -97,7 +106,7 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		out.UsageEventsPurged = n
 	}
 
-	if cfg.VacuumAfterPurge && (out.SessionsDeleted > 0 || out.SubagentsDeleted > 0 || out.MemoriesPurged > 0 || out.JobsPurged > 0 || out.InboxPurged > 0 || out.UsageEventsPurged > 0) {
+	if cfg.VacuumAfterPurge && (out.SessionsDeleted > 0 || out.SubagentsDeleted > 0 || out.MediaDeleted > 0 || out.MemoriesPurged > 0 || out.JobsPurged > 0 || out.InboxPurged > 0 || out.UsageEventsPurged > 0) {
 		if r.VacuumAsync {
 			// VACUUM takes an exclusive lock and rewrites the whole file, so it
 			// can be slow on large databases. On startup we run it in the
@@ -116,10 +125,11 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		}
 	}
 
-	if out.SessionsDeleted > 0 || out.SubagentsDeleted > 0 || out.MemoriesPurged > 0 || out.JobsPurged > 0 || out.InboxPurged > 0 || out.UsageEventsPurged > 0 {
+	if out.SessionsDeleted > 0 || out.SubagentsDeleted > 0 || out.MediaDeleted > 0 || out.MemoriesPurged > 0 || out.JobsPurged > 0 || out.InboxPurged > 0 || out.UsageEventsPurged > 0 {
 		logging.L().Info("retention.complete",
 			"sessions_deleted", out.SessionsDeleted,
 			"subagents_deleted", out.SubagentsDeleted,
+			"media_deleted", out.MediaDeleted,
 			"memories_purged", out.MemoriesPurged,
 			"memory_events_purged", out.MemoryEventsPurged,
 			"jobs_purged", out.JobsPurged,

--- a/cometmind/internal/retention/retention_test.go
+++ b/cometmind/internal/retention/retention_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cometline/cometmind/internal/config"
 	"github.com/cometline/cometmind/internal/db"
 	"github.com/cometline/cometmind/internal/jobs"
+	"github.com/cometline/cometmind/internal/media"
 	"github.com/cometline/cometmind/internal/memory"
 	"github.com/cometline/cometmind/internal/session"
 	"github.com/cometline/cometmind/internal/usage"
@@ -160,6 +161,66 @@ func TestRunner_PurgesArchivedMemories(t *testing.T) {
 	}
 	if got.MemoriesPurged != 1 {
 		t.Fatalf("memories_purged=%d want 1", got.MemoriesPurged)
+	}
+}
+
+func TestRunner_PurgesExpiredDetachedMedia(t *testing.T) {
+	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
+	ctx := context.Background()
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := db.EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := session.New(conn)
+	ws, err := sessions.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess, err := sessions.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := media.RegisterBytes(sess.ID, "image/png", "expired", []byte("png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sessions.AppendAssistantMedia(ctx, sess.ID, []session.ContentBlock{{
+		Type: "image", ID: ref.ID, MediaType: ref.MediaType, Alt: ref.Alt,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessions.DeleteSession(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-31 * 24 * time.Hour).UnixMilli()
+	if err := db.New(conn).InitializeDetachedSessionMedia(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Runner{
+		DB:       conn,
+		Sessions: sessions,
+		Config: config.StorageConfig{
+			DetachedMediaRetentionDays: 30,
+		},
+	}).Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MediaDeleted != 1 {
+		t.Fatalf("media_deleted=%d want 1", result.MediaDeleted)
+	}
+	item, err := sessions.GetMedia(ctx, ref.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != "deleted" {
+		t.Fatalf("status=%q want deleted", item.Status)
 	}
 }
 

--- a/cometmind/internal/runtime/runtime.go
+++ b/cometmind/internal/runtime/runtime.go
@@ -195,7 +195,7 @@ func (r *Runtime) StartScheduler(ctx context.Context) {
 
 func runRetention(ctx context.Context, db *sql.DB, sessions *session.Service, mem *memory.Service, jobSvc *jobs.Service, inboxSvc *inbox.Service, usageSvc *usage.Service, cfg config.StorageConfig, inboxCfg config.InboxConfig, jobPurgeDays int, isRunning func(string) bool) (retention.Result, error) {
 	var out retention.Result
-	needDB := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || jobPurgeDays > 0 || inboxSvc != nil || usageSvc != nil
+	needDB := cfg.RetentionEnabled() || cfg.DetachedMediaRetentionEnabled() || cfg.MemoryPurgeEnabled() || jobPurgeDays > 0 || inboxSvc != nil || usageSvc != nil
 	if needDB {
 		rr := &retention.Runner{
 			DB:           db,
@@ -355,7 +355,7 @@ func (r *Runtime) StartRetentionMaintenance(ctx context.Context) {
 		for {
 			if !waitForMaintenance(ctx, r.retentionChanged, func() (bool, time.Duration) {
 				cfg := r.Config.EffectiveStorageConfig()
-				enabled := cfg.RetentionEnabled() || cfg.MemoryPurgeEnabled() || r.jobSettingsSnapshot().DeletedPurgeDays > 0 || cfg.RuntimeFilesEnabled() || r.Usage != nil
+				enabled := cfg.RetentionEnabled() || cfg.DetachedMediaRetentionEnabled() || cfg.MemoryPurgeEnabled() || r.jobSettingsSnapshot().DeletedPurgeDays > 0 || cfg.RuntimeFilesEnabled() || r.Usage != nil
 				interval := time.Duration(cfg.CleanupIntervalMinutes) * time.Minute
 				if interval <= 0 {
 					interval = time.Hour
@@ -369,10 +369,11 @@ func (r *Runtime) StartRetentionMaintenance(ctx context.Context) {
 				logging.L().Warn("retention.failed", "error", err)
 				continue
 			}
-			if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 || result.InboxPurged > 0 || result.UsageEventsPurged > 0 || result.ToolOutputDeleted > 0 || result.AgentTmpDeleted > 0 {
+			if result.SessionsDeleted > 0 || result.SubagentsDeleted > 0 || result.MediaDeleted > 0 || result.MemoriesPurged > 0 || result.MemoryEventsPurged > 0 || result.JobsPurged > 0 || result.InboxPurged > 0 || result.UsageEventsPurged > 0 || result.ToolOutputDeleted > 0 || result.AgentTmpDeleted > 0 {
 				logging.L().Info("retention.completed",
 					"sessions_deleted", result.SessionsDeleted,
 					"subagents_deleted", result.SubagentsDeleted,
+					"media_deleted", result.MediaDeleted,
 					"memories_purged", result.MemoriesPurged,
 					"memory_events_purged", result.MemoryEventsPurged,
 					"jobs_purged", result.JobsPurged,

--- a/cometmind/internal/session/fork_test.go
+++ b/cometmind/internal/session/fork_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cometsdk "github.com/cometline/comet-sdk"
 	"github.com/cometline/cometmind/internal/db"
@@ -361,7 +362,7 @@ func TestListMediaBackfillsGeneratedSourceFromToolResult(t *testing.T) {
 func TestDeleteSessionKeepsGalleryMedia(t *testing.T) {
 	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
 	ctx := context.Background()
-	svc, _ := newForkTestService(t)
+	svc, q := newForkTestService(t)
 	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -383,6 +384,20 @@ func TestDeleteSessionKeepsGalleryMedia(t *testing.T) {
 
 	if err := svc.DeleteSession(ctx, sess.ID); err != nil {
 		t.Fatalf("DeleteSession: %v", err)
+	}
+	deleted, err := svc.PurgeDetachedMedia(ctx, 30)
+	if err != nil {
+		t.Fatalf("PurgeDetachedMedia: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("first purge deleted %d media, want grace period", deleted)
+	}
+	detachedRow, err := q.GetSessionMedia(ctx, ref.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detachedRow.DetachedAt <= 0 {
+		t.Fatalf("detached_at=%d want initialized timestamp", detachedRow.DetachedAt)
 	}
 
 	listed, err := svc.ListMedia(ctx, MediaListFilter{})
@@ -450,5 +465,67 @@ func TestClearSessionTranscriptKeepsGalleryMedia(t *testing.T) {
 	}
 	if _, data, err := media.Read(sess.ID, ref.ID); err != nil || string(data) != string(png) {
 		t.Fatalf("file should survive transcript clear: %v", err)
+	}
+}
+
+func TestPurgeDetachedMediaDeletesExpiredFilesAndKeepsAttachedMedia(t *testing.T) {
+	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
+	ctx := context.Background()
+	svc, q := newForkTestService(t)
+	ws, err := svc.EnsureWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	detachedSession, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attachedSession, err := svc.NewSession(ctx, ws.ID, "model", "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	detachedRef, err := media.RegisterBytes(detachedSession.ID, "image/png", "detached", png)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.AppendAssistantMedia(ctx, detachedSession.ID, []ContentBlock{{
+		Type: "image", ID: detachedRef.ID, MediaType: detachedRef.MediaType, Alt: detachedRef.Alt,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	attachedRef, err := media.RegisterBytes(attachedSession.ID, "image/png", "attached", png)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.AppendAssistantMedia(ctx, attachedSession.ID, []ContentBlock{{
+		Type: "image", ID: attachedRef.ID, MediaType: attachedRef.MediaType, Alt: attachedRef.Alt,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.DeleteSession(ctx, detachedSession.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	old := time.Now().Add(-31 * 24 * time.Hour).UnixMilli()
+	if err := q.InitializeDetachedSessionMedia(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := svc.PurgeDetachedMedia(ctx, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expired purge deleted %d media, want 1", deleted)
+	}
+	if _, _, err := media.Read(detachedSession.ID, detachedRef.ID); !errors.Is(err, media.ErrNotFound) {
+		t.Fatalf("detached file still exists: %v", err)
+	}
+	attachedRow, err := q.GetSessionMedia(ctx, attachedRef.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attachedRow.Status != "ready" || attachedRow.DetachedAt != 0 {
+		t.Fatalf("attached row changed: %#v", attachedRow)
 	}
 }

--- a/cometmind/internal/session/service.go
+++ b/cometmind/internal/session/service.go
@@ -1422,6 +1422,30 @@ func (s *Service) DeleteMedia(ctx context.Context, mediaID string) (MediaRecord,
 	return mediaRecordFromDB(updated), nil
 }
 
+// PurgeDetachedMedia deletes files whose owning session has been gone past the retention window.
+func (s *Service) PurgeDetachedMedia(ctx context.Context, retentionDays int) (int, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+	now := time.Now()
+	if err := s.q.InitializeDetachedSessionMedia(ctx, now.UnixMilli()); err != nil {
+		return 0, err
+	}
+	cutoff := now.Add(-time.Duration(retentionDays) * 24 * time.Hour).UnixMilli()
+	ids, err := s.q.ListExpiredDetachedSessionMediaIDs(ctx, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, mediaID := range ids {
+		if _, err := s.DeleteMedia(ctx, mediaID); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
 func mediaRecordFromDB(row db.SessionMedia) MediaRecord {
 	var duration *int64
 	if row.DurationMs.Valid {


### PR DESCRIPTION
## Background

Gallery media survives chat deletion indefinitely, and deleting it always requires confirmation. Detached media now follows configurable retention while users can independently control Gallery delete confirmations.

[5ba881f](https://github.com/Cometline/cometline/commit/5ba881f70f3117514497270bd2815c4d33b53d19): Adds detached-media timestamps, a configurable 30-day retention policy, scheduled cleanup, and coverage for migration, grace-period, expiry, and attached-media behavior.

[10b5055](https://github.com/Cometline/cometline/commit/10b5055a09e092dc57acd88b655fd2a4f8a9994a): Adds Gallery deletion controls, including a separate confirmation preference, a Don't ask again action, retention settings, and frontend coverage.

[089aaf4](https://github.com/Cometline/cometline/commit/089aaf4f7ec5c0b957145cd9dd3ea7f693897fff): Documents the detached-media lifecycle and retention behavior across the project architecture references.