### PR TITLE
[feat/workspace-tab-refinements] fix: retain web tabs across switches

### DIFF
--- a/cometline/src/lib/components/WorkspacePanel.svelte
+++ b/cometline/src/lib/components/WorkspacePanel.svelte
@@ -15,6 +15,7 @@
 		SquareTerminal
 	} from '@lucide/svelte';
 	import { tick, untrack } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import FileTreeBrowser from '$lib/components/FileTreeBrowser.svelte';
 	import PanelTabStrip from '$lib/components/PanelTabStrip.svelte';
@@ -40,11 +41,7 @@
 	import { isBlankTabUrl, urlTabChipLabel } from '$lib/workspace/workspace-panel-state';
 
 	let addressInputEl = $state<HTMLInputElement | null>(null);
-	let webCanGoBack = $state(false);
-	let webCanGoForward = $state(false);
-	let loading = $state(false);
 	let addressInput = $state('');
-	let webPageTitle = $state('');
 	let addressEditing = $state(false);
 	let lastObservedPanelUrl = $state<string | null>(null);
 	let editorState = $state<{
@@ -55,14 +52,7 @@
 		revert: () => void;
 	} | null>(null);
 	let dirtyByPath = $state<Record<string, boolean>>({});
-	let capturingContext = $state(false);
-	let webSurfaceRef = $state<{
-		navigateBack: () => boolean;
-		navigateForward: () => boolean;
-		reload: () => void;
-		focus: () => void;
-		captureContext: (source?: string) => Promise<import('$lib/actions/start-chat').WebContext | null>;
-	} | null>(null);
+	const webSurfaces = new SvelteMap<string, ReturnType<typeof WorkspaceWebSurface>>();
 	let panelFocusEl = $state<HTMLDivElement | null>(null);
 	let searchCaretWrap = $state<HTMLDivElement | null>(null);
 	let searchCaretEl = $state<HTMLSpanElement | null>(null);
@@ -95,6 +85,7 @@
 	const panelFilePath = $derived(shellStore.workspacePanelFilePath);
 	const panelFileTabs = $derived(shellStore.workspacePanelFileTabs);
 	const panelUrlTabs = $derived(shellStore.workspacePanelUrlTabs);
+	const webTabs = $derived(shellStore.workspaceWebTabs);
 	const wikiFileTabs = $derived(shellStore.wikiPanelFileTabs);
 	const workspaceSurfaceFileTabs = $derived(shellStore.workspaceSurfaceFileTabs);
 	const panelGitDiffPath = $derived(shellStore.workspacePanelGitDiffPath);
@@ -129,9 +120,15 @@
 	const workspaceHasContentDot = $derived(Boolean(workspaceContent));
 	const changesHasContentDot = $derived(Boolean(changesContent));
 	const webSearchHasContentDot = $derived(Boolean(webSearchUrl));
-	const canGoBack = $derived(webSearchUrl ? webCanGoBack : false);
-	const canGoForward = $derived(webSearchUrl ? webCanGoForward : false);
-	const pageTitle = $derived(webSearchUrl ? webPageTitle : '');
+	const activeWebTabKey = $derived(
+		panelSessionKey && panelUrlTabId ? `${panelSessionKey}:${panelUrlTabId}` : null
+	);
+	const webSurfaceRef = $derived(activeWebTabKey ? webSurfaces.get(activeWebTabKey) : undefined);
+	const canGoBack = $derived(webSurfaceRef?.pageState?.canGoBack ?? false);
+	const canGoForward = $derived(webSurfaceRef?.pageState?.canGoForward ?? false);
+	const pageTitle = $derived(panelUrlTabMeta[panelUrlTabId ?? '']?.title ?? '');
+	const loading = $derived(webSurfaceRef?.pageState?.loading ?? false);
+	const capturingContext = $derived(webSurfaceRef?.pageState?.capturing ?? false);
 
 	function displayAddress(url: string | null | undefined): string {
 		if (!url || isBlankTabUrl(url)) return '';
@@ -196,8 +193,6 @@
 	const showCenteredWebSearch = $derived(showWebSearchField && !showWebview);
 	const showAddressOverlay = $derived(showWebSearchField && showWebview && addressEditing);
 	const showContentSearch = $derived(showCenteredWebSearch || showAddressOverlay);
-	const activeUrlTabIndex = $derived(panelUrlTabs.indexOf(panelUrlTabId ?? ''));
-	const urlTabKey = $derived(`${panelSessionKey ?? ''}:url-tab:${activeUrlTabIndex}`);
 	const searchCaretTrail = $derived(settingsStore.settings.appearance.caretTrail);
 	const searchCaretColor = $derived(settingsStore.settings.appearance.heroComposer.glowColor);
 	const searchCaretTrailEnabled = $derived(searchCaretTrail.enabled);
@@ -254,26 +249,6 @@
 		addressInput = displayAddress(panelUrl);
 	}
 
