### PR TITLE
[main] feat: bill cache reads at cache rates

### DIFF
--- a/comet-sdk/internal/responsesproto/stream.go
+++ b/comet-sdk/internal/responsesproto/stream.go
@@ -40,15 +40,9 @@ type streamEvent struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
 	Item      outputItem      `json:"item"`
-	Usage     *struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
-	Response *struct {
-		Usage *struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
-		} `json:"usage"`
+	Usage     *responseUsage  `json:"usage"`
+	Response  *struct {
+		Usage             *responseUsage `json:"usage"`
 		IncompleteDetails *struct {
 			Reason string `json:"reason"`
 		} `json:"incomplete_details"`
@@ -58,14 +52,43 @@ type streamEvent struct {
 	} `json:"error"`
 }
 
+type responseUsage struct {
+	InputTokens        int `json:"input_tokens"`
+	OutputTokens       int `json:"output_tokens"`
+	InputTokensDetails *struct {
+		CachedTokens        int `json:"cached_tokens"`
+		CacheWriteTokens    int `json:"cache_write_tokens"`
+		CacheCreationTokens int `json:"cache_creation_tokens"`
+	} `json:"input_tokens_details"`
+}
+
+func tokenUsageFrom(u *responseUsage) cometsdk.TokenUsage {
+	if u == nil {
+		return cometsdk.TokenUsage{}
+	}
+	usage := cometsdk.TokenUsage{
+		InputTokens:  u.InputTokens,
+		OutputTokens: u.OutputTokens,
+	}
+	if d := u.InputTokensDetails; d != nil {
+		usage.CacheRead = d.CachedTokens
+		if d.CacheWriteTokens > 0 {
+			usage.CacheWrite = d.CacheWriteTokens
+		} else {
+			usage.CacheWrite = d.CacheCreationTokens
+		}
+	}
+	return usage
+}
+
 type outputItem struct {
-	Type             string        `json:"type"`
-	CallID           string        `json:"call_id"`
-	ID               string        `json:"id"`
-	Name             string        `json:"name"`
+	Type             string          `json:"type"`
+	CallID           string          `json:"call_id"`
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
 	Arguments        json.RawMessage `json:"arguments"`
-	Summary          []ContentPart `json:"summary"`
-	EncryptedContent string        `json:"encrypted_content"`
+	Summary          []ContentPart   `json:"summary"`
+	EncryptedContent string          `json:"encrypted_content"`
 }
 
 // ParseLoop reads SSE events from body and dispatches typed cometsdk.Events
