### PR TITLE
[main] chore: stop tracking local git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/*
 !docs/postmortems/**
 !docs/learning/
 .claude/*
+
+.worktrees/


### PR DESCRIPTION
## Background

A leftover git worktree path was checked in on main as a gitlink. Local worktrees should stay on disk, not in the repo.

[dec57c2](https://github.com/Cometline/cometline/commit/dec57c2114daf7318a39ec3c19c4a84dda8d34de): Remove `.worktrees/stream` from tracking and ignore `.worktrees/` so later local checkouts do not get committed again.