### PR TITLE
[main] feat: share terminal env with the chat agent

### DIFF
--- a/cometline/electron/resources/shell-integration/bash/integration.bash
+++ b/cometline/electron/resources/shell-integration/bash/integration.bash
@@ -1,0 +1,33 @@
+_cometline_dump_env() {
+	local dir="${COMETLINE_ENV_DIR:-}"
+	[[ -n "$dir" ]] || return 0
+	(
+		umask 077
+		mkdir -p "$dir" || exit 1
+		local tmp="$dir/environ.tmp"
+		: >"$tmp" || exit 1
+		local key
+		if command -v compgen >/dev/null 2>&1; then
+			while IFS= read -r key; do
+				[[ -n "$key" ]] || continue
+				printf '%s=%s\0' "$key" "${!key}" >>"$tmp" || exit 1
+			done < <(compgen -e)
+		else
+			exit 1
+		fi
+		chmod 600 "$tmp" || true
+		mv -f "$tmp" "$dir/environ" || exit 1
+		chmod 600 "$dir/environ" || true
+	)
+}
+
+case ";${PROMPT_COMMAND-};" in
+	*";_cometline_dump_env;"*) ;;
+	*)
+		if [[ -n "${PROMPT_COMMAND-}" ]]; then
+			PROMPT_COMMAND="_cometline_dump_env; ${PROMPT_COMMAND}"
+		else
+			PROMPT_COMMAND="_cometline_dump_env"
+		fi
+		;;
+esac

--- a/cometline/electron/resources/shell-integration/zsh/integration.zsh
+++ b/cometline/electron/resources/shell-integration/zsh/integration.zsh
@@ -1,0 +1,29 @@
+if [[ -o interactive ]]; then
+	autoload -Uz add-zsh-hook 2>/dev/null || true
+fi
+
+_cometline_dump_env() {
+	emulate -L zsh
+	setopt no_nomatch
+	local dir="${COMETLINE_ENV_DIR:-}"
+	[[ -n "$dir" ]] || return 0
+	(
+		umask 077
+		command mkdir -p "$dir" || exit 1
+		local tmp="$dir/environ.tmp"
+		: >|"$tmp" || exit 1
+		local key
+		for key in ${(k)parameters}; do
+			[[ ${(Pt)key} == *export* ]] || continue
+			printf '%s=%s\0' "$key" "${(P)key}" >>"$tmp" || exit 1
+		done
+		command chmod 600 "$tmp" || true
+		command mv -f "$tmp" "$dir/environ" || exit 1
+		command chmod 600 "$dir/environ" || true
+	)
+}
+
+if [[ -o interactive ]] && typeset -f add-zsh-hook >/dev/null; then
+	add-zsh-hook -d precmd _cometline_dump_env 2>/dev/null || true
+	add-zsh-hook precmd _cometline_dump_env
+fi

--- a/cometline/electron/src/domains/terminal-env.test.ts
+++ b/cometline/electron/src/domains/terminal-env.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	bashRcPath,
+	clearAllTerminalEnv,
+	cometmindDataDir,
+	integrationScriptPath,
+	isValidSessionId,
+	prepareEnvDir,
+	shellIntegrationRoot,
+	shellKind,
+	shSingleQuote,
+	spawnArgs,
+	terminalEnvDir,
+	writeBashRc,
+	writeZshDotDir,
+	zshDotDir
+} from './terminal-env.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		fs.rmSync(directory, { force: true, recursive: true });
+	}
+});
+
+describe('terminal-env', () => {
+	it('accepts path-safe session ids', () => {
+		expect(isValidSessionId('01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(true);
+		expect(isValidSessionId('../etc')).toBe(false);
+		expect(isValidSessionId('a/b')).toBe(false);
+	});
+
+	it('uses COMETMIND_DATA_DIR when set', () => {
+		expect(cometmindDataDir({ COMETMIND_DATA_DIR: '/tmp/state' }, '/Users/me')).toBe(
+			'/tmp/state'
+		);
+		expect(cometmindDataDir({}, '/Users/me')).toBe(path.join('/Users/me', '.cometmind'));
+	});
+
+	it('prepares a session env directory', () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-term-env-'));
+		temporaryDirectories.push(home);
+		const env = { COMETMIND_DATA_DIR: path.join(home, 'state') };
+		const dir = prepareEnvDir('sess1', env, home);
+		expect(fs.statSync(dir).isDirectory()).toBe(true);
+	});
+
+	it('writes zsh wrappers that source the integration script', () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-term-env-'));
+		temporaryDirectories.push(home);
+		const envDir = path.join(home, 'env');
+		fs.mkdirSync(envDir);
+		const script = path.join(home, 'integration.zsh');
+		fs.writeFileSync(script, '');
+		const zdot = writeZshDotDir(envDir, script);
+		expect(zdot).toBe(zshDotDir(envDir));
+		const zshrc = fs.readFileSync(path.join(zdot, '.zshrc'), 'utf8');
+		expect(zshrc).toContain(`source '${script}'`);
+		expect(fs.existsSync(path.join(zdot, '.zshenv'))).toBe(true);
+		expect(fs.readFileSync(path.join(zdot, '.zprofile'), 'utf8')).toContain('.zprofile');
+	});
+
+	it('writes a bash rc wrapper instead of a typed source command', () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-term-env-'));
+		temporaryDirectories.push(home);
+		const envDir = path.join(home, 'env');
+		const script = path.join(home, 'integration.bash');
+		fs.writeFileSync(script, '');
+		const rc = writeBashRc(envDir, script);
+		expect(rc).toBe(bashRcPath(envDir));
+		expect(fs.readFileSync(rc, 'utf8')).toContain(`. '${script}'`);
+		expect(spawnArgs('bash', rc)).toEqual(['-i', '--rcfile', rc]);
+		expect(spawnArgs('zsh', null)).toEqual(['-l']);
+	});
+
+	it('quotes shell paths', () => {
+		expect(shSingleQuote("it's")).toBe(`'it'\\''s'`);
+	});
+
+	it('resolves zsh vs bash integration scripts', () => {
+		expect(shellKind('/bin/zsh')).toBe('zsh');
+		expect(shellKind('/opt/homebrew/bin/bash')).toBe('bash');
+		expect(integrationScriptPath('/res', '/bin/zsh')).toBe(
+			path.join('/res', 'zsh', 'integration.zsh')
+		);
+		expect(integrationScriptPath('/res', '/bin/bash')).toBe(
+			path.join('/res', 'bash', 'integration.bash')
+		);
+		expect(integrationScriptPath('/res', '/bin/fish')).toBe('');
+		expect(shellIntegrationRoot(true, '/Resources', '/app')).toBe(
+			path.join('/Resources', 'shell-integration')
+		);
+		expect(shellIntegrationRoot(false, '/Resources', '/app')).toBe(
+			path.join('/app', 'electron/resources/shell-integration')
+		);
+	});
+
+	it('clears all session env dirs', () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cometline-term-env-'));
+		temporaryDirectories.push(home);
+		const env = { COMETMIND_DATA_DIR: path.join(home, 'state') };
+		prepareEnvDir('sess1', env, home);
+		clearAllTerminalEnv(env, home);
+		expect(fs.existsSync(terminalEnvDir('sess1', env, home))).toBe(false);
+	});
+});