-	function updateWebNavigation(state: {
-		url: string;
-		title: string;
-		canGoBack: boolean;
-		canGoForward: boolean;
-		loading: boolean;
-	}) {
-		webCanGoBack = state.canGoBack;
-		webCanGoForward = state.canGoForward;
-		loading = state.loading;
-		webPageTitle = state.title;
-		if (!addressEditing) addressInput = displayAddress(state.url || panelUrl);
-		if (state.url.startsWith('http://') || state.url.startsWith('https://')) {
-			shellStore.setPendingPageContextForActive({ title: state.title, source: state.url });
-			if (state.url !== webSearchUrl || state.title) {
-				shellStore.syncWorkspacePanelUrlFromGuest(state.url, state.title);
-			}
-		}
-	}
-
 	function onBack() {
 		if (showWebview && webSurfaceRef?.navigateBack()) return;
 		shellStore.panelHistoryBack();
@@ -298,12 +273,19 @@
 	}
 
 	async function capturePageContext() {
-		const context = await webSurfaceRef?.captureContext();
-		if (context) shellStore.addWebContextForActive(context);
+		const key = activeWebTabKey;
+		const sessionId = panelSessionKey;
+		const surface = webSurfaceRef;
+		const context = await surface?.captureContext();
+		if (context && sessionId === panelSessionKey && key && webSurfaces.get(key) === surface) {
+			shellStore.addWebContextForActive(context);
+		}
 	}
 
 	async function resolvePageContext(source: string) {
-		return (await webSurfaceRef?.captureContext(source)) ?? null;
+		const matches = webTabs.filter((tab) => tab.sessionId === panelSessionKey && tab.url === source);
+		const tab = matches.find((tab) => tab.key === activeWebTabKey) ?? matches[0];
+		return tab ? ((await webSurfaces.get(tab.key)?.captureContext(source)) ?? null) : null;
 	}
 
 	function captureFileContext(filePath: string) {
@@ -553,6 +535,13 @@
 	$effect(() => shellStore.registerWorkspacePanelLeaveGuard(requestLeaveEditor));
 
 	$effect(() => {
+		// Only the visible page contributes automatic context; background guests stay passive.
+		if (!panelOpen || !showWebview || !webSearchUrl || !isHttpUrl(webSearchUrl)) return;
+		const context = { source: webSearchUrl, title: pageTitle };
+		untrack(() => shellStore.setPendingPageContextForActive(context));
+	});
+
+	$effect(() => {
 		const url = panelUrl;
 		if (url !== lastObservedPanelUrl) {
 			lastObservedPanelUrl = url;
@@ -566,7 +555,6 @@
 
 	$effect(() => {
 		if (!shellStore.hasWorkspacePanelForSession) {
-			loading = false;
 			editorState = null;
 			if (!addressEditing) {
 				addressInput = '';
@@ -614,7 +602,7 @@
 		void panelFilePath;
 		void panelFileTabs.length;
 		void panelUrlTabs.length;
-		void activeUrlTabIndex;
+		void activeWebTabKey;
 		void showWebview;
 		void showFilePreview;
 		if (!panelOpen) return;
@@ -973,27 +961,33 @@
 						/>
 					</div>
 				{/if}
-				{#if webSearchUrl}
-					<div
-						class="panel-layer panel-layer-content"
-						class:active={showWebview}
-						inert={!showWebview}
-						aria-hidden={!showWebview}
-					>
-						{#key urlTabKey}
-							<WorkspaceWebSurface
-								bind:this={webSurfaceRef}
-								url={webSearchUrl}
-								sessionKey={urlTabKey}
-								onNavigationState={updateWebNavigation}
-								onFocus={() => shellStore.setFocusedPane('web')}
-								onNewWindow={onNewWindow}
-								onCapturingChange={(value) => (capturingContext = value)}
-							/>
-						{/key}
-					</div>
-				{/if}
 			{/if}
+			{#each webTabs as tab (tab.key)}
+				{@const active = panelOpen && showWebview && tab.key === activeWebTabKey}
+				<div
+					class="panel-layer panel-layer-content"
+					class:active
+					inert={!active}
+					aria-hidden={!active}
+				>
+					<WorkspaceWebSurface
+						bind:this={() => webSurfaces.get(tab.key), (surface) => {
+							if (surface) webSurfaces.set(tab.key, surface);
+							else webSurfaces.delete(tab.key);
+						}}
+						url={tab.url}
+						sessionKey={tab.key}
+						onNavigationState={(state) =>
+							shellStore.syncWorkspacePanelUrlFromGuest(tab.sessionId, tab.id, state.url, state.title)}
+						onFocus={() => {
+							if (active) shellStore.setFocusedPane('web');
+						}}
+						onNewWindow={(url) => {
+							if (active) onNewWindow(url);
+						}}
+					/>
+				</div>
+			{/each}
 			{#if showWebSearchField}
 				<div
 					class="web-search-stage"

--- a/cometline/src/lib/components/WorkspacePanel.svelte.test.ts
+++ b/cometline/src/lib/components/WorkspacePanel.svelte.test.ts
@@ -1,0 +1,351 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '$lib/types';
+
+const { emptyComponent } = vi.hoisted(() => ({ emptyComponent: () => ({}) }));
+vi.mock('./FileTreeBrowser.svelte', () => ({ default: emptyComponent }));
+vi.mock('./WorkspaceFileSurface.svelte', () => ({ default: emptyComponent }));
+vi.mock('./GitChangesBrowser.svelte', () => ({ default: emptyComponent }));
+vi.mock('./GitDiffView.svelte', () => ({ default: emptyComponent }));
+vi.mock('./TerminalPanel.svelte', () => ({ default: emptyComponent }));
+vi.mock('./ConfirmActionModal.svelte', () => ({ default: emptyComponent }));
+
+import WorkspacePanel from './WorkspacePanel.svelte';
+import { shellStore } from '$lib/stores/shell.svelte';
+import { sessionStore } from '$lib/stores/session.svelte';
+import { deliverWindowSyncFromPeer } from '$lib/window-sync';
+
+const session: Session = {
+	id: 'web-lifecycle',
+	workspace_id: 'repo',
+	workspace_path: '/repo',
+	title: 'Web tabs',
+	model_id: 'model',
+	provider_id: 'provider',
+	status: 'active',
+	origin: 'user',
+	agent_mode: 'auto',
+	pinned: false,
+	running: false,
+	created_at: 0,
+	updated_at: 0,
+	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 }
+};
+
+// Real Svelte components/DOM; only Electron's native guest methods are simulated.
+function attachGuest(container: HTMLElement, url: string) {
+	const el = Array.from(
+		container.querySelectorAll<HTMLElement & { src: string }>('webview')
+	).find((el) => el.src === url)!;
+	expect(el).toBeDefined();
+	let requestedUrl = el.src;
+	const srcWrites = vi.fn();
+	Object.defineProperty(el, 'src', {
+		configurable: true,
+		get: () => requestedUrl,
+		set: (value: string) => {
+			requestedUrl = value;
+			srcWrites(value);
+		}
+	});
+	const native = {
+		stop: vi.fn(),
+		reload: vi.fn(),
+		goBack: vi.fn(),
+		goForward: vi.fn(),
+		canGoBack: vi.fn(() => false),
+		canGoForward: vi.fn(() => false),
+		getURL: vi.fn(() => url),
+		getTitle: vi.fn(() => ''),
+		executeJavaScript: vi.fn(async () => ({
+			url,
+			title: 'Captured page',
+			content: 'Page body'
+		}))
+	};
+	Object.assign(el, native);
+	return {
+		el,
+		...native,
+		srcWrites,
+		async navigate(nextUrl: string, title: string) {
+			native.getURL.mockReturnValue(nextUrl);
+			native.getTitle.mockReturnValue(title);
+			el.dispatchEvent(new Event('did-navigate'));
+			await tick();
+		}
+	};
+}
+
+describe('WorkspacePanel web tab lifetimes', () => {
+	beforeEach(() => {
+		shellStore.clearWorkspacePanelForSession(session.id);
+		shellStore.clearWorkspacePanelForSession('other-session');
+		sessionStore.selectSession(session);
+		shellStore.commitActiveWorkspace('/repo');
+	});
+
+	afterEach(() => {
+		cleanup();
+		shellStore.clearWorkspacePanelForSession(session.id);
+		shellStore.clearWorkspacePanelForSession('other-session');
+		sessionStore.selectSession(null);
+	});
+
+	it('retains each guest across tab switches and only destroys the closed tab', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://example.com');
+		const [firstId] = shellStore.workspacePanelUrlTabs;
+		const { container, getByRole } = render(WorkspacePanel);
+		await tick();
+		const first = attachGuest(container, 'https://example.com');
+		await first.navigate('https://example.com', 'Example');
+
+		shellStore.openWorkspacePanelUrlForActive('https://www.youtube.com/watch?v=1');
+		const [, youtubeId] = shellStore.workspacePanelUrlTabs;
+		await tick();
+		const youtube = attachGuest(container, 'https://www.youtube.com/watch?v=1');
+		await youtube.navigate('https://www.youtube.com/watch?v=1', 'YouTube');
+		expect(first.el.isConnected).toBe(true);
+		expect(first.stop).not.toHaveBeenCalled();
+
+		await fireEvent.click(getByRole('tab', { name: 'Example' }));
+		expect(youtube.el.isConnected).toBe(true);
+		expect(youtube.el.parentElement).toHaveAttribute('aria-hidden', 'true');
+		expect(youtube.stop).not.toHaveBeenCalled();
+		await fireEvent.click(getByRole('tab', { name: 'YouTube' }));
+		expect(youtube.el.parentElement).toHaveAttribute('aria-hidden', 'false');
+		expect(youtube.srcWrites).not.toHaveBeenCalled();
+
+		// Closing an earlier tab changes the array index, not the surviving guest identity.
+		shellStore.closeUrlTabForActive(firstId);
+		await tick();
+		expect(first.el.isConnected).toBe(false);
+		expect(first.stop).toHaveBeenCalledOnce();
+		expect(youtube.el.isConnected).toBe(true);
+		expect(youtube.srcWrites).not.toHaveBeenCalled();
+		expect(youtube.stop).not.toHaveBeenCalled();
+
+		shellStore.closeUrlTabForActive(youtubeId);
+		await tick();
+		expect(youtube.el.isConnected).toBe(false);
+		expect(youtube.stop).toHaveBeenCalledOnce();
+		expect(container.querySelectorAll('webview')).toHaveLength(0);
+	});
+
+	it('isolates background navigation, loading, focus, and active toolbar commands', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://background.example');
+		const [backgroundId] = shellStore.workspacePanelUrlTabs;
+		const { container, getByRole } = render(WorkspacePanel);
+		await tick();
+		const background = attachGuest(container, 'https://background.example');
+		await background.navigate('https://background.example', 'Background');
+		shellStore.openWorkspacePanelUrlForActive('https://active.example');
+		await tick();
+		const active = attachGuest(container, 'https://active.example');
+		active.canGoBack.mockReturnValue(true);
+		await active.navigate('https://active.example', 'Active');
+		shellStore.setFocusedPane('chat');
+
+		background.canGoForward.mockReturnValue(true);
+		await background.navigate('https://background.example/next', 'Background next');
+		background.el.dispatchEvent(new Event('did-start-loading'));
+		background.el.dispatchEvent(new Event('focus'));
+		await tick();
+		expect(shellStore.workspacePanelUrl).toBe('https://active.example');
+		expect(shellStore.workspacePanelUrlTabMeta[backgroundId]).toEqual({
+			url: 'https://background.example/next',
+			title: 'Background next'
+		});
+		expect(shellStore.focusedPane).toBe('chat');
+		expect(shellStore.pendingWebContexts).toEqual([
+			expect.objectContaining({ source: 'https://active.example', title: 'Active' })
+		]);
+		expect(getByRole('button', { name: 'Forward' })).toBeDisabled();
+		expect(getByRole('button', { name: 'Reload page' }).querySelector('.spin')).toBeNull();
+		await fireEvent.click(getByRole('button', { name: 'Back' }));
+		await fireEvent.click(getByRole('button', { name: 'Reload page' }));
+		expect(active.goBack).toHaveBeenCalledOnce();
+		expect(active.reload).toHaveBeenCalledOnce();
+		expect(background.goBack).not.toHaveBeenCalled();
+		expect(background.reload).not.toHaveBeenCalled();
+
+		await fireEvent.click(getByRole('tab', { name: 'Background next' }));
+		expect(getByRole('button', { name: 'Forward' })).toBeEnabled();
+		expect(getByRole('button', { name: 'Reload page' }).querySelector('.spin')).not.toBeNull();
+		expect(background.srcWrites).not.toHaveBeenCalled();
+		expect(background.stop).not.toHaveBeenCalled();
+	});
+
+	it('retains guests while browsing files, hiding the pane, or switching sessions', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://www.youtube.com');
+		const [youtubeId] = shellStore.workspacePanelUrlTabs;
+		const { container } = render(WorkspacePanel);
+		await tick();
+		const youtube = attachGuest(container, 'https://www.youtube.com');
+		await youtube.navigate('https://www.youtube.com', 'YouTube');
+
+		await shellStore.openFilePreviewForActive('README.md');
+		await tick();
+		await youtube.navigate('https://www.youtube.com/watch?v=2', 'Next video');
+		expect(shellStore.contentSurface).toBe('workspace');
+		expect(shellStore.workspacePanelFilePath).toBe('README.md');
+		expect(youtube.el.isConnected).toBe(true);
+
+		shellStore.toggleWorkspacePanel();
+		await tick();
+		await youtube.navigate('https://www.youtube.com/watch?v=3', 'Third video');
+		expect(shellStore.workspacePanelOpen).toBe(false);
+		expect(youtube.el.isConnected).toBe(true);
+
+		sessionStore.selectSession({ ...session, id: 'other-session' });
+		await tick();
+		expect(youtube.el.isConnected).toBe(true);
+		shellStore.openWorkspacePanelUrlForActive('https://other.example');
+		await tick();
+		const other = attachGuest(container, 'https://other.example');
+		await other.navigate('https://other.example', 'Other session');
+		await youtube.navigate('https://www.youtube.com/watch?v=4', 'Fourth video');
+		expect(shellStore.workspacePanelUrl).toBe('https://other.example');
+		expect(shellStore.pendingWebContexts).toEqual([
+			expect.objectContaining({ source: 'https://other.example', title: 'Other session' })
+		]);
+		expect(youtube.el.isConnected).toBe(true);
+
+		sessionStore.selectSession(session);
+		shellStore.activateUrlTabForActive(youtubeId);
+		await tick();
+		expect(shellStore.workspacePanelUrl).toBe('https://www.youtube.com/watch?v=4');
+		expect(youtube.el.parentElement).toHaveAttribute('aria-hidden', 'false');
+		expect(youtube.srcWrites).not.toHaveBeenCalled();
+		expect(youtube.stop).not.toHaveBeenCalled();
+
+		shellStore.clearWorkspacePanelForSession(session.id);
+		await tick();
+		expect(youtube.stop).toHaveBeenCalledOnce();
+		expect(youtube.el.isConnected).toBe(false);
+		youtube.el.dispatchEvent(new Event('did-navigate'));
+		await tick();
+		expect(shellStore.workspaceWebTabs).toEqual([
+			expect.objectContaining({ sessionId: 'other-session', url: 'https://other.example' })
+		]);
+		expect(other.el.isConnected).toBe(true);
+		expect(other.stop).not.toHaveBeenCalled();
+	});
+
+	it('does not undo address navigation when loading events still report the old URL', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://old.example');
+		const { container } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://old.example');
+		await guest.navigate('https://old.example', 'Old page');
+
+		shellStore.navigateWorkspacePanel('https://new.example');
+		await tick();
+		guest.el.dispatchEvent(new Event('did-start-loading'));
+		await tick();
+		expect(shellStore.workspacePanelUrl).toBe('https://new.example');
+		expect(guest.srcWrites.mock.calls).toEqual([['https://new.example']]);
+		await guest.navigate('https://new.example', 'New page');
+		expect(guest.srcWrites).toHaveBeenCalledOnce();
+	});
+
+	it('retains a loaded guest while opening a blank tab and resolves its pending context', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://www.youtube.com');
+		const { container } = render(WorkspacePanel);
+		await tick();
+		const youtube = attachGuest(container, 'https://www.youtube.com');
+		await youtube.navigate('https://www.youtube.com', 'YouTube');
+		shellStore.openWebSearchPanel();
+		await tick();
+		expect(container.querySelectorAll('webview')).toHaveLength(2);
+		expect(youtube.el.isConnected).toBe(true);
+		expect(youtube.stop).not.toHaveBeenCalled();
+		expect(youtube.srcWrites).not.toHaveBeenCalled();
+
+		const contexts = await shellStore.resolvePendingWebContextsForActive();
+		expect(contexts).toEqual([
+			expect.objectContaining({ source: 'https://www.youtube.com', content: 'Page body' })
+		]);
+		expect(youtube.executeJavaScript).toHaveBeenCalledOnce();
+	});
+
+	it('discards an in-flight capture when its guest is closed', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://example.com');
+		const [tabId] = shellStore.workspacePanelUrlTabs;
+		const { container } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://example.com');
+		let rejectCapture!: (error: Error) => void;
+		guest.executeJavaScript.mockImplementation(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectCapture = reject;
+				})
+		);
+		const pending = shellStore.resolvePendingWebContextsForActive();
+		shellStore.closeUrlTabForActive(tabId);
+		await tick();
+		rejectCapture(new Error('Guest destroyed'));
+		await expect(pending).resolves.toEqual([]);
+	});
+
+	it('does not attach an in-flight capture to another session', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://example.com');
+		const { container, getByRole } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://example.com');
+		let resolveCapture!: (value: { url: string; title: string; content: string }) => void;
+		guest.executeJavaScript.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCapture = resolve;
+				})
+		);
+		await fireEvent.click(getByRole('button', { name: 'Add page to chat context' }));
+		sessionStore.selectSession({ ...session, id: 'other-session' });
+		resolveCapture({ url: 'https://example.com', title: 'Example', content: 'Body' });
+		await tick();
+		expect(shellStore.pendingWebContexts).toEqual([]);
+	});
+
+	it('resolves context from the selected tab when two guests have the same URL', async () => {
+		const sharedUrl = 'https://example.com/dashboard';
+		shellStore.openWorkspacePanelUrlForActive(sharedUrl);
+		const { container } = render(WorkspacePanel);
+		await tick();
+		const first = attachGuest(container, sharedUrl);
+		await first.navigate(sharedUrl, 'First dashboard');
+		shellStore.openWorkspacePanelUrlForActive('https://second.example');
+		await tick();
+		const second = attachGuest(container, 'https://second.example');
+		await second.navigate(sharedUrl, 'Second dashboard');
+		second.executeJavaScript.mockResolvedValue({
+			url: sharedUrl,
+			title: 'Second dashboard',
+			content: 'Selected tab content'
+		});
+
+		const contexts = await shellStore.resolvePendingWebContextsForActive();
+		expect(contexts).toEqual([expect.objectContaining({ content: 'Selected tab content' })]);
+		expect(first.executeJavaScript).not.toHaveBeenCalled();
+	});
+
+	it.each(['local', 'peer'] as const)(
+		'destroys guests when a session is removed by %s',
+		async (source) => {
+			shellStore.openWorkspacePanelUrlForActive('https://example.com');
+			const { container } = render(WorkspacePanel);
+			await tick();
+			const guest = attachGuest(container, 'https://example.com');
+			if (source === 'peer')
+				deliverWindowSyncFromPeer({ type: 'session-remove', sessionId: session.id });
+			else sessionStore.removeSession(session.id);
+			await tick();
+			expect(guest.el.isConnected).toBe(false);
+			expect(guest.stop).toHaveBeenCalledOnce();
+			expect(shellStore.workspaceWebTabs).toEqual([]);
+		}
+	);
+});

