### PR TITLE
[main] fix: stop dual-window remount and terminal focus steal

### DIFF
--- a/cometline/src/lib/components/ChatView.svelte
+++ b/cometline/src/lib/components/ChatView.svelte
@@ -25,6 +25,7 @@
 	import { startJobInSession } from '$lib/jobs/start-job-in-chat';
 	import type { JobResource } from '$lib/client/cometmind';
 	import { createChatViewController } from '$lib/conversation/chat-view-controller.svelte';
+	import { shouldApplyComposerFocus } from '$lib/conversation/composer-focus';
 	import { PanelLeftClose, PanelLeftOpen } from '@lucide/svelte';
 	import { miniShellStore } from '$lib/stores/mini-shell.svelte';
 	import { composerHistoryStore } from '$lib/stores/composer-history.svelte';
@@ -161,6 +162,7 @@
 	let composerVariant = $derived(chatView.composerVariant);
 	let heroLayout = $derived(chatView.heroLayout);
 	let composerFocusRequest = $derived(shellStore.composerFocusRequest);
+	let lastAppliedComposerFocusId = $state(0);
 	let sessionRunActive = $derived(
 		chatStore.isStreamingFor(sessionId) ||
 			(sessionStore.sessions.find((session) => session.id === sessionId)?.running ?? false)
@@ -272,11 +274,16 @@
 
 	$effect(() => {
 		if (
-			!composerFocusRequest.id ||
-			composerFocusRequest.sessionId !== sessionId ||
-			shellStore.focusedPane !== 'chat'
+			!shouldApplyComposerFocus({
+				requestId: composerFocusRequest.id,
+				requestSessionId: composerFocusRequest.sessionId,
+				sessionId,
+				focusedPane: shellStore.focusedPane,
+				lastAppliedRequestId: lastAppliedComposerFocusId
+			})
 		)
 			return;
+		lastAppliedComposerFocusId = composerFocusRequest.id;
 		composerRef?.focus();
 	});
 

--- a/cometline/src/lib/conversation/composer-focus.test.ts
+++ b/cometline/src/lib/conversation/composer-focus.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldApplyComposerFocus } from './composer-focus';
+
+const base = {
+	requestId: 3,
+	requestSessionId: 'sess-1',
+	sessionId: 'sess-1',
+	focusedPane: 'chat' as const,
+	lastAppliedRequestId: 2
+};
+
+describe('shouldApplyComposerFocus', () => {
+	it('applies a new request for the open session on the chat pane', () => {
+		expect(shouldApplyComposerFocus(base)).toBe(true);
+	});
+
+	it('ignores a leftover request while the terminal is focused', () => {
+		expect(shouldApplyComposerFocus({ ...base, focusedPane: 'terminal' })).toBe(false);
+	});
+
+	it('does not refocus when only the composer instance identity changed', () => {
+		expect(shouldApplyComposerFocus({ ...base, lastAppliedRequestId: 3 })).toBe(false);
+	});
+
+	it('ignores a request aimed at another session', () => {
+		expect(shouldApplyComposerFocus({ ...base, requestSessionId: 'sess-2' })).toBe(false);
+	});
+});

--- a/cometline/src/lib/conversation/composer-focus.ts
+++ b/cometline/src/lib/conversation/composer-focus.ts
@@ -1,0 +1,15 @@
+export type ComposerFocusPane = 'chat' | 'web' | 'terminal';
+
+export function shouldApplyComposerFocus(opts: {
+	requestId: number;
+	requestSessionId: string | null;
+	sessionId: string;
+	focusedPane: ComposerFocusPane;
+	lastAppliedRequestId: number;
+}): boolean {
+	if (!opts.requestId) return false;
+	if (opts.requestSessionId !== opts.sessionId) return false;
+	if (opts.focusedPane !== 'chat') return false;
+	if (opts.requestId === opts.lastAppliedRequestId) return false;
+	return true;
+}