--- a/cometline/electron/src/domains/terminal-env.ts
+++ b/cometline/electron/src/domains/terminal-env.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+export type ShellKind = 'zsh' | 'bash' | 'other';
+
+export function isValidSessionId(id: string) {
+	return SESSION_ID_RE.test(id);
+}
+
+export function cometmindDataDir(env: NodeJS.ProcessEnv = process.env, home = os.homedir()) {
+	const override = env.COMETMIND_DATA_DIR?.trim();
+	if (override) return override;
+	return path.join(home, '.cometmind');
+}
+
+export function terminalEnvDir(
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+	home = os.homedir()
+) {
+	if (!isValidSessionId(sessionId)) throw new Error('Invalid terminal session id');
+	return path.join(cometmindDataDir(env, home), 'terminal-env', sessionId);
+}
+
+export function shellIntegrationRoot(packaged: boolean, resourcesPath: string, appPath: string) {
+	if (packaged) return path.join(resourcesPath, 'shell-integration');
+	return path.join(appPath, 'electron/resources/shell-integration');
+}
+
+export function shellKind(shellPath: string): ShellKind {
+	const name = path.basename(shellPath).toLowerCase();
+	if (name === 'zsh' || name.endsWith('zsh')) return 'zsh';
+	if (name === 'bash' || name.endsWith('bash')) return 'bash';
+	return 'other';
+}
+
+export function integrationScriptPath(root: string, shellPath: string) {
+	switch (shellKind(shellPath)) {
+		case 'zsh':
+			return path.join(root, 'zsh', 'integration.zsh');
+		case 'bash':
+			return path.join(root, 'bash', 'integration.bash');
+		default:
+			return '';
+	}
+}
+
+export function zshDotDir(envDir: string) {
+	return path.join(envDir, 'zdot');
+}
+
+export function bashRcPath(envDir: string) {
+	return path.join(envDir, 'bashrc');
+}
+
+export function shSingleQuote(value: string) {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function sourceUserZshFile(filename: string, restoreOurZdot: boolean) {
+	const restore = restoreOurZdot
+		? `if [[ -n "\${COMETLINE_ZDOTDIR-}" ]]; then
+	ZDOTDIR="\${COMETLINE_ZDOTDIR}"
+fi
+`
+		: `if [[ -n "\${COMETLINE_USER_ZDOTDIR-}" ]]; then
+	ZDOTDIR="\${COMETLINE_USER_ZDOTDIR}"
+else
+	unset ZDOTDIR
+fi
+`;
+	return `_cometline_user_zdotdir="\${COMETLINE_USER_ZDOTDIR:-\${HOME}}"
+if [[ -f "\${_cometline_user_zdotdir}/${filename}" ]]; then
+	ZDOTDIR="\${_cometline_user_zdotdir}"
+	source "\${_cometline_user_zdotdir}/${filename}"
+fi
+${restore}unset _cometline_user_zdotdir
+`;
+}
+
+export function writeZshDotDir(envDir: string, integrationPath: string) {
+	const zdot = zshDotDir(envDir);
+	fs.mkdirSync(zdot, { recursive: true, mode: 0o700 });
+	const quoted = shSingleQuote(integrationPath);
+	const sourceIntegration = `[[ -f ${quoted} ]] && source ${quoted}\n`;
+	fs.writeFileSync(
+		path.join(zdot, '.zshenv'),
+		`if [[ -n "\${COMETLINE_ZSHENV_SOURCED-}" ]]; then
+	return
+fi
+COMETLINE_ZSHENV_SOURCED=1
+: "\${COMETLINE_ZDOTDIR:=\${ZDOTDIR:-}}"
+if [[ -n "\${COMETLINE_USER_ZDOTDIR-}" && -f "\${COMETLINE_USER_ZDOTDIR}/.zshenv" ]]; then
+	ZDOTDIR="\${COMETLINE_USER_ZDOTDIR}"
+	source "\${COMETLINE_USER_ZDOTDIR}/.zshenv"
+elif [[ -z "\${COMETLINE_USER_ZDOTDIR-}" && -f "\${HOME}/.zshenv" ]]; then
+	unset ZDOTDIR
+	source "\${HOME}/.zshenv"
+fi
+if [[ -n "\${COMETLINE_ZDOTDIR-}" ]]; then
+	ZDOTDIR="\${COMETLINE_ZDOTDIR}"
+fi
+`,
+		{ mode: 0o600 }
+	);
+	fs.writeFileSync(path.join(zdot, '.zprofile'), sourceUserZshFile('.zprofile', true), {
+		mode: 0o600
+	});
+	fs.writeFileSync(
+		path.join(zdot, '.zshrc'),
+		`${sourceIntegration}${sourceUserZshFile('.zshrc', false)}${sourceIntegration}`,
+		{ mode: 0o600 }
+	);
+	fs.writeFileSync(path.join(zdot, '.zlogin'), sourceUserZshFile('.zlogin', false), {
+		mode: 0o600
+	});
+	return zdot;
+}
+
+export function writeBashRc(envDir: string, integrationPath: string) {
+	const rc = bashRcPath(envDir);
+	fs.mkdirSync(envDir, { recursive: true, mode: 0o700 });
+	const quoted = shSingleQuote(integrationPath);
+	fs.writeFileSync(
+		rc,
+		`if [ -f /etc/profile ]; then . /etc/profile; fi
+if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile"
+elif [ -f "$HOME/.bash_login" ]; then . "$HOME/.bash_login"
+elif [ -f "$HOME/.profile" ]; then . "$HOME/.profile"
+fi
+if [ -f ${quoted} ]; then . ${quoted}; fi
+`,
+		{ mode: 0o600 }
+	);
+	return rc;
+}
+
+export function prepareEnvDir(
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+	home = os.homedir()
+) {
+	const dir = terminalEnvDir(sessionId, env, home);
+	fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+	return dir;
+}
+
+export function removeTerminalEnvDir(
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+	home = os.homedir()
+) {
+	if (!isValidSessionId(sessionId)) return;
+	fs.rmSync(terminalEnvDir(sessionId, env, home), { force: true, recursive: true });
+}
+
+export function clearAllTerminalEnv(env: NodeJS.ProcessEnv = process.env, home = os.homedir()) {
+	const root = path.join(cometmindDataDir(env, home), 'terminal-env');
+	fs.rmSync(root, { force: true, recursive: true });
+}
+
+export function spawnArgs(kind: ShellKind, bashRc: string | null): string[] {
+	if (kind === 'bash' && bashRc) return ['-i', '--rcfile', bashRc];
+	return ['-l'];
+}

--- a/cometline/electron/src/domains/terminal.ts
+++ b/cometline/electron/src/domains/terminal.ts
@@ -1,8 +1,22 @@
-import { BrowserWindow, type IpcMainInvokeEvent } from 'electron';
+import { app, BrowserWindow, type IpcMainInvokeEvent } from 'electron';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import pty, { type IPty } from 'node-pty';
+
+import {
+	clearAllTerminalEnv,
+	integrationScriptPath,
+	prepareEnvDir,
+	removeTerminalEnvDir,
+	SESSION_ID_RE,
+	shellIntegrationRoot,
+	shellKind,
+	spawnArgs,
+	writeBashRc,
+	writeZshDotDir,
+	zshDotDir
+} from './terminal-env.js';
 
 const BUFFER_MAX_CHARS = 2_000_000;
 const MIN_COLS = 2;
@@ -38,6 +52,7 @@ export interface TerminalCreateInput {
 
 export function createTerminalManager(getMainWindow: () => BrowserWindow | null) {
 	const sessions = new Map<string, TerminalEntry>();
+	clearAllTerminalEnv();
 
 	const dimensions = (input: Pick<TerminalCreateInput, 'cols' | 'rows'> = {}) => {
 		const cols = Number.isInteger(input.cols) ? (input.cols ?? 80) : 80;
@@ -70,7 +85,7 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 	const requireInput = (event: IpcMainInvokeEvent, sessionId: unknown) => {
 		if (!isMainWindowSender(event))
 			throw new Error('Terminal access is only available in the main window');
-		if (typeof sessionId !== 'string' || !/^[A-Za-z0-9_-]{1,128}$/.test(sessionId)) {
+		if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) {
 			throw new Error('Invalid terminal session id');
 		}
 	};
@@ -93,10 +108,48 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 		return '/bin/zsh';
 	};
 
+	const integrationRoot = () =>
+		shellIntegrationRoot(app.isPackaged, process.resourcesPath, app.getAppPath());
+
+	const spawnEnv = (
+		kind: ReturnType<typeof shellKind>,
+		envDir: string,
+		zshWrapperReady: boolean
+	) => {
+		const env: NodeJS.ProcessEnv = {
+			...process.env,
+			TERM: 'xterm-256color',
+			TERM_PROGRAM: 'Cometline',
+			COMETLINE_ENV_DIR: envDir
+		};
+		if (kind !== 'zsh' || !zshWrapperReady) return env;
+		const zdot = zshDotDir(envDir);
+		env.COMETLINE_ZDOTDIR = zdot;
+		env.COMETLINE_USER_ZDOTDIR = process.env.ZDOTDIR || os.homedir();
+		env.ZDOTDIR = zdot;
+		return env;
+	};
+
 	const appendOutput = (entry: TerminalEntry, data: string) => {
 		entry.output += data;
 		if (entry.output.length > BUFFER_MAX_CHARS)
 			entry.output = entry.output.slice(-BUFFER_MAX_CHARS);
+	};
+
+	const prepareEnvCapture = (sessionId: string, shellPath: string) => {
+		const envDir = prepareEnvDir(sessionId);
+		const kind = shellKind(shellPath);
+		const script = integrationScriptPath(integrationRoot(), shellPath);
+		const scriptReady = Boolean(script && fs.existsSync(script));
+		let bashRc: string | null = null;
+		let zshWrapperReady = false;
+		if (kind === 'zsh' && scriptReady) {
+			writeZshDotDir(envDir, script);
+			zshWrapperReady = true;
+		} else if (kind === 'bash' && scriptReady) {
+			bashRc = writeBashRc(envDir, script);
+		}
+		return { envDir, kind, bashRc, zshWrapperReady };
 	};
 
 	const create = (sessionId: string, workspacePath: string, input: TerminalCreateInput) => {
@@ -115,12 +168,13 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 
 		const size = dimensions(input);
 		const shellPath = shell();
-		const processHandle = pty.spawn(shellPath, ['-l'], {
+		const capture = prepareEnvCapture(sessionId, shellPath);
+		const processHandle = pty.spawn(shellPath, spawnArgs(capture.kind, capture.bashRc), {
 			name: 'xterm-256color',
 			cols: size.cols,
 			rows: size.rows,
 			cwd: workspacePath,
-			env: { ...process.env, TERM: 'xterm-256color', TERM_PROGRAM: 'Cometline' }
+			env: spawnEnv(capture.kind, capture.envDir, capture.zshWrapperReady)
 		});
 		const entry: TerminalEntry = {
 			sessionId,
@@ -140,6 +194,7 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 			entry.status = 'exited';
 			entry.exitCode = exitCode;
 			entry.process = null;
+			removeTerminalEnvDir(sessionId);
 			send('cometline:terminal-exit', snapshot(entry));
 			sessions.delete(sessionId);
 		});
@@ -156,6 +211,7 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 				console.warn(`Failed to terminate terminal for session ${sessionId}:`, error);
 			}
 		}
+		removeTerminalEnvDir(sessionId);
 		if (remove) sessions.delete(sessionId);
 		return true;
 	};
@@ -169,6 +225,7 @@ export function createTerminalManager(getMainWindow: () => BrowserWindow | null)
 		terminate,
 		terminateAll: () => {
 			for (const sessionId of sessions.keys()) terminate(sessionId, true);
+			clearAllTerminalEnv();
 		},
 		write: (sessionId: string, data: string) => {
 			const entry = sessions.get(sessionId);

--- a/cometline/package.json
+++ b/cometline/package.json
@@ -169,6 +169,10 @@
 			{
 				"from": "buildResources/trayTemplate.png",
 				"to": "trayTemplate.png"
+			},
+			{
+				"from": "electron/resources/shell-integration",
+				"to": "shell-integration"
 			}
 		]
 	}

--- a/cometmind/internal/acp/cli.go
+++ b/cometmind/internal/acp/cli.go
@@ -40,7 +40,7 @@ func defaultCLIProcessStarter(
 
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = workspaceRoot
-	cmd.Env = process.Env()
+	cmd.Env = process.EnvForSession(process.SessionIDFrom(ctx))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, nil, err

--- a/cometmind/internal/acp/manager.go
+++ b/cometmind/internal/acp/manager.go
@@ -6,16 +6,19 @@ import (
 	"io"
 	"strings"
 	"sync"
+
+	"github.com/cometline/cometmind/internal/process"
 )
 
 // RunOptions configures one delegated coding-harness run.
 type RunOptions struct {
-	ChildSessionID string
-	WorkspaceRoot  string
-	Task           string
-	Context        string
-	VerifyCommand  string
-	OnProgress     func(ProgressUpdate)
+	ChildSessionID  string
+	ParentSessionID string
+	WorkspaceRoot   string
+	Task            string
+	Context         string
+	VerifyCommand   string
+	OnProgress      func(ProgressUpdate)
 }
 
 // SessionManager keeps active CLI processes keyed by child session ID.
@@ -58,6 +61,7 @@ func (m *SessionManager) Run(ctx context.Context, opts RunOptions) (TaskResult, 
 	if cfg.Timeout > 0 {
 		runCtx, cancel = context.WithTimeout(ctx, cfg.Timeout)
 	}
+	runCtx = process.WithSessionID(runCtx, opts.ParentSessionID)
 	defer cancel()
 
 	promptText := opts.Task

--- a/cometmind/internal/acp/runner.go
+++ b/cometmind/internal/acp/runner.go
@@ -133,9 +133,10 @@ func (c *cmdWaitCloser) Close() error {
 func runVerifyCommand(ctx context.Context, workspaceRoot, command string) (string, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command) //nolint:gosec // delegated verify step
 	cmd.Dir = workspaceRoot
-	cmd.Env = process.Env()
+	env := process.EnvForSession(process.SessionIDFrom(ctx))
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
-	text := string(out)
+	text := process.RedactSecretValues(string(out), env)
 	if err != nil {
 		return text, err
 	}

--- a/cometmind/internal/paths/paths.go
+++ b/cometmind/internal/paths/paths.go
@@ -188,6 +188,28 @@ func ProcessMetaPath(mode string) (string, error) {
 	return filepath.Join(d, mode+".json"), nil
 }
 
+// TerminalEnvRoot returns ~/.cometmind/terminal-env (not created).
+func TerminalEnvRoot() (string, error) {
+	d, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "terminal-env"), nil
+}
+
+// TerminalEnvFile returns ~/.cometmind/terminal-env/{sessionID}/environ.
+// The session id must be a path-safe identifier; the file is not created.
+func TerminalEnvFile(sessionID string) (string, error) {
+	if !ValidSessionID(sessionID) {
+		return "", ErrInvalidSessionID
+	}
+	root, err := TerminalEnvRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, sessionID, "environ"), nil
+}
+
 // ProcessReloadResultPath returns the path a long-lived process writes its most
 // recent settings-reload outcome to, so a short-lived CLI invocation (e.g.
 // `cometmind settings reload`) can confirm the reload actually completed

--- a/cometmind/internal/paths/paths_test.go
+++ b/cometmind/internal/paths/paths_test.go
@@ -1,6 +1,7 @@
 package paths
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -49,6 +50,54 @@ func TestProcessPathsUseDataDir(t *testing.T) {
 	}
 	if desktopPath != filepath.Join(override, "cometline-desktop.json") {
 		t.Fatalf("desktop path = %q", desktopPath)
+	}
+}
+
+func TestTerminalEnvFileUsesDataDir(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "state")
+	t.Setenv("COMETMIND_DATA_DIR", override)
+
+	got, err := TerminalEnvFile("sess_abc")
+	if err != nil {
+		t.Fatalf("TerminalEnvFile() error = %v", err)
+	}
+	if got != filepath.Join(override, "terminal-env", "sess_abc", "environ") {
+		t.Fatalf("TerminalEnvFile() = %q", got)
+	}
+}
+
+func TestTerminalEnvFileRejectsUnsafeID(t *testing.T) {
+	if _, err := TerminalEnvFile("../etc"); !errors.Is(err, ErrInvalidSessionID) {
+		t.Fatalf("err = %v, want ErrInvalidSessionID", err)
+	}
+}
+
+func TestIsTerminalEnvPath(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "state")
+	t.Setenv("COMETMIND_DATA_DIR", override)
+	file := filepath.Join(override, "terminal-env", "sess_abc", "environ")
+	if !IsTerminalEnvPath(file) {
+		t.Fatal("expected env file to be private")
+	}
+	if !IsTerminalEnvPath(filepath.Join(override, "terminal-env")) {
+		t.Fatal("expected env root to be private")
+	}
+	if IsTerminalEnvPath(filepath.Join(override, "tool-output", "x.txt")) {
+		t.Fatal("tool-output should not be treated as terminal-env")
+	}
+}
+
+func TestCommandMentionsTerminalEnv(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "state")
+	t.Setenv("COMETMIND_DATA_DIR", override)
+	if !CommandMentionsTerminalEnv("cat " + filepath.Join(override, "terminal-env", "sess", "environ")) {
+		t.Fatal("expected absolute snapshot path to be detected")
+	}
+	if !CommandMentionsTerminalEnv("cat ~/.cometmind/terminal-env/sess/environ") {
+		t.Fatal("expected home-relative snapshot path to be detected")
+	}
+	if CommandMentionsTerminalEnv("echo hello") {
+		t.Fatal("plain command should not match")
 	}
 }
 