--- a/cometline/src/lib/components/WorkspaceWebSurface.svelte
+++ b/cometline/src/lib/components/WorkspaceWebSurface.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import type { WebContext } from '$lib/actions/start-chat';
 
 	type WebviewElement = HTMLElement & {
@@ -35,15 +36,13 @@
 		sessionKey,
 		onNavigationState,
 		onFocus,
-		onNewWindow,
-		onCapturingChange
+		onNewWindow
 	}: {
 		url: string | null;
 		sessionKey: string | null;
 		onNavigationState: (state: NavigationState) => void;
 		onFocus: () => void;
 		onNewWindow: (url: string) => void;
-		onCapturingChange: (capturing: boolean) => void;
 	} = $props();
 
 	const PAGE_CONTEXT_CACHE_TTL_MS = 10_000;
@@ -51,11 +50,16 @@
 	let webviewEl = $state<WebviewElement | null>(null);
 	let loadedUrl: string | null = null;
 	let loadedSessionKey: string | null = null;
-	let loading = $state(false);
-	let title = $state('');
 	let cachedContext = $state<CachedPageContext | null>(null);
 	let captureRun = 0;
-	let capturing = false;
+	export const pageState = $state({
+		url: '',
+		title: '',
+		canGoBack: false,
+		canGoForward: false,
+		loading: false,
+		capturing: false
+	});
 
 	function currentUrl() {
 		const fallback = url ?? '';
@@ -70,21 +74,22 @@
 		const el = webviewEl;
 		if (!el) return;
 		try {
-			title = el.getTitle() || '';
+			pageState.title = el.getTitle() || '';
 		} catch {
-			title = '';
+			pageState.title = '';
 		}
-		onNavigationState({
+		Object.assign(pageState, {
 			url: currentUrl(),
-			title,
 			canGoBack: el.canGoBack(),
-			canGoForward: el.canGoForward(),
-			loading
+			canGoForward: el.canGoForward()
 		});
+		// Loading events can still report the old document after a new src was requested.
+		if (pageState.url === loadedUrl) onNavigationState(pageState);
 	}
 
 	function attachWebview(el: WebviewElement) {
 		el.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-popups allow-forms');
+		const handleFocus = () => onFocus();
 		const rememberGuestLocation = () => {
 			loadedUrl = currentUrl();
 			loadedSessionKey = sessionKey;
@@ -94,30 +99,30 @@
 			publishNavigationState();
 		};
 		const onInPageNavigate = () => {
-			loading = false;
+			pageState.loading = false;
 			rememberGuestLocation();
 			publishNavigationState();
 		};
 		const onStartLoading = (event: Event & { isMainFrame?: boolean }) => {
 			if (event.isMainFrame === false) return;
-			loading = true;
+			pageState.loading = true;
 			publishNavigationState();
 		};
 		const onStopLoading = () => {
-			loading = false;
+			pageState.loading = false;
 			publishNavigationState();
 		};
 		const onFrameFinishLoad = (event: Event & { isMainFrame?: boolean }) => {
 			if (event.isMainFrame === false) return;
-			loading = false;
+			pageState.loading = false;
 			publishNavigationState();
 		};
 		const onFailLoad = () => {
-			loading = false;
+			pageState.loading = false;
 			publishNavigationState();
 		};
 		const onTitleUpdated = (event: Event & { title?: string }) => {
-			title = event.title ?? '';
+			pageState.title = event.title ?? '';
 			publishNavigationState();
 		};
 		const handleNewWindow = (event: Event & { url?: string; preventDefault?: () => void }) => {
@@ -133,9 +138,10 @@
 		el.addEventListener('did-fail-load', onFailLoad);
 		el.addEventListener('page-title-updated', onTitleUpdated);
 		el.addEventListener('new-window', handleNewWindow);
-		el.addEventListener('focus', onFocus);
+		el.addEventListener('focus', handleFocus);
 
 		return () => {
+			captureRun += 1;
 			el.removeEventListener('did-navigate', onNavigate);
 			el.removeEventListener('did-navigate-in-page', onInPageNavigate);
 			el.removeEventListener('did-start-loading', onStartLoading);
@@ -144,7 +150,7 @@
 			el.removeEventListener('did-fail-load', onFailLoad);
 			el.removeEventListener('page-title-updated', onTitleUpdated);
 			el.removeEventListener('new-window', handleNewWindow);
-			el.removeEventListener('focus', onFocus);
+			el.removeEventListener('focus', handleFocus);
 			try {
 				el.stop();
 			} catch {
@@ -178,7 +184,7 @@
 		const el = webviewEl;
 		const capturedSessionKey = sessionKey;
 		const expectedUrl = source ?? currentUrl();
-		if (!el || !capturedSessionKey || !expectedUrl || capturing) return null;
+		if (!el || !capturedSessionKey || !expectedUrl || pageState.capturing) return null;
 		if (source && currentUrl() !== expectedUrl) return null;
 
 		const cached = cachedContext;
@@ -192,8 +198,7 @@
 		}
 
 		const run = ++captureRun;
-		capturing = true;
-		onCapturingChange(true);
+		pageState.capturing = true;
 		try {
 			const page = await el.executeJavaScript<{
 				title?: string;
@@ -213,22 +218,25 @@
 			if (!content) return null;
 			const context = {
 				kind: 'page' as const,
-				title: String(page?.title || title).trim(),
+				title: String(page?.title || pageState.title).trim(),
 				source: pageUrl,
 				content
 			};
 			cachedContext = { sessionKey: capturedSessionKey, url: pageUrl, ...context, capturedAt: Date.now() };
 			return context;
+		} catch (error) {
+			if (run !== captureRun) return null;
+			throw error;
 		} finally {
-			capturing = false;
-			onCapturingChange(false);
+			pageState.capturing = false;
 		}
 	}
 
 	$effect(() => {
 		const el = webviewEl;
 		if (!el) return;
-		return attachWebview(el);
+		// Callback updates must not tear down a live guest's event subscriptions.
+		return untrack(() => attachWebview(el));
 	});
 
 	$effect(() => {

--- a/cometline/src/lib/stores/session.svelte.ts
+++ b/cometline/src/lib/stores/session.svelte.ts
@@ -20,6 +20,7 @@ function createSessionStore() {
 	let loaded = $state(false);
 	let current = $state<Session | null>(null);
 	let pendingMessages = $state.raw(new Map<string, Omit<PendingMessage, 'sessionId'>>());
+	const removalListeners = new Set<(sessionId: string) => void>();
 
 	function writeSession(
 		session: Session,
@@ -84,6 +85,7 @@ function createSessionStore() {
 
 	function removeSession(id: string, options: { broadcast?: boolean } = {}) {
 		const { broadcast = true } = options;
+		for (const listener of removalListeners) listener(id);
 		sessions = sessions.filter((item) => item.id !== id);
 		unreadSessionOutputStore.remove(id, broadcast);
 		if (current?.id === id) current = null;
@@ -154,6 +156,10 @@ function createSessionStore() {
 		},
 		get current() {
 			return current;
+		},
+		onSessionRemoved(listener: (sessionId: string) => void) {
+			removalListeners.add(listener);
+			return () => removalListeners.delete(listener);
 		},
 		selectSession,
 		setSessions,

--- a/cometline/src/lib/stores/shell.svelte.test.ts
+++ b/cometline/src/lib/stores/shell.svelte.test.ts
@@ -123,7 +123,7 @@ describe('shellStore workspace panel focus behavior', () => {
 		const [, exampleTab] = shellStore.workspacePanelUrlTabs;
 		shellStore.activateUrlTabForActive(searchTab);
 
-		shellStore.syncWorkspacePanelUrlFromGuest('https://www.youtube.com/', 'YouTube');
+		shellStore.syncWorkspacePanelUrlFromGuest('sess-1', searchTab, 'https://www.youtube.com/', 'YouTube');
 
 		expect(shellStore.workspacePanelUrlTabs).toEqual([searchTab, exampleTab]);
 		expect(shellStore.workspacePanelUrl).toBe('https://www.youtube.com/');

--- a/cometline/src/lib/stores/shell.svelte.ts
+++ b/cometline/src/lib/stores/shell.svelte.ts
@@ -1,4 +1,5 @@
 import { getActiveSessionId } from '$lib/active-session';
+import { sessionStore } from '$lib/stores/session.svelte';
 import { readHasSeenIntroSync } from '$lib/stores/settings.svelte';
 import type { WebContext } from '$lib/actions/start-chat';
 import {
@@ -28,7 +29,7 @@ import {
 	closeWorkspacePanelUrlTab,
 	fileTabsFor,
 	navigateWorkspacePanelUrl,
-	syncActiveUrlTab,
+	syncUrlTab,
 	openWorkspacePanelFile,
 	openWorkspacePanelUrl as openWorkspacePanelUrlState,
 	urlTabsFor,
@@ -674,6 +675,17 @@ function createShellStore() {
 			if (!key) return [] as string[];
 			return urlTabsFor(panelStateFor(key));
 		},
+		/** Live web guests follow tab ownership, not the currently selected session/surface. */
+		get workspaceWebTabs() {
+			return Object.entries(tabsBySession).flatMap(([sessionId, tabs]) =>
+				(tabs['web-search'] ?? []).map((id) => ({
+					key: `${sessionId}:${id}`,
+					sessionId,
+					id,
+					...(urlTabMetaBySession[sessionId]?.[id] ?? { url: id, title: '' })
+				}))
+			);
+		},
 		get workspacePanelGitDiffPath() {
 			const key = panelSessionKey();
 			if (!key) return null;
@@ -1065,13 +1077,11 @@ function createShellStore() {
 				focusedPane = 'web';
 			}
 		},
-		syncWorkspacePanelUrlFromGuest(url: string, title = '') {
-			const sessionId = panelSessionKey();
-			if (!sessionId) return;
+		syncWorkspacePanelUrlFromGuest(sessionId: string, tabId: string, url: string, title = '') {
 			const next = url.trim();
 			if (!next.startsWith('http://') && !next.startsWith('https://')) return;
 			const current = panelStateFor(sessionId);
-			const nextState = syncActiveUrlTab(current, next, title);
+			const nextState = syncUrlTab(current, tabId, next, title);
 			if (nextState === current) return;
 			applyPanelState(sessionId, nextState);
 		},
@@ -1430,3 +1440,9 @@ function createShellStore() {
 }
 
 export const shellStore = createShellStore();
+
+sessionStore.onSessionRemoved((sessionId) => {
+	if (shellStore.workspaceWebTabs.some((tab) => tab.sessionId === sessionId)) {
+		shellStore.clearWorkspacePanelForSession(sessionId);
+	}
+});

--- a/cometline/src/lib/workspace/workspace-panel-state.test.ts
+++ b/cometline/src/lib/workspace/workspace-panel-state.test.ts
@@ -12,7 +12,7 @@ import {
 	openWorkspacePanelFile,
 	openWorkspacePanelUrl,
 	replacesActiveFile,
-	syncActiveUrlTab,
+	syncUrlTab,
 	urlTabChipLabel,
 	urlTabMetaFor,
 	urlTabsFor
@@ -170,7 +170,7 @@ describe('workspace panel state', () => {
 		state = openWorkspacePanelUrl(state, 'https://example.com');
 		const [, exampleTab] = urlTabsFor(state);
 		state = activateWorkspacePanelUrlTab(state, searchTab);
-		state = syncActiveUrlTab(state, 'https://www.youtube.com/', 'YouTube');
+		state = syncUrlTab(state, searchTab, 'https://www.youtube.com/', 'YouTube');
 		expect(urlTabsFor(state)).toEqual([searchTab, exampleTab]);
 		expect(state.content['web-search']).toMatchObject({
 			mode: 'url',
@@ -184,7 +184,7 @@ describe('workspace panel state', () => {
 		});
 		expect(urlTabChipLabel(urlTabMetaFor(state, searchTab))).toBe('YouTube');
 
-		state = syncActiveUrlTab(state, 'https://www.youtube.com/watch?v=1');
+		state = syncUrlTab(state, searchTab, 'https://www.youtube.com/watch?v=1');
 		expect(urlTabsFor(state)).toEqual([searchTab, exampleTab]);
 		expect(urlTabChipLabel(urlTabMetaFor(state, searchTab))).toBe('YouTube');
 	});
@@ -203,6 +203,27 @@ describe('workspace panel state', () => {
 			tabId: tabB,
 			title: ''
 		});
+	});
+
+	it('updates a background URL tab without changing active content or visibility', () => {
+		let state = openWorkspacePanelUrl(createWorkspacePanelState('web-search'), 'https://a.example');
+		const [tabA] = urlTabsFor(state);
+		state = openWorkspacePanelUrl(state, 'https://b.example');
+		state = { ...state, visible: false, surface: 'terminal', contentSurface: 'workspace' };
+		const content = state.content;
+		const next = syncUrlTab(state, tabA, 'https://a.example/next', 'Next');
+		expect(next.content).toBe(content);
+		expect(next.visible).toBe(false);
+		expect(next.surface).toBe('terminal');
+		expect(next.contentSurface).toBe('workspace');
+		expect(next.urlTabMeta[tabA]).toEqual({ url: 'https://a.example/next', title: 'Next' });
+	});
+
+	it('ignores late guest events for closed tabs', () => {
+		let state = openWorkspacePanelUrl(createWorkspacePanelState('web-search'), 'https://a.example');
+		const [tabA] = urlTabsFor(state);
+		state = closeWorkspacePanelUrlTab(state, tabA);
+		expect(syncUrlTab(state, tabA, 'https://a.example/late', 'Late')).toBe(state);
 	});
 
 	it('stores and clears one-shot file reveal ranges', () => {

--- a/cometline/src/lib/workspace/workspace-panel-state.ts
+++ b/cometline/src/lib/workspace/workspace-panel-state.ts
@@ -432,39 +432,32 @@ export function navigateWorkspacePanelUrl(
 	};
 }
 
-/**
- * Guest (webview) navigated in place. Keep the same tab slot and allow
- * duplicate URLs — do not merge with another tab the way address-bar replace does.
- */
-export function syncActiveUrlTab(
+/** Guest navigation updates its owning tab without activating it or reopening the panel. */
+export function syncUrlTab(
 	state: WorkspacePanelState,
+	id: string,
 	url: string,
 	title = ''
 ): WorkspacePanelState {
+	if (!urlTabsFor(state).includes(id)) return state;
 	const content = state.content['web-search'];
-	if (content?.mode !== 'url') return state;
-	const id = content.tabId ?? content.url;
-	if (!id) return state;
+	const active = activeTabId(content) === id;
 	const prev = urlTabMetaFor(state, id);
 	const nextTitle = isDisplayTabTitle(title, url)
 		? title.trim()
 		: prev.title;
-	if (prev.url === url && prev.title === nextTitle && content.url === url && content.tabId === id) {
+	if (prev.url === url && prev.title === nextTitle) {
 		return state;
 	}
 	return {
 		...state,
-		visible: true,
-		surface: 'web',
-		contentSurface: 'web-search',
 		urlTabMeta: {
 			...state.urlTabMeta,
 			[id]: { url, title: nextTitle }
 		},
-		content: {
-			...state.content,
-			'web-search': { mode: 'url', url, tabId: id, title: nextTitle }
-		}
+		content: active
+			? { ...state.content, 'web-search': { mode: 'url', url, tabId: id, title: nextTitle } }
+			: state.content
 	};
 }
 


### PR DESCRIPTION
## Background

Switching web tabs currently destroys the previous webview, which stops YouTube playback and loses the live page state. Each open tab should own its guest until the tab or its session is removed. This is the second stacked PR and depends on #134.

[11a2762](https://github.com/Cometline/cometline/commit/11a276277f81cfcd47f71baa7a83002091b82a78): Retain one webview per session and stable tab ID, derive toolbar state from the selected guest, and route background navigation only to its owner. Session-removal notifications clean up guests for local and peer-window deletions. Context resolution prefers the selected tab when URLs match, and capture teardown and loading-event ordering are covered by regression tests.

Self-review reproduced and fixed incorrect duplicate-URL context selection and leaked guests after session removal. make check passed with 1,077 Vitest tests, and the renderer production build passed. The component tests simulate Electron guest methods; actual YouTube playback has not been manually verified. Retained background tabs consume memory, and the existing background-throttling settings remain unchanged.

### Reference

[Prerequisite: workspace tab refinements](https://github.com/Cometline/cometline/pull/134)