@@ -223,11 +246,9 @@ func ToSDKEvents(providerID, eventType, data string, state *StreamState) ([]come
 	case "response.completed", "response.incomplete":
 		usage := cometsdk.TokenUsage{}
 		if ev.Usage != nil {
-			usage.InputTokens = ev.Usage.InputTokens
-			usage.OutputTokens = ev.Usage.OutputTokens
+			usage = tokenUsageFrom(ev.Usage)
 		} else if ev.Response != nil && ev.Response.Usage != nil {
-			usage.InputTokens = ev.Response.Usage.InputTokens
-			usage.OutputTokens = ev.Response.Usage.OutputTokens
+			usage = tokenUsageFrom(ev.Response.Usage)
 		}
 		finish := cometsdk.FinishStop
 		if state.sawTool {

--- a/comet-sdk/provider/codex/convert_test.go
+++ b/comet-sdk/provider/codex/convert_test.go
@@ -134,6 +134,30 @@ func TestConvertEvent_TextToolAndCompleted(t *testing.T) {
 	require.Equal(t, cometsdk.DoneEvent{}, events[1])
 }
 
+func TestConvertEvent_CompletedUsageIncludesCachedTokens(t *testing.T) {
+	state := &responsesproto.StreamState{}
+	events, err := responsesproto.ToSDKEvents(providerID, "", `{
+		"type":"response.completed",
+		"response":{
+			"usage":{
+				"input_tokens":125,
+				"output_tokens":48,
+				"input_tokens_details":{"cached_tokens":98,"cache_write_tokens":4}
+			}
+		}
+	}`, state)
+	require.NoError(t, err)
+	require.Equal(t, cometsdk.StepFinishEvent{
+		FinishReason: cometsdk.FinishStop,
+		Usage: cometsdk.TokenUsage{
+			InputTokens:  125,
+			OutputTokens: 48,
+			CacheRead:    98,
+			CacheWrite:   4,
+		},
+	}, events[0])
+}
+
 func TestConvertEvent_SSEEventTypeFallback(t *testing.T) {
 	state := &responsesproto.StreamState{}
 

--- a/cometline/src/lib/components/usage/UsagePage.svelte
+++ b/cometline/src/lib/components/usage/UsagePage.svelte
@@ -15,6 +15,8 @@
 	import { seriesColor } from '$lib/usage/chart';
 	import { truncateWorkspacePath } from '$lib/jobs/group-jobs';
 	import {
+		cacheHitRate,
+		formatCacheHit,
 		formatEventTime,
 		formatKind,
 		formatRangeLabel,
@@ -56,6 +58,9 @@
 		)
 	);
 	const legendCosts = $derived(Object.fromEntries(legendRows.map((row) => [row.key, row.cost])));
+	const cacheReadTotal = $derived(summary?.totals.cache_read ?? 0);
+	const billedInputTotal = $derived(summary?.totals.billed_input ?? 0);
+	const cacheHit = $derived(formatCacheHit(cacheHitRate(billedInputTotal, cacheReadTotal)));
 
 	async function refresh(nextOffset = 0) {
 		const seq = ++refreshSeq;
@@ -101,12 +106,15 @@
 			);
 			if (!items.length) return;
 			const rows = [
-				['Date', 'Kind', 'Model', 'Tokens', 'Cost'],
+				['Date', 'Kind', 'Model', 'Input', 'Cache read', 'Cache write', 'Output', 'Cost'],
 				...items.map((item) => [
 					new Date(item.created_at).toISOString(),
 					item.call_kind,
 					item.model_id,
-					String(item.input_tokens + item.output_tokens + item.cache_read + item.cache_write),
+					String(item.input_tokens),
+					String(item.cache_read),
+					String(item.cache_write),
+					String(item.output_tokens),
 					item.priced ? item.estimated_usd.toFixed(6) : ''
 				])
 			];
@@ -136,7 +144,10 @@
 </script>
 
 <div class="usage-page settings-ui">
-	<p class="usage-desc">Usage is kept for one year. Older events are removed automatically.</p>
+	<p class="usage-desc">
+		Usage is kept for one year. Estimated cost uses public API rates. Cached input is billed at the
+		cache rate when the provider reports it.
+	</p>
 	<header class="usage-toolbar">
 		<div class="chips" role="group" aria-label="Date range">
 			<button type="button" class:active={preset === 'today'} onclick={() => applyPreset('today')}>Today</button>
@@ -185,6 +196,10 @@
 				<span>Estimated</span>
 			</article>
 			<article>
+				<strong>{cacheReadTotal > 0 ? `${formatTokens(cacheReadTotal)} · ${cacheHit}` : '—'}</strong>
+				<span>Cache read</span>
+			</article>
+			<article>
 				<strong>{formatTokens(summary.totals.unpriced_tokens)}</strong>
 				<span>Unpriced</span>
 			</article>
@@ -209,6 +224,7 @@
 				<div class="legend-head">
 					<span>{groupBy === 'kind' ? 'Kind' : 'Model'}</span>
 					<span>Tokens</span>
+					<span>Cache</span>
 					<span>Cost</span>
 				</div>
 				{#each legendRows as row, index (row.key)}
@@ -218,6 +234,7 @@
 							{row.label}
 						</span>
 						<span class="legend-meta">{formatTokens(row.tokens)}</span>
+						<span class="legend-meta">{row.cache}</span>
 						<span class="legend-meta">{row.cost}</span>
 					</div>
 				{/each}
@@ -236,7 +253,9 @@
 							<th>Date</th>
 							<th>Kind</th>
 							<th>Model</th>
-							<th>Tokens</th>
+							<th>Input</th>
+							<th>Cache</th>
+							<th>Output</th>
 							<th>Cost</th>
 						</tr>
 					</thead>
@@ -246,7 +265,9 @@
 								<td>{formatEventTime(item.created_at)}</td>
 								<td>{formatKind(item.call_kind)}</td>
 								<td>{item.model_id}</td>
-								<td>{formatTokens(item.input_tokens + item.output_tokens + item.cache_read + item.cache_write)}</td>
+								<td>{formatTokens(item.billed_input)}</td>
+								<td>{item.cache_read > 0 ? formatTokens(item.cache_read) : '—'}</td>
+								<td>{formatTokens(item.output_tokens)}</td>
 								<td>{item.priced ? formatUSD(item.estimated_usd) : '—'}</td>
 							</tr>
 						{/each}
@@ -424,7 +445,7 @@
 
 	.kpis {
 		display: grid;
-		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-columns: repeat(4, minmax(0, 1fr));
 		gap: 12px;
 	}
 
@@ -484,7 +505,7 @@
 	.legend-head,
 	.legend-row {
 		display: grid;
-		grid-template-columns: minmax(0, 1fr) 4.5rem 4.5rem;
+		grid-template-columns: minmax(0, 1fr) 4.5rem 4.5rem 4.5rem;
 		gap: 12px;
 		align-items: center;
 	}
@@ -567,6 +588,7 @@
 		}
 
 		.kpis {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 			gap: 8px;
 		}
 

--- a/cometline/src/lib/generated/cometmind-api/types.gen.ts
+++ b/cometline/src/lib/generated/cometmind-api/types.gen.ts
@@ -1308,6 +1308,11 @@ export type ImportMediaRequest = {
 
 export type UsageTotals = {
     tokens: number;
+    /**
+     * Fresh input tokens after cache is split out of inclusive provider totals
+     */
+    billed_input: number;
+    cache_read: number;
     priced_tokens: number;
     unpriced_tokens: number;
     estimated_usd: number;
@@ -1322,6 +1327,10 @@ export type UsageBucket = {
     output_tokens?: number;
     cache_read?: number;
     cache_write?: number;
+    /**
+     * Fresh input tokens after cache is split out of inclusive provider totals
+     */
+    billed_input?: number;
     tokens: number;
     estimated_usd: number;
     priced: boolean;
@@ -1364,6 +1373,10 @@ export type UsageEventResource = {
     output_tokens: number;
     cache_read: number;
     cache_write: number;
+    /**
+     * Fresh input tokens after cache is split out of inclusive provider totals
+     */
+    billed_input: number;
     estimated_usd: number;
     priced: boolean;
 };

--- a/cometline/src/lib/usage/format.test.ts
+++ b/cometline/src/lib/usage/format.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+	cacheHitRate,
 	clampUsageRange,
+	formatCacheHit,
 	formatKind,
 	formatRangeLabel,
 	formatTokens,
@@ -80,9 +82,20 @@ describe('usage format', () => {
 				'model'
 			)
 		).toEqual([
-			{ key: 'codex/gpt-5.6-luna', label: 'codex/gpt-5.6-luna', tokens: 8800, cost: '$0.12' },
-			{ key: 'xai/grok-4.6', label: 'xai/grok-4.6', tokens: 528800, cost: '—' }
+			{
+				key: 'codex/gpt-5.6-luna',
+				label: 'codex/gpt-5.6-luna',
+				tokens: 8800,
+				cache: '—',
+				cost: '$0.12'
+			},
+			{ key: 'xai/grok-4.6', label: 'xai/grok-4.6', tokens: 528800, cache: '—', cost: '—' }
 		]);
+	});
+
+	it('formats cache hit rate and hides zero as unknown', () => {
+		expect(formatCacheHit(cacheHitRate(800, 200))).toBe('20%');
+		expect(formatCacheHit(cacheHitRate(1000, 0))).toBe('—');
 	});
 
 	it('clamps custom ranges to one year', () => {

--- a/cometline/src/lib/usage/format.ts
+++ b/cometline/src/lib/usage/format.ts
@@ -52,10 +52,28 @@ export type UsageSeriesBucket = {
 	provider_id?: string;
 	model_id?: string;
 	call_kind?: string;
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_read?: number;
+	cache_write?: number;
+	billed_input?: number;
 	tokens: number;
 	estimated_usd: number;
 	priced: boolean;
 };
+
+export function cacheHitRate(freshInput: number, cacheRead: number): number | null {
+	const read = Math.max(0, cacheRead);
+	if (read <= 0) return null;
+	const denom = Math.max(0, freshInput) + read;
+	if (denom <= 0) return null;
+	return read / denom;
+}
+
+export function formatCacheHit(rate: number | null): string {
+	if (rate == null) return '—';
+	return `${Math.round(rate * 100)}%`;
+}
 
 export const MAX_RANGE_DAYS = 366;
 
@@ -131,6 +149,7 @@ export type UsageLegendRow = {
 	key: string;
 	label: string;
 	tokens: number;
+	cache: string;
 	cost: string;
 };
 
@@ -142,10 +161,12 @@ export function legendRowsForSeries(
 	const indexed = indexSeriesBuckets(buckets, groupBy);
 	return keys.map((key) => {
 		const bucket = indexed[key];
+		const cacheRead = bucket?.cache_read ?? 0;
 		return {
 			key,
 			label: groupBy === 'kind' ? formatKind(key) : key,
 			tokens: bucket?.tokens ?? 0,
+			cache: cacheRead > 0 ? formatTokens(cacheRead) : '—',
 			cost: formatBucketCost(bucket)
 		};
 	});

--- a/cometmind/internal/apigen/types.gen.go
+++ b/cometmind/internal/apigen/types.gen.go
@@ -2165,6 +2165,8 @@ type UpdateSkillRequest struct {
 
 // UsageBucket defines model for UsageBucket.
 type UsageBucket struct {
+	// BilledInput Fresh input tokens after cache is split out of inclusive provider totals
+	BilledInput    *int    `json:"billed_input,omitempty"`
 	CacheRead      *int    `json:"cache_read,omitempty"`
 	CacheWrite     *int    `json:"cache_write,omitempty"`
 	CallKind       *string `json:"call_kind,omitempty"`
@@ -2181,6 +2183,8 @@ type UsageBucket struct {
 
 // UsageEventResource defines model for UsageEventResource.
 type UsageEventResource struct {
+	// BilledInput Fresh input tokens after cache is split out of inclusive provider totals
+	BilledInput  int     `json:"billed_input"`
 	CacheRead    int     `json:"cache_read"`
 	CacheWrite   int     `json:"cache_write"`
 	CallKind     string  `json:"call_kind"`
@@ -2232,6 +2236,9 @@ type UsageSummaryResponse struct {
 
 // UsageTotals defines model for UsageTotals.
 type UsageTotals struct {
+	// BilledInput Fresh input tokens after cache is split out of inclusive provider totals
+	BilledInput    int     `json:"billed_input"`
+	CacheRead      int     `json:"cache_read"`
 	EstimatedUsd   float32 `json:"estimated_usd"`
 	PricedTokens   int     `json:"priced_tokens"`
 	Tokens         int     `json:"tokens"`

--- a/cometmind/internal/contract/contract_test.go
+++ b/cometmind/internal/contract/contract_test.go
@@ -152,6 +152,8 @@ func TestUsageSchemasMatchOpenAPI(t *testing.T) {
 		"to":   2,
 		"totals": map[string]any{
 			"tokens":          10,
+			"billed_input":    6,
+			"cache_read":      2,
 			"priced_tokens":   8,
 			"unpriced_tokens": 2,
 			"estimated_usd":   0.12,

--- a/cometmind/internal/usage/cost.go
+++ b/cometmind/internal/usage/cost.go
@@ -1,8 +1,71 @@
 package usage
 
-import "github.com/cometline/cometmind/internal/modelcatalog"
+import (
+	"strings"
 
-// EstimateUSD applies models.dev per-1M-token rates.
+	"github.com/cometline/cometmind/internal/modelcatalog"
+)
+
+// BilledUsage is the disjoint token classes used for totals and estimates.
+type BilledUsage struct {
+	Input      int
+	Output     int
+	CacheRead  int
+	CacheWrite int
+}
+
+// Tokens is the non-overlapping display total.
+func (b BilledUsage) Tokens() int {
+	return b.Input + b.Output + b.CacheRead + b.CacheWrite
+}
+
+func clampNonNeg(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// inputIncludesCache reports whether provider input totals already contain
+// cache read (and sometimes cache write). Unknown providers default to exclusive
+// so a gateway cannot underflow billed input to zero.
+//
+// This table is the billing contract. HTTP responses expose billed_input so
+// the desktop client must not copy these IDs.
+func inputIncludesCache(providerID string) bool {
+	switch strings.ToLower(strings.TrimSpace(providerID)) {
+	case "openai", "xai", "codex", "opencode-go", "opencode", "google":
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizeUsage splits a provider usage payload into disjoint billed classes.
+// Exclusive providers (Anthropic) keep input as-is. Inclusive providers
+// subtract cache from input so cache is not charged at the full input rate.
+func NormalizeUsage(providerID string, input, output, cacheRead, cacheWrite int) BilledUsage {
+	input = clampNonNeg(input)
+	output = clampNonNeg(output)
+	cacheRead = clampNonNeg(cacheRead)
+	cacheWrite = clampNonNeg(cacheWrite)
+	fresh := input
+	if inputIncludesCache(providerID) {
+		if cacheRead+cacheWrite <= input {
+			fresh = input - cacheRead - cacheWrite
+		} else {
+			fresh = clampNonNeg(input - cacheRead)
+		}
+	}
+	return BilledUsage{
+		Input:      fresh,
+		Output:     output,
+		CacheRead:  cacheRead,
+		CacheWrite: cacheWrite,
+	}
+}
+
+// EstimateUSD applies models.dev per-1M-token rates to disjoint token classes.
 func EstimateUSD(cost modelcatalog.Cost, input, output, cacheRead, cacheWrite int) float64 {
 	if !cost.Found {
 		return 0

--- a/cometmind/internal/usage/cost_test.go
+++ b/cometmind/internal/usage/cost_test.go
@@ -16,3 +16,83 @@ func TestEstimateUSD(t *testing.T) {
 		t.Fatal("unpriced should be 0")
 	}
 }
+
+func TestNormalizeUsageExclusiveKeepsInput(t *testing.T) {
+	t.Parallel()
+	got := NormalizeUsage("anthropic", 1000, 50, 200, 100)
+	if got != (BilledUsage{Input: 1000, Output: 50, CacheRead: 200, CacheWrite: 100}) {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Tokens() != 1350 {
+		t.Fatalf("tokens=%d", got.Tokens())
+	}
+}
+
+func TestNormalizeUsageInclusiveSubtractsCache(t *testing.T) {
+	t.Parallel()
+	got := NormalizeUsage("openai", 1000, 50, 200, 0)
+	if got != (BilledUsage{Input: 800, Output: 50, CacheRead: 200, CacheWrite: 0}) {
+		t.Fatalf("got %+v", got)
+	}
+	codex := NormalizeUsage("codex", 1000, 10, 400, 0)
+	if codex.Input != 600 || codex.CacheRead != 400 {
+		t.Fatalf("codex=%+v", codex)
+	}
+	xai := NormalizeUsage("xai", 1000, 10, 100, 50)
+	if xai.Input != 850 {
+		t.Fatalf("xai=%+v", xai)
+	}
+}
+
+func TestNormalizeUsageInclusiveDoesNotUnderflow(t *testing.T) {
+	t.Parallel()
+	got := NormalizeUsage("openai", 100, 0, 200, 50)
+	if got.Input != 0 {
+		t.Fatalf("input=%d", got.Input)
+	}
+	if got.CacheRead != 200 {
+		t.Fatalf("cache_read=%d", got.CacheRead)
+	}
+}
+
+func TestNormalizeUsageCodexWithoutCacheKeepsInput(t *testing.T) {
+	t.Parallel()
+	got := NormalizeUsage("codex", 1000, 10, 0, 0)
+	if got != (BilledUsage{Input: 1000, Output: 10}) {
+		t.Fatalf("got %+v", got)
+	}
+	cost := modelcatalog.Cost{Input: 3, Output: 15, Found: true}
+	usd := EstimateUSD(cost, got.Input, got.Output, got.CacheRead, got.CacheWrite)
+	if usd != 0.00315 {
+		t.Fatalf("codex estimate %v want 0.00315 (still API-priced)", usd)
+	}
+}
+
+func TestNormalizeUsageUnknownProviderIsExclusive(t *testing.T) {
+	t.Parallel()
+	got := NormalizeUsage("mystery-gateway", 1000, 0, 200, 0)
+	if got.Input != 1000 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestEstimateUSDUsesCacheRateAfterNormalize(t *testing.T) {
+	t.Parallel()
+	cost := modelcatalog.Cost{Input: 3, Output: 15, CacheRead: 0.3, CacheWrite: 3.75, Found: true}
+	anthropic := NormalizeUsage("anthropic", 1_000_000, 0, 1_000_000, 0)
+	got := EstimateUSD(cost, anthropic.Input, anthropic.Output, anthropic.CacheRead, anthropic.CacheWrite)
+	if got != 3.3 {
+		t.Fatalf("anthropic got %v want 3.3", got)
+	}
+	openai := NormalizeUsage("openai", 1_000_000, 0, 200_000, 0)
+	got = EstimateUSD(cost, openai.Input, openai.Output, openai.CacheRead, openai.CacheWrite)
+	want := 0.8*3 + 0.2*0.3
+	if got != want {
+		t.Fatalf("openai got %v want %v", got, want)
+	}
+	zeroCache := NormalizeUsage("openai", 1_000_000, 1_000_000, 0, 0)
+	got = EstimateUSD(cost, zeroCache.Input, zeroCache.Output, zeroCache.CacheRead, zeroCache.CacheWrite)
+	if got != 18 {
+		t.Fatalf("zero cache got %v want 18", got)
+	}
+}

--- a/cometmind/internal/usage/service.go
+++ b/cometmind/internal/usage/service.go
@@ -54,6 +54,7 @@ type Recorded struct {
 	OutputTokens int
 	CacheRead    int
 	CacheWrite   int
+	BilledInput  int
 	EstimatedUSD float64
 	Priced       bool
 }
@@ -68,6 +69,7 @@ type Bucket struct {
 	OutputTokens int
 	CacheRead    int
 	CacheWrite   int
+	BilledInput  int
 	Tokens       int
 	EstimatedUSD float64
 	Priced       bool
@@ -77,6 +79,8 @@ type Bucket struct {
 // Totals is the dashboard KPI set.
 type Totals struct {
 	Tokens         int
+	BilledInput    int
+	CacheRead      int
 	PricedTokens   int
 	UnpricedTokens int
 	EstimatedUSD   float64
@@ -233,7 +237,8 @@ func recordedFromRow(row db.UsageEvent, prices costCache) Recorded {
 	if prices == nil {
 		prices = newCostCache()
 	}
-	usd, priced := prices.price(row.ProviderID, row.ModelID, in, out, cacheRead, cacheWrite)
+	billed := NormalizeUsage(row.ProviderID, in, out, cacheRead, cacheWrite)
+	usd, priced := prices.price(row.ProviderID, row.ModelID, billed.Input, billed.Output, billed.CacheRead, billed.CacheWrite)
 	return Recorded{
 		ID:           row.ID,
 		CreatedAt:    row.CreatedAt,
@@ -246,9 +251,14 @@ func recordedFromRow(row db.UsageEvent, prices costCache) Recorded {
 		OutputTokens: out,
 		CacheRead:    cacheRead,
 		CacheWrite:   cacheWrite,
+		BilledInput:  billed.Input,
 		EstimatedUSD: usd,
 		Priced:       priced,
 	}
+}
+
+func (r Recorded) Billed() BilledUsage {
+	return NormalizeUsage(r.ProviderID, r.InputTokens, r.OutputTokens, r.CacheRead, r.CacheWrite)
 }
 
 func addTokens(b *Bucket, rec Recorded) {
@@ -256,7 +266,8 @@ func addTokens(b *Bucket, rec Recorded) {
 	b.OutputTokens += rec.OutputTokens
 	b.CacheRead += rec.CacheRead
 	b.CacheWrite += rec.CacheWrite
-	tokens := rec.InputTokens + rec.OutputTokens + rec.CacheRead + rec.CacheWrite
+	b.BilledInput += rec.BilledInput
+	tokens := rec.Billed().Tokens()
 	b.Tokens += tokens
 	if rec.Priced {
 		b.EstimatedUSD += rec.EstimatedUSD
@@ -282,8 +293,10 @@ func accumulate(rows []db.UsageEvent) (Totals, []Bucket, []Bucket) {
 	var totals Totals
 	for _, row := range rows {
 		rec := recordedFromRow(row, prices)
-		tokens := rec.InputTokens + rec.OutputTokens + rec.CacheRead + rec.CacheWrite
+		tokens := rec.Billed().Tokens()
 		totals.Tokens += tokens
+		totals.BilledInput += rec.BilledInput
+		totals.CacheRead += rec.CacheRead
 		if rec.Priced {
 			totals.PricedTokens += tokens
 			totals.EstimatedUSD += rec.EstimatedUSD
@@ -419,7 +432,7 @@ func (s *Service) Series(ctx context.Context, from, to int64, workspaceID, group
 		if dayTotals[day] == nil {
 			dayTotals[day] = map[string]int{}
 		}
-		dayTotals[day][key] += rec.InputTokens + rec.OutputTokens + rec.CacheRead + rec.CacheWrite
+		dayTotals[day][key] += rec.Billed().Tokens()
 	}
 	keys := make([]string, 0, len(keySet))
 	for k := range keySet {

--- a/cometmind/internal/usage/service_test.go
+++ b/cometmind/internal/usage/service_test.go
@@ -209,6 +209,56 @@ func TestUsageClampRangeAndPurgeOlderThan(t *testing.T) {
 	}
 }
 
+func TestUsageInclusiveCacheDoesNotDoubleCount(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := store.OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	svc := usage.NewService(sqlDB)
+	now := time.Now()
+	from := now.Add(-time.Hour).UnixMilli()
+	to := now.Add(time.Hour).UnixMilli()
+	if err := svc.Record(ctx, usage.Event{
+		ProviderID: "openai",
+		ModelID:    "gpt-4o",
+		CallKind:   usage.KindAgentStep,
+		Usage:      cometsdk.TokenUsage{InputTokens: 1000, OutputTokens: 50, CacheRead: 200},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, err := svc.Summary(ctx, from, to, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Totals.Tokens != 1050 {
+		t.Fatalf("tokens=%d want 1050 (fresh 800 + cache 200 + out 50)", summary.Totals.Tokens)
+	}
+	if summary.Totals.BilledInput != 800 {
+		t.Fatalf("billed_input=%d want 800", summary.Totals.BilledInput)
+	}
+	if summary.Totals.CacheRead != 200 {
+		t.Fatalf("cache_read=%d want 200", summary.Totals.CacheRead)
+	}
+	if summary.ByModel[0].CacheRead != 200 {
+		t.Fatalf("cache_read=%d", summary.ByModel[0].CacheRead)
+	}
+	if summary.ByModel[0].BilledInput != 800 {
+		t.Fatalf("model billed_input=%d", summary.ByModel[0].BilledInput)
+	}
+	page, err := svc.List(ctx, from, to, "", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Items[0].InputTokens != 1000 || page.Items[0].CacheRead != 200 {
+		t.Fatalf("raw row=%+v", page.Items[0])
+	}
+	if page.Items[0].BilledInput != 800 {
+		t.Fatalf("billed input=%d", page.Items[0].BilledInput)
+	}
+}
+
 func TestUsageRecordSkipsAllZeroTokens(t *testing.T) {
 	ctx := context.Background()
 	sqlDB, err := store.OpenSQLite(ctx, ":memory:")

--- a/cometmind/openapi.yaml
+++ b/cometmind/openapi.yaml
@@ -5051,9 +5051,14 @@ components:
     UsageTotals:
       type: object
       additionalProperties: false
-      required: [tokens, priced_tokens, unpriced_tokens, estimated_usd]
+      required: [tokens, billed_input, cache_read, priced_tokens, unpriced_tokens, estimated_usd]
       properties:
         tokens:
+          type: integer
+        billed_input:
+          type: integer
+          description: Fresh input tokens after cache is split out of inclusive provider totals
+        cache_read:
           type: integer
         priced_tokens:
           type: integer
@@ -5083,6 +5088,9 @@ components:
           type: integer
         cache_write:
           type: integer
+        billed_input:
+          type: integer
+          description: Fresh input tokens after cache is split out of inclusive provider totals
         tokens:
           type: integer
         estimated_usd:
@@ -5150,7 +5158,7 @@ components:
     UsageEventResource:
       type: object
       additionalProperties: false
-      required: [id, created_at, provider_id, model_id, call_kind, input_tokens, output_tokens, cache_read, cache_write, estimated_usd, priced]
+      required: [id, created_at, provider_id, model_id, call_kind, input_tokens, output_tokens, cache_read, cache_write, billed_input, estimated_usd, priced]
       properties:
         id:
           type: string
@@ -5175,6 +5183,9 @@ components:
           type: integer
         cache_write:
           type: integer
+        billed_input:
+          type: integer
+          description: Fresh input tokens after cache is split out of inclusive provider totals
         estimated_usd:
           type: number
         priced:

--- a/cometmind/server/usage_handlers.go
+++ b/cometmind/server/usage_handlers.go
@@ -97,6 +97,7 @@ func (a *App) handleListUsageEvents(c *gin.Context) {
 			"output_tokens": item.OutputTokens,
 			"cache_read":    item.CacheRead,
 			"cache_write":   item.CacheWrite,
+			"billed_input":  item.BilledInput,
 			"estimated_usd": item.EstimatedUSD,
 			"priced":        item.Priced,
 		})
@@ -153,6 +154,8 @@ func parseUsageTZOffset(c *gin.Context) (offsetMin int, ok bool) {
 func usageTotalsJSON(t usage.Totals) gin.H {
 	return gin.H{
 		"tokens":          t.Tokens,
+		"billed_input":    t.BilledInput,
+		"cache_read":      t.CacheRead,
 		"priced_tokens":   t.PricedTokens,
 		"unpriced_tokens": t.UnpricedTokens,
 		"estimated_usd":   t.EstimatedUSD,
@@ -171,6 +174,7 @@ func usageBucketsJSON(items []usage.Bucket) []gin.H {
 			"output_tokens":   item.OutputTokens,
 			"cache_read":      item.CacheRead,
 			"cache_write":     item.CacheWrite,
+			"billed_input":    item.BilledInput,
 			"tokens":          item.Tokens,
 			"estimated_usd":   item.EstimatedUSD,
 			"priced":          item.Priced,


### PR DESCRIPTION
## Background

Usage estimates treated provider input as one blob, so OpenAI-style cache hits were charged at the full input rate and sometimes counted twice. Codex should still show a public API estimate rather than Included or $0.

[27eaa8a](https://github.com/Cometline/cometline/commit/27eaa8a7fcb378ed95850cb5b009074a20161417): Inclusive providers subtract cache from input before pricing. Anthropic keeps exclusive input. Responses streams now copy `cached_tokens`. The Usage page shows cache as its own class and reads `billed_input` from the API so the client does not copy the provider table. CSV still exports raw `input_tokens`.