--- a/cometmind/internal/paths/sessionid.go
+++ b/cometmind/internal/paths/sessionid.go
@@ -1,0 +1,66 @@
+package paths
+
+import (
+	"errors"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ErrInvalidSessionID is returned when a session id cannot be used as a path segment.
+var ErrInvalidSessionID = errors.New("invalid session id")
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+
+// ValidSessionID reports whether id is safe to use as a terminal-env path segment.
+func ValidSessionID(id string) bool {
+	return sessionIDPattern.MatchString(id)
+}
+
+// IsTerminalEnvPath reports whether abs is the terminal-env root or a file under it.
+func IsTerminalEnvPath(abs string) bool {
+	root, err := TerminalEnvRoot()
+	if err != nil || root == "" || abs == "" {
+		return false
+	}
+	return pathWithin(root, abs)
+}
+
+func pathWithin(root, abs string) bool {
+	root = filepath.Clean(root)
+	abs = filepath.Clean(abs)
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// CommandMentionsTerminalEnv reports whether a shell command string names the
+// private terminal-env snapshot directory.
+func CommandMentionsTerminalEnv(command string) bool {
+	if strings.TrimSpace(command) == "" {
+		return false
+	}
+	root, err := TerminalEnvRoot()
+	if err == nil && root != "" && strings.Contains(command, root) {
+		return true
+	}
+	if strings.Contains(command, filepath.Join("~", ".cometmind", "terminal-env")) ||
+		strings.Contains(command, "~/.cometmind/terminal-env") ||
+		strings.Contains(command, "$HOME/.cometmind/terminal-env") ||
+		strings.Contains(command, "${HOME}/.cometmind/terminal-env") {
+		return true
+	}
+	if home, err := Home(); err == nil && home != "" &&
+		strings.Contains(command, filepath.Join(home, ".cometmind", "terminal-env")) {
+		return true
+	}
+	return false
+}

--- a/cometmind/internal/process/session_env.go
+++ b/cometmind/internal/process/session_env.go
@@ -1,0 +1,212 @@
+package process
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cometline/cometmind/internal/paths"
+)
+
+const (
+	minRedactValueLen = 8
+	redactedValue     = "[redacted]"
+)
+
+// EnvForSession returns Env() overlaid with the desktop terminal snapshot for sessionID.
+// A missing or unreadable snapshot is ignored.
+func EnvForSession(sessionID string) []string {
+	return MergeSessionEnv(sessionID, Env())
+}
+
+// MergeSessionEnv overlays a terminal env snapshot onto base.
+// COMETMIND_*, DYLD_*, and LD_PRELOAD from the snapshot are dropped.
+// PATH is re-augmented after the overlay.
+func MergeSessionEnv(sessionID string, base []string) []string {
+	extra, ok := readSessionEnv(sessionID)
+	if !ok || len(extra) == 0 {
+		return base
+	}
+	merged := overlayEnv(base, extra)
+	return replacePath(merged, AugmentedPath(envValue(merged, "PATH")))
+}
+
+func readSessionEnv(sessionID string) (map[string]string, bool) {
+	if !paths.ValidSessionID(sessionID) {
+		return nil, false
+	}
+	file, err := paths.TerminalEnvFile(sessionID)
+	if err != nil {
+		return nil, false
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, false
+	}
+	return parseEnvironFile(data), true
+}
+
+func parseEnvironFile(data []byte) map[string]string {
+	out := make(map[string]string)
+	for _, entry := range bytes.Split(data, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		key, value, ok := strings.Cut(string(entry), "=")
+		if !ok || key == "" || !allowSessionEnvKey(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+var deniedSessionEnvKeys = map[string]struct{}{
+	"BASH_ENV":        {},
+	"LD_LIBRARY_PATH": {},
+	"LD_PRELOAD":      {},
+	"LINENO":          {},
+	"OLDPWD":          {},
+	"PROMPT":          {},
+	"PS1":             {},
+	"PWD":             {},
+	"RPROMPT":         {},
+	"SHLVL":           {},
+	"ZDOTDIR":         {},
+	"_":               {},
+}
+
+func allowSessionEnvKey(key string) bool {
+	if _, denied := deniedSessionEnvKeys[key]; denied {
+		return false
+	}
+	if strings.HasPrefix(key, "COMETMIND_") || strings.HasPrefix(key, "COMETLINE_") || strings.HasPrefix(key, "DYLD_") {
+		return false
+	}
+	return true
+}
+
+func overlayEnv(base []string, extra map[string]string) []string {
+	seen := make(map[string]int, len(base)+len(extra))
+	out := make([]string, 0, len(base)+len(extra))
+	for _, kv := range base {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if idx, exists := seen[key]; exists {
+			out[idx] = kv
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, kv)
+	}
+	for key, value := range extra {
+		kv := key + "=" + value
+		if idx, exists := seen[key]; exists {
+			out[idx] = kv
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, kv)
+	}
+	return out
+}
+
+func replacePath(env []string, path string) []string {
+	for i, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			env[i] = "PATH=" + path
+			return env
+		}
+	}
+	return append(env, "PATH="+path)
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return strings.TrimPrefix(kv, prefix)
+		}
+	}
+	return ""
+}
+
+func isExplicitSecretKey(key string) bool {
+	switch strings.ToUpper(key) {
+	case "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SECURITY_TOKEN":
+		return true
+	default:
+		return false
+	}
+}
+
+func isGenericSecretKey(key string) bool {
+	upper := strings.ToUpper(key)
+	return strings.Contains(upper, "SECRET") ||
+		strings.Contains(upper, "PASSWORD") ||
+		strings.Contains(upper, "TOKEN") ||
+		strings.Contains(upper, "API_KEY")
+}
+
+func isSecretEnvKey(key string) bool {
+	return isExplicitSecretKey(key) || isGenericSecretKey(key)
+}
+
+// RedactSecretValues replaces secret-looking values from env in text.
+func RedactSecretValues(text string, env []string) string {
+	if text == "" || len(env) == 0 {
+		return text
+	}
+	values := secretValues(env)
+	if len(values) == 0 {
+		return text
+	}
+	for _, value := range values {
+		text = strings.ReplaceAll(text, value, redactedValue)
+	}
+	return text
+}
+
+// WriteSessionEnvSnapshot writes a null-delimited KEY=VALUE snapshot for tests and tools.
+func WriteSessionEnvSnapshot(sessionID string, pairs ...string) error {
+	file, err := paths.TerminalEnvFile(sessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(file), 0o700); err != nil {
+		return err
+	}
+	var b bytes.Buffer
+	for _, pair := range pairs {
+		b.WriteString(pair)
+		b.WriteByte(0)
+	}
+	return os.WriteFile(file, b.Bytes(), 0o600)
+}
+
+func secretValues(env []string) []string {
+	seen := make(map[string]struct{})
+	var values []string
+	for _, kv := range env {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok || value == "" || !isSecretEnvKey(key) {
+			continue
+		}
+		if !isExplicitSecretKey(key) && len(value) < minRedactValueLen {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return len(values[i]) > len(values[j])
+	})
+	return values
+}

