### PR TITLE
[main] feat: retry model timeouts after tools

### DIFF
--- a/cometmind/internal/agent/runner.go
+++ b/cometmind/internal/agent/runner.go
@@ -21,7 +21,13 @@ import (
 	"github.com/cometline/cometmind/internal/tools"
 )
 
-const memoryRetrievalTimeout = 3 * time.Second
+const (
+	memoryRetrievalTimeout       = 3 * time.Second
+	maxStreamRecoveryAttempts    = 3
+	defaultStreamRecoveryBackoff = 2 * time.Second
+	maxStreamRecoveryBackoff     = 8 * time.Second
+	timeoutContinueHint          = "The model timed out before finishing. Send another message to continue from here."
+)
 
 // TurnStore is the narrow persistence seam the agent loop drives. It is the
 // subset of session.Service the Runner actually needs, declared here on the
@@ -61,11 +67,14 @@ type Runner struct {
 	MaxSteps               int
 	MaxTokens              int
 	MemoryRetrievalTimeout time.Duration
-	SystemPrompt           string
-	AgentMode              session.AgentMode
-	SkillIndex             string
-	JobIndex               string
-	SubagentOrchestrator   *subagent.Orchestrator
+	// StreamRecoveryBackoff is the first wait between recoverable model-stream
+	// retries. Later attempts double it up to eight seconds. Zero uses 2s.
+	StreamRecoveryBackoff time.Duration
+	SystemPrompt          string
+	AgentMode             session.AgentMode
+	SkillIndex            string
+	JobIndex              string
+	SubagentOrchestrator  *subagent.Orchestrator
 
 	// MemorySem is an optional semaphore that bounds the number of
 	// extractMemoryAfterTurn calls that may run concurrently across all
@@ -440,11 +449,25 @@ func (r *Runner) Run(ctx context.Context, turn session.AgentTurn, ch chan<- even
 					logging.L().Warn("agent.step.overflow_compact_failed", "session", turn.ID, "error", compactErr)
 				}
 			}
-			if recoveryAttempt == 0 && recoverableStreamFailure(err) && !completeToolCall {
+			if ctx.Err() == nil && recoveryAttempt < maxStreamRecoveryAttempts && recoverableStreamFailure(err) && !completeToolCall {
 				textChars, reasoningChars := partialRenderLengths(result)
 				recoveryAttempt++
-				logging.L().Warn("agent.step.recover", "session", turn.ID, "provider", r.Provider.ID(), "model", turn.ModelID, "step", steps+1, "failure_category", failureCategory, "recovery_attempt", recoveryAttempt, "text_chars", textChars, "reasoning_chars", reasoningChars)
+				delay := recoveryDelay(r.StreamRecoveryBackoff, recoveryAttempt)
+				if ra := retryAfterDelay(err); ra > delay {
+					delay = ra
+				}
+				logging.L().Warn("agent.step.recover", "session", turn.ID, "provider", r.Provider.ID(), "model", turn.ModelID, "step", steps+1, "failure_category", failureCategory, "recovery_attempt", recoveryAttempt, "delay_ms", delay.Milliseconds(), "text_chars", textChars, "reasoning_chars", reasoningChars)
 				ch <- event.TurnRecover(textChars, reasoningChars)
+				if waitErr := waitForRecovery(ctx, delay); waitErr != nil {
+					persistPartialStep(ctx, r.Sessions, turn.ID, turn.ProviderID, result, pendingMemories)
+					if errors.Is(waitErr, context.Canceled) && errors.Is(ctx.Err(), context.Canceled) {
+						logging.L().Info("agent.step.stopped", "session", turn.ID, "provider", r.Provider.ID(), "model", turn.ModelID, "step", steps+1, "duration_ms", time.Since(streamStarted).Milliseconds())
+						return nil
+					}
+					logging.L().Error("agent.step.failed", "session", turn.ID, "provider", r.Provider.ID(), "model", turn.ModelID, "step", steps+1, "events", eventCount, "first_event", firstEventLogged, "first_output", firstOutputLogged, "complete_tool_call", completeToolCall, "failure_category", failureCategory, "recovery_attempt", recoveryAttempt, "duration_ms", time.Since(streamStarted).Milliseconds(), "error", waitErr)
+					ch <- event.Errorf(userFacingAgentError(waitErr), "llm")
+					return waitErr
+				}
 				continue
 			}
 			persistPartialStep(ctx, r.Sessions, turn.ID, turn.ProviderID, result, pendingMemories)
@@ -953,7 +976,7 @@ func userFacingAgentError(err error) string {
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return "The model timed out before finishing. Send the message again to continue."
+			return timeoutContinueHint
 		}
 		return "Response interrupted. Send the message again to continue."
 	}
