### PR TITLE
[main] fix: keep session title when clearing transcript

### DIFF
--- a/cometline/src/lib/components/composer/composer-slash.svelte.ts
+++ b/cometline/src/lib/components/composer/composer-slash.svelte.ts
@@ -338,10 +338,6 @@ export function createComposerSlashController(deps: {
 			chatStore.resetTranscript(sessionId);
 			shellStore.centerComposer();
 			deps.onTranscriptCleared?.();
-			const current = sessionStore.current;
-			if (current?.id === sessionId) {
-				sessionStore.updateSession({ ...current, title: '' });
-			}
 			deps.getInput()?.clear();
 			deps.setValue('');
 			deps.setImages([]);

--- a/cometmind/internal/db/queries/sessions.sql
+++ b/cometmind/internal/db/queries/sessions.sql
@@ -242,7 +242,6 @@ WHERE id = ?;
 -- name: ResetSessionTranscriptState :exec
 UPDATE sessions
 SET
-    title = ?,
     token_usage = ?,
     context_summary = '',
     compacted_until_message_id = NULL,

--- a/cometmind/internal/db/sessions.sql.go
+++ b/cometmind/internal/db/sessions.sql.go
@@ -643,7 +643,6 @@ func (q *Queries) MarkSessionNonDisposable(ctx context.Context, id string) error
 const resetSessionTranscriptState = `-- name: ResetSessionTranscriptState :exec
 UPDATE sessions
 SET
-    title = ?,
     token_usage = ?,
     context_summary = '',
     compacted_until_message_id = NULL,
@@ -653,13 +652,12 @@ WHERE id = ?
 `
 
 type ResetSessionTranscriptStateParams struct {
-	Title      string `json:"title"`
 	TokenUsage string `json:"token_usage"`
 	ID         string `json:"id"`
 }
 
 func (q *Queries) ResetSessionTranscriptState(ctx context.Context, arg ResetSessionTranscriptStateParams) error {
-	_, err := q.db.ExecContext(ctx, resetSessionTranscriptState, arg.Title, arg.TokenUsage, arg.ID)
+	_, err := q.db.ExecContext(ctx, resetSessionTranscriptState, arg.TokenUsage, arg.ID)
 	return err
 }
 

--- a/cometmind/internal/gateway/router.go
+++ b/cometmind/internal/gateway/router.go
@@ -369,7 +369,7 @@ func (r *Router) ChangeWorkspace(ctx context.Context, msg InboundMessage, worksp
 }
 
 // HandleClearSlash clears the transcript for the session mapped to the current
-// platform channel or thread while preserving the session identity.
+// platform channel or thread while preserving the session identity and title.
 func (r *Router) HandleClearSlash(ctx context.Context, msg InboundMessage) (string, error) {
 	if r == nil || r.Sessions == nil {
 		return "", fmt.Errorf("gateway router is not configured")

--- a/cometmind/internal/gateway/router_test.go
+++ b/cometmind/internal/gateway/router_test.go
@@ -304,8 +304,8 @@ func TestHandleClearSlashClearsMappedSessionTranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSession() error = %v", err)
 	}
-	if updated.Title != "" {
-		t.Fatalf("title = %q, want empty", updated.Title)
+	if updated.Title != "hello" {
+		t.Fatalf("title = %q, want %q", updated.Title, "hello")
 	}
 	if updated.TokenUsage != "{}" {
 		t.Fatalf("token_usage = %q, want {}", updated.TokenUsage)

--- a/cometmind/internal/session/service.go
+++ b/cometmind/internal/session/service.go
@@ -548,7 +548,7 @@ func (s *Service) PruneUnusedUserSessions(ctx context.Context) (int, error) {
 }
 
 // ClearSessionTranscript deletes all transcript rows for a session and resets
-// compaction, token usage, and title while preserving the session identity.
+// compaction and token usage while preserving the session identity and title.
 // Delegated child sessions are removed as well so subagent UI does not reappear
 // on transcript reload.
 func (s *Service) ClearSessionTranscript(ctx context.Context, sessionID string) error {
@@ -568,7 +568,6 @@ func (s *Service) ClearSessionTranscript(ctx context.Context, sessionID string) 
 		return err
 	}
 	return s.q.ResetSessionTranscriptState(ctx, db.ResetSessionTranscriptStateParams{
-		Title:      "",
 		TokenUsage: "{}",
 		ID:         sessionID,
 	})

--- a/cometmind/server/server_test.go
+++ b/cometmind/server/server_test.go
@@ -721,6 +721,9 @@ func TestClearSessionResetsTranscript(t *testing.T) {
 	if _, err := svc.AppendUserMessage(ctx, sess.ID, "hello"); err != nil {
 		t.Fatalf("AppendUserMessage() error = %v", err)
 	}
+	if err := svc.SetTitleIfEmpty(ctx, sess.ID, "keep this title"); err != nil {
+		t.Fatalf("SetTitleIfEmpty() error = %v", err)
+	}
 	if err := svc.UpdateContextSummary(ctx, sess.ID, "old summary", "ignored"); err != nil {
 		t.Fatalf("UpdateContextSummary() error = %v", err)
 	}
@@ -743,8 +746,11 @@ func TestClearSessionResetsTranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSession() error = %v", err)
 	}
-	if got.ContextSummary != "" || got.CompactedUntilMessageID != "" || got.Title != "" {
+	if got.ContextSummary != "" || got.CompactedUntilMessageID != "" {
 		t.Fatalf("session state after clear = %+v", got)
+	}
+	if got.Title != "keep this title" {
+		t.Fatalf("session title after clear = %q, want %q", got.Title, "keep this title")
 	}
 }
 

--- a/docs/learning/06-cometmind-features.md
+++ b/docs/learning/06-cometmind-features.md
@@ -81,7 +81,7 @@ Reusable prompt templates stored as `SKILL.md` files with YAML frontmatter (`nam
 - Chat: `/{skill-name}` in the composer
 - Built-in slash commands (in `cometline/src/lib/skills/slash-commands.ts`):
   - `/change` — fork session into another workspace
-  - `/clear` — clear transcript and start fresh
+  - `/clear` — clear transcript and start fresh (keeps the session title)
   - `/create-skill` — draft a skill for review
   - `/model` — switch model for the current session
   - `/job` — claim a ready job


### PR DESCRIPTION
## Background

`/clear` was wiping the session title along with the transcript, both in Cometline and through the Discord gateway. The conversation should start fresh, but the existing title should stay.

[b6b4d40](https://github.com/Cometline/cometline/commit/b6b4d40c44b090fc02b002c1b79057d6b8efedef): Clear now resets messages, compaction, and token usage without blanking the title, and the composer no longer locally empties it either.