--- a/cometmind/internal/process/session_env_test.go
+++ b/cometmind/internal/process/session_env_test.go
@@ -1,0 +1,116 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSessionEnv(t *testing.T, sessionID string, pairs ...string) {
+	t.Helper()
+	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
+	if err := WriteSessionEnvSnapshot(sessionID, pairs...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeSessionEnvOverlaysValues(t *testing.T) {
+	writeSessionEnv(t, "sess1", "CAPTURED_VAR=from-terminal", "PATH=/tmp/term-bin")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	merged := MergeSessionEnv("sess1", []string{"PATH=/usr/bin:/bin", "FOO=base"})
+	if envValue(merged, "CAPTURED_VAR") != "from-terminal" {
+		t.Fatalf("missing overlay: %v", merged)
+	}
+	if envValue(merged, "FOO") != "base" {
+		t.Fatalf("lost base: %v", merged)
+	}
+	path := envValue(merged, "PATH")
+	if !strings.Contains(path, "/tmp/term-bin") {
+		t.Fatalf("PATH missing terminal entry: %q", path)
+	}
+	home, _ := os.UserHomeDir()
+	if home != "" && !strings.Contains(path, filepath.Join(home, ".cometmind", "bin")) {
+		t.Fatalf("PATH missing augmented entry: %q", path)
+	}
+}
+
+func TestMergeSessionEnvDropsDeniedKeys(t *testing.T) {
+	writeSessionEnv(t, "sess1",
+		"COMETMIND_API_KEY=from-terminal",
+		"COMETLINE_ENV_DIR=/tmp/env",
+		"DYLD_INSERT_LIBRARIES=/tmp/evil.dylib",
+		"LD_PRELOAD=/tmp/evil.so",
+		"PWD=/tmp",
+		"OLDPWD=/tmp",
+		"SAFE_VAR=ok",
+	)
+	merged := MergeSessionEnv("sess1", []string{"COMETMIND_API_KEY=from-sidecar", "PATH=/bin"})
+	if envValue(merged, "COMETMIND_API_KEY") != "from-sidecar" {
+		t.Fatalf("COMETMIND_API_KEY = %q", envValue(merged, "COMETMIND_API_KEY"))
+	}
+	if envValue(merged, "COMETLINE_ENV_DIR") != "" {
+		t.Fatalf("COMETLINE leaked: %v", merged)
+	}
+	if envValue(merged, "DYLD_INSERT_LIBRARIES") != "" {
+		t.Fatalf("DYLD leaked: %v", merged)
+	}
+	if envValue(merged, "LD_PRELOAD") != "" {
+		t.Fatalf("LD_PRELOAD leaked: %v", merged)
+	}
+	if envValue(merged, "PWD") != "" || envValue(merged, "OLDPWD") != "" {
+		t.Fatalf("cwd leaked: %v", merged)
+	}
+	if envValue(merged, "SAFE_VAR") != "ok" {
+		t.Fatalf("SAFE_VAR = %q", envValue(merged, "SAFE_VAR"))
+	}
+}
+
+func TestMergeSessionEnvMissingFile(t *testing.T) {
+	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
+	base := []string{"FOO=1", "PATH=/bin"}
+	got := MergeSessionEnv("missing", base)
+	if envValue(got, "FOO") != "1" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestMergeSessionEnvRejectsTraversalID(t *testing.T) {
+	base := []string{"FOO=1"}
+	got := MergeSessionEnv("../etc", base)
+	if envValue(got, "FOO") != "1" || len(got) != 1 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestRedactSecretValues(t *testing.T) {
+	env := []string{
+		"AWS_SESSION_TOKEN=supersecrettokenvalue",
+		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG",
+		"SAFE=visible",
+		"SHORT_TOKEN=ab",
+	}
+	in := "token=supersecrettokenvalue key=wJalrXUtnFEMI/K7MDENG SAFE=visible SHORT_TOKEN=ab"
+	got := RedactSecretValues(in, env)
+	if strings.Contains(got, "supersecrettokenvalue") || strings.Contains(got, "wJalrXUtnFEMI/K7MDENG") {
+		t.Fatalf("secrets leaked: %q", got)
+	}
+	if !strings.Contains(got, "SAFE=visible") || !strings.Contains(got, "SHORT_TOKEN=ab") {
+		t.Fatalf("over-redacted: %q", got)
+	}
+}
+
+func TestRedactExplicitAWSKeysOfAnyLength(t *testing.T) {
+	got := RedactSecretValues("x=abcd", []string{"AWS_SESSION_TOKEN=abcd"})
+	if strings.Contains(got, "abcd") {
+		t.Fatalf("explicit AWS token not redacted: %q", got)
+	}
+}
+
+func TestWithSessionID(t *testing.T) {
+	ctx := WithSessionID(t.Context(), "sess1")
+	if SessionIDFrom(ctx) != "sess1" {
+		t.Fatalf("SessionIDFrom = %q", SessionIDFrom(ctx))
+	}
+}

--- a/cometmind/internal/process/session_id.go
+++ b/cometmind/internal/process/session_id.go
@@ -1,0 +1,19 @@
+package process
+
+import "context"
+
+type sessionIDKey struct{}
+
+// WithSessionID attaches a chat session id used to load a terminal env snapshot.
+func WithSessionID(ctx context.Context, sessionID string) context.Context {
+	if sessionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+// SessionIDFrom returns the session id attached by WithSessionID.
+func SessionIDFrom(ctx context.Context) string {
+	v, _ := ctx.Value(sessionIDKey{}).(string)
+	return v
+}

--- a/cometmind/internal/tools/delegatecoding.go
+++ b/cometmind/internal/tools/delegatecoding.go
@@ -88,11 +88,12 @@ func (d DelegateCodingTask) Execute(ctx context.Context, input json.RawMessage) 
 	}
 
 	runOpts := acp.RunOptions{
-		ChildSessionID: child.ID,
-		WorkspaceRoot:  d.Workspace.Root,
-		Task:           task,
-		Context:        in.Context,
-		VerifyCommand:  in.VerifyCommand,
+		ChildSessionID:  child.ID,
+		ParentSessionID: parentID,
+		WorkspaceRoot:   d.Workspace.Root,
+		Task:            task,
+		Context:         in.Context,
+		VerifyCommand:   in.VerifyCommand,
 		OnProgress: func(u acp.ProgressUpdate) {
 			if emit == nil {
 				return

--- a/cometmind/internal/tools/execctx.go
+++ b/cometmind/internal/tools/execctx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cometline/cometmind/internal/event"
+	"github.com/cometline/cometmind/internal/process"
 )
 
 type execCtxKey int
@@ -19,7 +20,8 @@ type ProgressFn func(event.Event)
 
 // WithToolSession attaches the active CometMind session id to the tool context.
 func WithToolSession(ctx context.Context, sessionID string) context.Context {
-	return context.WithValue(ctx, execKeySession, sessionID)
+	ctx = context.WithValue(ctx, execKeySession, sessionID)
+	return process.WithSessionID(ctx, sessionID)
 }
 
 // ToolSessionFrom returns the active session id when present.

--- a/cometmind/internal/tools/fs/workspace.go
+++ b/cometmind/internal/tools/fs/workspace.go
@@ -44,11 +44,18 @@ func (w Workspace) ResolveReadable(rel string) (string, error) {
 	mount, subpath, ok := runtimeMount(rel)
 	if !ok {
 		if filepath.IsAbs(rel) {
-			return filepath.Clean(rel), nil
+			clean := filepath.Clean(rel)
+			if err := rejectPrivateRuntimePath(clean); err != nil {
+				return "", err
+			}
+			return clean, nil
 		}
 		joined := filepath.Clean(filepath.Join(filepath.Clean(w.Root), rel))
 		resolved, err := filepath.EvalSymlinks(joined)
 		if err != nil {
+			return "", err
+		}
+		if err := rejectPrivateRuntimePath(resolved); err != nil {
 			return "", err
 		}
 		return resolved, nil
@@ -87,6 +94,9 @@ func (w Workspace) ResolveSearchRoot(rel string) (root, displayPrefix string, er
 	if !IsRuntimePath(rel) {
 		if filepath.IsAbs(rel) {
 			clean := filepath.Clean(rel)
+			if err := rejectPrivateRuntimePath(clean); err != nil {
+				return "", "", err
+			}
 			return clean, clean, nil
 		}
 		root, err = w.Resolve(rel)
@@ -133,6 +143,13 @@ func MountDocs() string {
 func IsRuntimePath(rel string) bool {
 	_, _, ok := runtimeMount(rel)
 	return ok
+}
+
+func rejectPrivateRuntimePath(abs string) error {
+	if paths.IsTerminalEnvPath(abs) {
+		return fmt.Errorf("path is private")
+	}
+	return nil
 }
 
 func runtimeMount(rel string) (mount, subpath string, ok bool) {

--- a/cometmind/internal/tools/fs/workspace_test.go
+++ b/cometmind/internal/tools/fs/workspace_test.go
@@ -1,0 +1,27 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveReadableRejectsTerminalEnv(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", root)
+	envFile := filepath.Join(root, "terminal-env", "sess1", "environ")
+	if err := os.MkdirAll(filepath.Dir(envFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envFile, []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ws := Workspace{Root: t.TempDir()}
+	if _, err := ws.ResolveReadable(envFile); err == nil || !strings.Contains(err.Error(), "private") {
+		t.Fatalf("ResolveReadable err = %v, want private", err)
+	}
+	if _, _, err := ws.ResolveSearchRoot(envFile); err == nil || !strings.Contains(err.Error(), "private") {
+		t.Fatalf("ResolveSearchRoot err = %v, want private", err)
+	}
+}

--- a/cometmind/internal/tools/grep.go
+++ b/cometmind/internal/tools/grep.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/cometline/cometmind/internal/paths"
 	"github.com/cometline/cometmind/internal/process"
 )
 
@@ -100,6 +101,7 @@ func grepRipgrep(ctx context.Context, workspaceRoot, searchRel, pattern, include
 	if include != "" {
 		args = append(args, "--glob", include)
 	}
+	args = append(args, "--glob", "!terminal-env/**")
 	args = append(args, pattern)
 
 	rgTarget := "."
@@ -261,6 +263,13 @@ func filterGrepOutput(workspaceRoot, text string) string {
 			continue
 		}
 		if grepPathHasSkippedDir(path) {
+			continue
+		}
+		abs := path
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(workspaceRoot, abs)
+		}
+		if paths.IsTerminalEnvPath(abs) {
 			continue
 		}
 		filtered = append(filtered, line)

--- a/cometmind/internal/tools/host_read_test.go
+++ b/cometmind/internal/tools/host_read_test.go
@@ -105,6 +105,54 @@ func TestReadFileWorkspaceSymlinkToExternal(t *testing.T) {
 	}
 }
 
+func TestListDirHidesTerminalEnv(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", data)
+	if err := os.MkdirAll(filepath.Join(data, "terminal-env", "sess"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(data, "visible.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := ListDir{Workspace: Workspace{Root: t.TempDir()}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"path":`+quoteJSON(t, data)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "visible.txt") {
+		t.Fatalf("list result = %+v", res)
+	}
+	if strings.Contains(res.Output, "terminal-env") {
+		t.Fatalf("terminal-env leaked: %s", res.Output)
+	}
+}
+
+func TestGlobSkipsTerminalEnv(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", data)
+	envFile := filepath.Join(data, "terminal-env", "sess", "environ")
+	if err := os.MkdirAll(filepath.Dir(envFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envFile, []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(data, "ok.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := Glob{Workspace: Workspace{Root: t.TempDir()}}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"pattern":"**/*","path":`+quoteJSON(t, data)+`}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || !strings.Contains(res.Output, "ok.txt") {
+		t.Fatalf("glob result = %+v", res)
+	}
+	if strings.Contains(res.Output, "terminal-env") || strings.Contains(res.Output, "environ") {
+		t.Fatalf("terminal-env leaked: %s", res.Output)
+	}
+}
+
 func TestListDirAbsoluteExternalPath(t *testing.T) {
 	root, external := hostReadFixture(t)
 	tool := ListDir{Workspace: Workspace{Root: root}}

--- a/cometmind/internal/tools/listdir.go
+++ b/cometmind/internal/tools/listdir.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/cometline/cometmind/internal/paths"
 )
 
 // ListDir lists non-hidden entries one level under a path. Relative paths
@@ -51,6 +54,9 @@ func (l ListDir) Execute(ctx context.Context, input json.RawMessage) (Result, er
 	for _, e := range ents {
 		name := e.Name()
 		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if paths.IsTerminalEnvPath(filepath.Join(p, name)) {
 			continue
 		}
 		if e.IsDir() {

--- a/cometmind/internal/tools/runcommand.go
+++ b/cometmind/internal/tools/runcommand.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cometline/cometmind/internal/paths"
 	"github.com/cometline/cometmind/internal/process"
 )
 
@@ -59,6 +60,9 @@ func (r RunCommand) Execute(ctx context.Context, input json.RawMessage) (Result,
 	if err := denylistCheck(command); err != nil {
 		return Result{OK: false, Output: err.Error()}, nil
 	}
+	if paths.CommandMentionsTerminalEnv(command) {
+		return Result{OK: false, Output: "path is private"}, nil
+	}
 	if _, err := r.Workspace.Resolve("."); err != nil {
 		return Result{}, err
 	}
@@ -86,10 +90,11 @@ func (r RunCommand) Execute(ctx context.Context, input json.RawMessage) (Result,
 
 	cmd := exec.CommandContext(cmdCtx, "sh", "-c", command) //nolint:gosec
 	cmd.Dir = root
-	cmd.Env = process.Env()
+	env := process.EnvForSession(process.SessionIDFrom(ctx))
+	cmd.Env = env
 
 	out, err := cmd.CombinedOutput()
-	text := boundToolOutput(string(out))
+	text := boundToolOutput(process.RedactSecretValues(string(out), env))
 
 	var exit *int
 	if err != nil {

--- a/cometmind/internal/tools/runcommand_env_test.go
+++ b/cometmind/internal/tools/runcommand_env_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cometline/cometmind/internal/process"
+)
+
+func writeTerminalEnv(t *testing.T, sessionID string, pairs ...string) {
+	t.Helper()
+	t.Setenv("COMETMIND_DATA_DIR", t.TempDir())
+	if err := process.WriteSessionEnvSnapshot(sessionID, pairs...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunCommandMergesSessionEnv(t *testing.T) {
+	writeTerminalEnv(t, "sess_env", "CAPTURED_VAR=from-terminal")
+	tool := RunCommand{Workspace: Workspace{Root: t.TempDir()}}
+	res, err := tool.Execute(
+		WithToolSession(t.Context(), "sess_env"),
+		json.RawMessage(`{"command":"printf %s \"$CAPTURED_VAR\""}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Output != "from-terminal" {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestRunCommandRedactsSessionSecrets(t *testing.T) {
+	const token = "supersecrettokenvalue"
+	writeTerminalEnv(t, "sess_env", "AWS_SESSION_TOKEN="+token)
+	tool := RunCommand{Workspace: Workspace{Root: t.TempDir()}}
+	res, err := tool.Execute(
+		WithToolSession(t.Context(), "sess_env"),
+		json.RawMessage(`{"command":"printf %s \"$AWS_SESSION_TOKEN\""}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("result = %+v", res)
+	}
+	if strings.Contains(res.Output, token) {
+		t.Fatalf("token leaked: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "[redacted]") {
+		t.Fatalf("expected redaction, got %q", res.Output)
+	}
+}
+
+func TestRunCommandRejectsTerminalEnvPath(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("COMETMIND_DATA_DIR", data)
+	tool := RunCommand{Workspace: Workspace{Root: t.TempDir()}}
+	cmd, _ := json.Marshal(map[string]string{
+		"command": "cat " + data + "/terminal-env/sess/environ",
+	})
+	res, err := tool.Execute(WithToolSession(t.Context(), "sess"), cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || !strings.Contains(res.Output, "private") {
+		t.Fatalf("result = %+v, want private", res)
+	}
+}

--- a/cometmind/internal/tools/searchutil.go
+++ b/cometmind/internal/tools/searchutil.go
@@ -10,14 +10,16 @@ import (
 	"time"
 
 	gitignore "github.com/sabhiram/go-gitignore"
+
+	"github.com/cometline/cometmind/internal/paths"
 )
 
 const (
-	globMaxFiles        = 100
-	grepMaxOutputChars  = 12000
-	grepTimeout         = 60 * time.Second
-	searchMaxVisited    = 250_000
-	searchWalkTimeout   = 90 * time.Second
+	globMaxFiles       = 100
+	grepMaxOutputChars = 12000
+	grepTimeout        = 60 * time.Second
+	searchMaxVisited   = 250_000
+	searchWalkTimeout  = 90 * time.Second
 )
 
 // errSearchBudget stops a recursive search when the visited-entry budget is
@@ -125,6 +127,13 @@ func walkSearchableFiles(ctx context.Context, workspaceRoot, searchRoot string, 
 
 		name := d.Name()
 		if strings.HasPrefix(name, ".") {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if paths.IsTerminalEnvPath(path) {
 			if d.IsDir() {
 				return fs.SkipDir
 			}


### PR DESCRIPTION
## Background

`export` in the session terminal only changed that PTY. The same chat's `run_command` and coding-harness runs started a fresh `sh -c` with sidecar env, so in-shell STS tokens and other exports were invisible unless the user pasted them into chat.

[26dfd3c](https://github.com/Cometline/cometline/commit/26dfd3cfb1ee02c89fb60abce11abc94b2bf7a91): CometMind now overlays a per-session env snapshot onto `run_command` and ACP, redacts secret-looking values in tool output, and keeps `~/.cometmind/terminal-env` out of `read_file`, `list_dir`, `grep`, `glob`, and shell commands that name that path.

[28b0f6b](https://github.com/Cometline/cometline/commit/28b0f6bf320a357479123784dde4cd704e3e7442): The desktop terminal writes that snapshot from a zsh or bash hook whenever the user returns to a prompt, so the linked chat can use the live shell environment without putting values in the transcript.