--- a/cometline/src/lib/sessions/session-runtime-events.test.ts
+++ b/cometline/src/lib/sessions/session-runtime-events.test.ts
@@ -32,7 +32,8 @@ function deps(): SessionRuntimeEventDeps {
 		refreshTranscript: vi.fn().mockResolvedValue(undefined),
 		resumeRun: vi.fn().mockResolvedValue(undefined),
 		refreshSession: vi.fn().mockResolvedValue(session('session-1')),
-		updateSession: vi.fn()
+		updateSession: vi.fn(),
+		isStreamingFor: vi.fn().mockReturnValue(false)
 	};
 }
 
@@ -61,6 +62,18 @@ describe('applySessionRuntimeEvent', () => {
 		await applySessionRuntimeEvent({ type: 'run_started', session_id: 'session-1' }, target);
 
 		expect(order).toEqual(['refresh', 'resume']);
+	});
+
+	it('does not attach when this window already has a live stream', async () => {
+		const target = deps();
+		vi.mocked(target.getActiveSessionId).mockReturnValue('session-1');
+		vi.mocked(target.isStreamingFor!).mockReturnValue(true);
+
+		await applySessionRuntimeEvent({ type: 'run_started', session_id: 'session-1' }, target);
+
+		expect(target.setRunning).toHaveBeenCalledWith('session-1', true);
+		expect(target.refreshTranscript).not.toHaveBeenCalled();
+		expect(target.resumeRun).not.toHaveBeenCalled();
 	});
 
 	it('does not follow a run for a session that is not open', async () => {
@@ -114,6 +127,21 @@ describe('reconcileActiveSession', () => {
 		);
 		expect(target.refreshTranscript).toHaveBeenCalledWith('session-1');
 		expect(target.resumeRun).toHaveBeenCalledWith('session-1');
+	});
+
+	it('does not attach a second stream when the session is already live', async () => {
+		const target = deps();
+		vi.mocked(target.getActiveSessionId).mockReturnValue('session-1');
+		vi.mocked(target.refreshSession).mockResolvedValue({
+			...session('session-1'),
+			running: true
+		});
+		vi.mocked(target.isStreamingFor!).mockReturnValue(true);
+
+		await reconcileActiveSession(target);
+
+		expect(target.refreshTranscript).not.toHaveBeenCalled();
+		expect(target.resumeRun).not.toHaveBeenCalled();
 	});
 
 	it('does nothing when no session is open', async () => {

--- a/cometline/src/lib/sessions/session-runtime-events.ts
+++ b/cometline/src/lib/sessions/session-runtime-events.ts
@@ -7,6 +7,7 @@ export interface SessionRuntimeEventDeps {
 	resumeRun: (sessionId: string) => Promise<void>;
 	refreshSession: (sessionId: string) => Promise<Session>;
 	updateSession: (session: Session) => void;
+	isStreamingFor?: (sessionId: string) => boolean;
 }
 
 export async function applySessionRuntimeEvent(
@@ -15,17 +16,17 @@ export async function applySessionRuntimeEvent(
 ): Promise<boolean> {
 	if (event.type === 'run_started') {
 		deps.setRunning(event.session_id, true);
-		if (deps.getActiveSessionId() === event.session_id) {
-			await deps.refreshTranscript(event.session_id);
-			await deps.resumeRun(event.session_id);
-		}
+		if (deps.getActiveSessionId() !== event.session_id) return true;
+		if (deps.isStreamingFor?.(event.session_id)) return true;
+		await deps.refreshTranscript(event.session_id);
+		await deps.resumeRun(event.session_id);
 		return true;
 	}
 	if (event.type === 'run_finished') {
 		deps.setRunning(event.session_id, false);
-		if (deps.getActiveSessionId() === event.session_id) {
-			await deps.refreshTranscript(event.session_id);
-		}
+		if (deps.getActiveSessionId() !== event.session_id) return true;
+		if (deps.isStreamingFor?.(event.session_id)) return true;
+		await deps.refreshTranscript(event.session_id);
 		return true;
 	}
 	if (event.type !== 'session_cleared') return false;
@@ -45,6 +46,7 @@ export async function reconcileActiveSession(deps: SessionRuntimeEventDeps): Pro
 	const latest = await deps.refreshSession(sessionId);
 	if (deps.getActiveSessionId() !== sessionId) return false;
 	deps.updateSession(latest);
+	if (deps.isStreamingFor?.(sessionId)) return true;
 	await deps.refreshTranscript(sessionId);
 	if (latest.running) {
 		void deps.resumeRun(sessionId).catch(() => undefined);

--- a/cometline/src/lib/stores/chat.svelte.test.ts
+++ b/cometline/src/lib/stores/chat.svelte.test.ts
@@ -39,6 +39,7 @@ import { chatStore, revealRemoteUserItems } from './chat.svelte';
 import { sessionStore } from './session.svelte';
 import { unreadSessionOutputStore } from './unread-session-output.svelte';
 import { startNewChat } from '$lib/actions/new-chat';
+import { deliverWindowSyncFromPeer } from '$lib/window-sync';
 
 async function flushAnimationFrames() {
 	await new Promise<void>((resolve) => {
@@ -508,6 +509,68 @@ describe('chatStore session switching', () => {
 		expect(vi.mocked(streamMessage)).toHaveBeenCalledTimes(1);
 
 		releaseA!();
+	});
+
+	it('does not replace a local live stream with a peer window snapshot', async () => {
+		let release: (() => void) | undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		vi.mocked(streamMessage).mockImplementation(async function* () {
+			yield { type: 'text_delta', delta: 'hello ' };
+			await gate;
+			yield { type: 'text_delta', delta: 'world' };
+			yield { type: 'done' };
+		});
+
+		chatStore.bindSession('sess-a');
+		void chatStore.send('sess-a', 'prompt');
+		await waitForStore(() =>
+			chatStore.items.some(
+				(item) => item.type === 'assistant' && item.text.includes('hello')
+			)
+		);
+
+		const live = chatStore.items.find((item) => item.type === 'assistant');
+		expect(live?.id).toBeTruthy();
+
+		deliverWindowSyncFromPeer({
+			type: 'chat-items',
+			sessionId: 'sess-a',
+			items: [
+				{ id: 'history-0', type: 'user', text: 'prompt' },
+				{
+					id: 'history-assistant-1',
+					type: 'assistant',
+					text: 'hel',
+					pending: true
+				}
+			]
+		});
+
+		const after = chatStore.items.find((item) => item.type === 'assistant');
+		expect(after?.id).toBe(live?.id);
+		expect(after?.text).toContain('hello');
+
+		release!();
+	});
+
+	it('applies peer window snapshots when this window is not streaming', () => {
+		chatStore.bindSession('sess-a');
+		deliverWindowSyncFromPeer({
+			type: 'chat-items',
+			sessionId: 'sess-a',
+			items: [{ id: 'peer-user', type: 'user', text: 'from peer', reveal: false }]
+		});
+
+		expect(chatStore.items).toEqual([
+			expect.objectContaining({
+				id: 'peer-user',
+				type: 'user',
+				text: 'from peer',
+				reveal: true
+			})
+		]);
 	});
 
 	it('replays and follows an already-running session', async () => {

--- a/cometline/src/lib/stores/chat.svelte.ts
+++ b/cometline/src/lib/stores/chat.svelte.ts
@@ -664,8 +664,8 @@ function createChatStore() {
 		}
 
 		const contexts = messageContextRefsFromWebContexts(payload.webContexts);
-		if (!opts?.skipUser) addUserToSession(nextSessionID, displayText, images, true, contexts);
 		markStreaming(nextSessionID, handle);
+		if (!opts?.skipUser) addUserToSession(nextSessionID, displayText, images, true, contexts);
 
 		const ctx = handle.ctx;
 		const preId = localID('assistant');
@@ -913,6 +913,7 @@ function createChatStore() {
 	if (browser) {
 		subscribeWindowSync((message) => {
 			if (message.type === 'chat-items') {
+				if (streamHandles.has(message.sessionId)) return;
 				// Flight visibility belongs to the sending renderer. Other windows have
 				// no matching particle, so render their copy immediately.
 				writeSessionItems(message.sessionId, revealRemoteUserItems(message.items), {

--- a/cometline/src/lib/stores/shell.svelte.test.ts
+++ b/cometline/src/lib/stores/shell.svelte.test.ts
@@ -475,6 +475,17 @@ describe('shellStore terminal panel visibility', () => {
 		shellStore.clearWorkspacePanelForSession('sess-1');
 	});
 
+	it('keeps the terminal pane focused across active-session churn', () => {
+		shellStore.openTerminalPanel();
+		expect(shellStore.focusedPane).toBe('terminal');
+
+		shellStore.onActiveSessionChange();
+
+		expect(shellStore.focusedPane).toBe('terminal');
+		expect(shellStore.terminalPanelOpen).toBe(true);
+		shellStore.clearWorkspacePanelForSession('sess-1');
+	});
+
 	it('closes the active terminal panel when its shell exits', () => {
 		shellStore.openTerminalPanel();
 

--- a/cometline/src/lib/stores/shell.svelte.ts
+++ b/cometline/src/lib/stores/shell.svelte.ts
@@ -873,7 +873,16 @@ function createShellStore() {
 			sessionFindRequestId += 1;
 		},
 		onActiveSessionChange() {
-			focusedPane = 'chat';
+			const sessionId = activeSessionId();
+			if (
+				sessionId &&
+				workspacePanelSurfaceBySession[sessionId] === 'terminal' &&
+				terminalPanelsBySession[sessionId]
+			) {
+				focusedPane = 'terminal';
+			} else {
+				focusedPane = 'chat';
+			}
 			syncWorkspacePanelOpenForActiveSession();
 		},
 		openWorkspacePanelUrl(url: string, sessionId: string) {

--- a/cometline/src/lib/window-sync.ts
+++ b/cometline/src/lib/window-sync.ts
@@ -53,3 +53,12 @@ export function subscribeWindowSync(listener: (message: SyncMessage) => void) {
 	listeners.add(listener);
 	return () => listeners.delete(listener);
 }
+
+/** Deliver a payload as if it came from another renderer. Tests only. */
+export function deliverWindowSyncFromPeer(message: SyncPayload) {
+	const syncMessage = cloneForWindowSync({ source: 'peer-window', ...message });
+	if (!syncMessage) return;
+	for (const listener of listeners) {
+		listener(syncMessage);
+	}
+}

--- a/cometline/src/routes/+layout.svelte
+++ b/cometline/src/routes/+layout.svelte
@@ -54,7 +54,8 @@
 			refreshTranscript: chatStore.refreshTranscript,
 			resumeRun: chatStore.resumeRun,
 			refreshSession: getSession,
-			updateSession: sessionStore.updateSession
+			updateSession: sessionStore.updateSession,
+			isStreamingFor: chatStore.isStreamingFor
 		};
 		const stopRuntimeEvents = startRuntimeEventStream((event) => {
 			void applySessionRuntimeEvent(event, runtimeEventDeps);


### PR DESCRIPTION
## Background

Mini and main windows each attach to the same session run, then overwrite each other with snapshots that use different item ids, so the assistant bubble remounts mid-stream. A leftover composer focus request also steals the caret from the terminal whenever session store churn flips the pane back to chat.

[1e204ab](https://github.com/Cometline/cometline/commit/1e204ab9b6027aeae5f454e81d4ebbd9397f54c9): A window that already has a live stream no longer calls refresh or resume on run lifecycle events, and peer `chat-items` are ignored while this renderer owns the SSE handle.

[567b03f](https://github.com/Cometline/cometline/commit/567b03f85ce1dfca53c3d2a76397b8ffcdcd13b6): Session churn keeps the terminal pane focused when that surface is still open, and composer focus applies only once per request id so a remount cannot steal the caret.