@@ -967,9 +990,45 @@ func userFacingAgentError(err error) string {
 		return "Response interrupted. Send the message again to continue."
 	}
 	if strings.Contains(lower, "deadline exceeded") || strings.Contains(lower, "timeout") {
-		return "The model timed out before finishing. Send the message again to continue."
+		return timeoutContinueHint
 	}
 	return msg
+}
+
+func recoveryDelay(base time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		base = defaultStreamRecoveryBackoff
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := base * time.Duration(1<<uint(attempt-1))
+	if delay > maxStreamRecoveryBackoff {
+		return maxStreamRecoveryBackoff
+	}
+	return delay
+}
+
+func retryAfterDelay(err error) time.Duration {
+	var rateLimit *cometsdk.RateLimitError
+	if errors.As(err, &rateLimit) {
+		return rateLimit.RetryAfterDelay
+	}
+	return 0
+}
+
+func waitForRecovery(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // backgroundProgressEmitter is used for tool callbacks that may outlive the

--- a/cometmind/internal/agent/runner_test.go
+++ b/cometmind/internal/agent/runner_test.go
@@ -1532,7 +1532,7 @@ func TestUserFacingAgentError(t *testing.T) {
 	if got := userFacingAgentError(fmt.Errorf("openai: context canceled")); !strings.Contains(got, "interrupted") {
 		t.Fatalf("wrapped canceled = %q", got)
 	}
-	if got := userFacingAgentError(context.DeadlineExceeded); !strings.Contains(got, "timed out") {
+	if got := userFacingAgentError(context.DeadlineExceeded); got != timeoutContinueHint {
 		t.Fatalf("deadline = %q", got)
 	}
 	if got := userFacingAgentError(fmt.Errorf("provider exploded")); got != "provider exploded" {
@@ -1553,7 +1553,7 @@ func TestRunner_RecoversPartialStreamOnceWithoutPersistingFirstAttempt(t *testin
 		},
 	}}
 	store := &fakeStore{}
-	r := &Runner{Provider: provider, Sessions: store, Registry: tools.NewRegistry(t.TempDir())}
+	r := &Runner{Provider: provider, Sessions: store, Registry: tools.NewRegistry(t.TempDir()), StreamRecoveryBackoff: time.Millisecond}
 
 	events, err := runAndDrain(t, r, session.AgentTurn{ID: "s-recover", ModelID: "m"})
 	if err != nil {
@@ -1576,29 +1576,27 @@ func TestRunner_RecoversPartialStreamOnceWithoutPersistingFirstAttempt(t *testin
 	}
 }
 
-func TestRunner_StopsAfterSecondRecoverableStreamFailureAndPersistsPartial(t *testing.T) {
+func TestRunner_StopsAfterMaxRecoverableStreamFailuresAndPersistsPartial(t *testing.T) {
+	eof := cometsdk.ErrorEvent{Err: &cometsdk.StreamError{ProviderID: "fake", Cause: io.ErrUnexpectedEOF}}
 	provider := &sequentialFakeProvider{sequences: [][]cometsdk.Event{
-		{
-			cometsdk.TextDeltaEvent{Text: "first"},
-			cometsdk.ErrorEvent{Err: &cometsdk.StreamError{ProviderID: "fake", Cause: io.ErrUnexpectedEOF}},
-		},
-		{
-			cometsdk.TextDeltaEvent{Text: "second"},
-			cometsdk.ErrorEvent{Err: &cometsdk.StreamError{ProviderID: "fake", Cause: io.ErrUnexpectedEOF}},
-		},
+		{cometsdk.TextDeltaEvent{Text: "first"}, eof},
+		{cometsdk.TextDeltaEvent{Text: "second"}, eof},
+		{cometsdk.TextDeltaEvent{Text: "third"}, eof},
+		{cometsdk.TextDeltaEvent{Text: "fourth"}, eof},
 	}}
 	store := &fakeStore{}
-	r := &Runner{Provider: provider, Sessions: store, Registry: tools.NewRegistry(t.TempDir())}
+	r := &Runner{Provider: provider, Sessions: store, Registry: tools.NewRegistry(t.TempDir()), StreamRecoveryBackoff: time.Millisecond}
 
 	_, err := runAndDrain(t, r, session.AgentTurn{ID: "s-double-fail", ModelID: "m"})
 	if err == nil {
 		t.Fatal("Run returned nil error")
 	}
-	if provider.calls != 2 {
-		t.Fatalf("Stream called %d times, want 2", provider.calls)
+	wantCalls := maxStreamRecoveryAttempts + 1
+	if provider.calls != wantCalls {
+		t.Fatalf("Stream called %d times, want %d", provider.calls, wantCalls)
 	}
-	if store.appendCalls != 1 || store.appendTexts[0] != "second" {
-		t.Fatalf("partial persistence = calls=%d texts=%q, want second attempt only", store.appendCalls, store.appendTexts)
+	if store.appendCalls != 1 || store.appendTexts[0] != "fourth" {
+		t.Fatalf("partial persistence = calls=%d texts=%q, want last attempt only", store.appendCalls, store.appendTexts)
 	}
 }
 
@@ -1607,7 +1605,7 @@ func TestRunner_DoesNotRecoverAfterCompleteToolCall(t *testing.T) {
 		cometsdk.ToolCallDoneEvent{ID: "tc-1", Name: "list_dir", Input: json.RawMessage(`{"path":"."}`)},
 		cometsdk.ErrorEvent{Err: &cometsdk.StreamError{ProviderID: "fake", Cause: io.ErrUnexpectedEOF}},
 	}}}
-	r := &Runner{Provider: provider, Sessions: &fakeStore{}, Registry: tools.NewRegistry(t.TempDir())}
+	r := &Runner{Provider: provider, Sessions: &fakeStore{}, Registry: tools.NewRegistry(t.TempDir()), StreamRecoveryBackoff: time.Millisecond}
 
 	_, err := runAndDrain(t, r, session.AgentTurn{ID: "s-tool-fail", ModelID: "m"})
 	if err == nil {
@@ -1615,6 +1613,73 @@ func TestRunner_DoesNotRecoverAfterCompleteToolCall(t *testing.T) {
 	}
 	if provider.calls != 1 {
 		t.Fatalf("Stream called %d times, want 1 after complete tool call", provider.calls)
+	}
+}
+
+func TestRunner_RecoversGatewayTimeoutAfterTools(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatalf("write hello.txt: %v", err)
+	}
+	gatewayTimeout := cometsdk.ErrorEvent{Err: &cometsdk.ServerError{ProviderID: "fake", StatusCode: 504, Message: "Gateway Timeout"}}
+	provider := &sequentialFakeProvider{sequences: [][]cometsdk.Event{
+		toolStep("tc1", "read_file", `{"path":"hello.txt"}`),
+		{gatewayTimeout},
+		{
+			cometsdk.TextDeltaEvent{Text: "continuing after timeout"},
+			cometsdk.StepFinishEvent{FinishReason: cometsdk.FinishStop},
+			cometsdk.DoneEvent{},
+		},
+	}}
+	store := &fakeStore{}
+	r := &Runner{
+		Provider:              provider,
+		Sessions:              store,
+		Registry:              tools.NewRegistry(dir),
+		StreamRecoveryBackoff: time.Millisecond,
+		MaxSteps:              4,
+	}
+
+	events, err := runAndDrain(t, r, session.AgentTurn{ID: "s-gateway", ModelID: "m"})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if provider.calls != 3 {
+		t.Fatalf("Stream called %d times, want 3 (tools, failed follow-up, recovered follow-up)", provider.calls)
+	}
+	if store.toolResults != 1 {
+		t.Fatalf("toolResults = %d, want 1", store.toolResults)
+	}
+	var recoverCount, errorCount int
+	for _, ev := range events {
+		if ev.Kind == event.KindTurnRecover {
+			recoverCount++
+		}
+		if ev.Kind == event.KindError {
+			errorCount++
+		}
+	}
+	if recoverCount != 1 {
+		t.Fatalf("turn_recover events = %d, want 1", recoverCount)
+	}
+	if errorCount != 0 {
+		t.Fatalf("error events = %d, want 0 while recovery succeeds", errorCount)
+	}
+}
+
+func TestRecoveryDelayDoublesAndCaps(t *testing.T) {
+	t.Parallel()
+	if got := recoveryDelay(2*time.Second, 1); got != 2*time.Second {
+		t.Fatalf("attempt 1 = %s, want 2s", got)
+	}
+	if got := recoveryDelay(2*time.Second, 2); got != 4*time.Second {
+		t.Fatalf("attempt 2 = %s, want 4s", got)
+	}
+	if got := recoveryDelay(2*time.Second, 3); got != 8*time.Second {
+		t.Fatalf("attempt 3 = %s, want 8s", got)
+	}
+	if got := recoveryDelay(2*time.Second, 4); got != 8*time.Second {
+		t.Fatalf("attempt 4 = %s, want cap 8s", got)
 	}
 }
 

--- a/cometmind/internal/agent/stream_failure.go
+++ b/cometmind/internal/agent/stream_failure.go
@@ -22,25 +22,36 @@ const (
 )
 
 // classifyStreamFailure keeps recovery policy independent of provider names.
-// It deliberately treats every 4xx response and cancellation as terminal.
+// User cancellation and auth failures stay terminal. Transient gateway pressure
+// (429, 5xx, timeouts) is recoverable so a later model step can continue after
+// tools have already finished.
 func classifyStreamFailure(err error) streamFailureCategory {
 	if err == nil {
 		return streamFailureOther
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) {
 		return streamFailureCancelled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return streamFailureRecoverable
 	}
 	var auth *cometsdk.AuthError
 	if errors.As(err, &auth) {
 		return streamFailureAuth
 	}
-	var server *cometsdk.ServerError
-	if errors.As(err, &server) && server.StatusCode >= 400 && server.StatusCode < 500 {
-		return streamFailureHTTP4xx
-	}
 	var rateLimit *cometsdk.RateLimitError
 	if errors.As(err, &rateLimit) {
-		return streamFailureHTTP4xx
+		return streamFailureRecoverable
+	}
+	var server *cometsdk.ServerError
+	if errors.As(err, &server) {
+		switch server.StatusCode {
+		case 429, 500, 502, 503, 504, 529:
+			return streamFailureRecoverable
+		}
+		if server.StatusCode >= 400 && server.StatusCode < 500 {
+			return streamFailureHTTP4xx
+		}
 	}
 	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) {
 		return streamFailureRecoverable
@@ -51,7 +62,8 @@ func classifyStreamFailure(err error) streamFailureCategory {
 	}
 	lower := strings.ToLower(err.Error())
 	if strings.Contains(lower, "connection reset") || strings.Contains(lower, "unexpected eof") ||
-		strings.Contains(lower, "connection aborted") || strings.Contains(lower, "broken pipe") {
+		strings.Contains(lower, "connection aborted") || strings.Contains(lower, "broken pipe") ||
+		strings.Contains(lower, "deadline exceeded") || strings.Contains(lower, "timeout") {
 		return streamFailureRecoverable
 	}
 	return streamFailureOther

--- a/cometmind/internal/agent/stream_failure_test.go
+++ b/cometmind/internal/agent/stream_failure_test.go
@@ -26,12 +26,15 @@ func TestClassifyStreamFailure(t *testing.T) {
 		want streamFailureCategory
 	}{
 		{"timeout", timeoutError{}, streamFailureRecoverable},
+		{"deadline exceeded", context.DeadlineExceeded, streamFailureRecoverable},
 		{"unexpected eof", io.ErrUnexpectedEOF, streamFailureRecoverable},
 		{"connection reset", syscall.ECONNRESET, streamFailureRecoverable},
 		{"cancelled", context.Canceled, streamFailureCancelled},
 		{"auth", &cometsdk.AuthError{ProviderID: "x", StatusCode: 401}, streamFailureAuth},
 		{"http 400", &cometsdk.ServerError{ProviderID: "x", StatusCode: 400}, streamFailureHTTP4xx},
-		{"rate limit", &cometsdk.RateLimitError{ProviderID: "x"}, streamFailureHTTP4xx},
+		{"rate limit", &cometsdk.RateLimitError{ProviderID: "x"}, streamFailureRecoverable},
+		{"gateway timeout", &cometsdk.ServerError{ProviderID: "x", StatusCode: 504, Message: "Gateway Timeout"}, streamFailureRecoverable},
+		{"timeout text", errors.New("upstream timeout"), streamFailureRecoverable},
 		{"other", errors.New("bad response"), streamFailureOther},
 	}
 	for _, tc := range cases {

--- a/cometmind/server/messages.go
+++ b/cometmind/server/messages.go
@@ -264,8 +264,8 @@ func userFacingMessageError(raw string) string {
 		strings.Contains(lower, "context cancelled") {
 		return "Response interrupted. Send the message again to continue."
 	}
-	if strings.Contains(lower, "deadline exceeded") {
-		return "The model timed out before finishing. Send the message again to continue."
+	if strings.Contains(lower, "deadline exceeded") || strings.Contains(lower, "timeout") {
+		return "The model timed out before finishing. Send another message to continue from here."
 	}
 	return raw
 }

--- a/cometmind/server/messages_error_test.go
+++ b/cometmind/server/messages_error_test.go
@@ -17,6 +17,9 @@ func TestUserFacingMessageError(t *testing.T) {
 	if got := userFacingMessageError("something else"); got != "something else" {
 		t.Fatalf("passthrough = %q", got)
 	}
+	if got := userFacingMessageError("net/http: timeout awaiting response headers"); got != "The model timed out before finishing. Send another message to continue from here." {
+		t.Fatalf("timeout = %q", got)
+	}
 }
 
 func TestMessagePersistenceContextStartsFreshAfterRequestDeadline(t *testing.T) {


### PR DESCRIPTION
## Background

Company gateways often time out after tools have already finished. The turn then stopped with a red error card even though the next model step was the only thing that failed.

[a09b761](https://github.com/Cometline/cometline/commit/a09b7619ba8bc05907ad80360b8a950d2d0d9865): Recoverable stream failures now include gateway timeouts, 429, and 5xx. The agent retries the same model step up to three times with backoff, keeps completed tools untouched, and only surfaces an error if recovery still fails.