### PR TITLE
[docs/remove-postmortems] feat: show web tab activity and mute controls

### DIFF
--- a/cometline/src/lib/components/AudioActivityIcon.svelte
+++ b/cometline/src/lib/components/AudioActivityIcon.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { Volume2, VolumeX } from '@lucide/svelte';
+	let { muted = false }: { muted?: boolean } = $props();
+</script>
+
+<span class="audio-icon" aria-hidden="true">
+	{#if muted}
+		<VolumeX size={14} />
+	{:else}
+		<span class="equalizer"><i></i><i></i><i></i></span>
+		<span class="still"><Volume2 size={14} /></span>
+	{/if}
+</span>
+
+<style>
+	.audio-icon {
+		display: inline-grid;
+		place-items: center;
+		width: 14px;
+		height: 14px;
+		flex-shrink: 0;
+	}
+	.equalizer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 2px;
+		height: 12px;
+	}
+	.equalizer i {
+		width: 2px;
+		height: 10px;
+		border-radius: 1px;
+		background: currentColor;
+		animation: audio-bars 900ms ease-in-out infinite alternate;
+	}
+	.equalizer i:nth-child(2) {
+		animation-delay: -300ms;
+	}
+	.equalizer i:nth-child(3) {
+		animation-delay: -600ms;
+	}
+	.still {
+		display: none;
+	}
+	@keyframes audio-bars {
+		from {
+			transform: scaleY(0.3);
+		}
+		to {
+			transform: scaleY(1);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.equalizer {
+			display: none;
+		}
+		.equalizer i {
+			animation: none;
+		}
+		.still {
+			display: inline-flex;
+		}
+	}
+</style>

--- a/cometline/src/lib/components/PanelTabStrip.svelte
+++ b/cometline/src/lib/components/PanelTabStrip.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { Plus, X } from '@lucide/svelte';
+	import { Globe, LoaderCircle, Plus, TriangleAlert, X } from '@lucide/svelte';
+	import AudioActivityIcon from './AudioActivityIcon.svelte';
+	import type { WebTabStatus } from '$lib/workspace/web-tab-activity.svelte';
 
 	let {
 		tabs,
@@ -10,7 +12,9 @@
 		titleFor,
 		onActivate,
 		onClose,
-		onNewTab
+		onNewTab,
+		webStatusFor,
+		onToggleMute
 	}: {
 		tabs: string[];
 		activeId: string | null;
@@ -21,7 +25,10 @@
 		onActivate: (id: string) => void;
 		onClose: (id: string) => void;
 		onNewTab?: () => void;
+		webStatusFor?: (id: string) => WebTabStatus | undefined;
+		onToggleMute?: (id: string) => void;
 	} = $props();
+	const stripId = $props.id();
 
 	function keepPaneFocus(event: MouseEvent) {
 		event.preventDefault();
@@ -35,19 +42,74 @@
 			{@const label = labelFor(tabId, active)}
 			{@const title = titleFor?.(tabId) ?? tabId}
 			{@const dirty = Boolean(dirtyById[tabId])}
-			<div class="panel-tab" class:active role="presentation">
+			{@const status = webStatusFor?.(tabId)}
+			{@const statusLabel =
+				status?.loadError || (status?.showLoading ? 'Loading page' : undefined)}
+			<div
+				class="panel-tab"
+				class:active
+				class:web-tab={Boolean(webStatusFor)}
+				role="presentation"
+			>
 				<button
 					type="button"
 					class="panel-tab-button"
 					role="tab"
 					aria-selected={active}
+					aria-describedby={statusLabel ? `${stripId}-status-${tabId}` : undefined}
 					{title}
 					onmousedown={keepPaneFocus}
 					onclick={() => onActivate(tabId)}
 				>
+					{#if webStatusFor}
+						<span
+							class="tab-status"
+							class:failed={Boolean(status?.loadError)}
+							title={statusLabel}
+							aria-hidden="true"
+						>
+							{#if status?.loadError}
+								<TriangleAlert size={13} />
+							{:else if status?.showLoading}
+								<span class="loading-icon"><LoaderCircle size={13} /></span>
+							{:else}
+								<Globe size={13} />
+							{/if}
+						</span>
+					{/if}
 					<span class="panel-tab-label">{label}</span>
 					{#if dirty}<span class="dirty-dot" aria-label="Unsaved changes">•</span>{/if}
 				</button>
+				{#if statusLabel}<span id={`${stripId}-status-${tabId}`} class="status-description"
+						>{statusLabel}</span
+					>{/if}
+				{#if webStatusFor && onToggleMute}
+					<span class="audio-slot">
+						{#if status?.audible || status?.muted}
+							<button
+								type="button"
+								class="tab-audio"
+								class:muted={status.muted}
+								disabled={!status.ready}
+								aria-label={`${status.muted ? 'Unmute' : 'Mute'} ${label}`}
+								aria-pressed={status.muted}
+								title={status.muted
+									? 'Muted - Click to unmute'
+									: 'Playing audio - Click to mute'}
+								onmousedown={(event) => {
+									event.preventDefault();
+									event.stopPropagation();
+								}}
+								onclick={(event) => {
+									event.stopPropagation();
+									onToggleMute(tabId);
+								}}
+							>
+								<AudioActivityIcon muted={status.muted} />
+							</button>
+						{/if}
+					</span>
+				{/if}
 				<button
 					type="button"
 					class="panel-tab-close"
@@ -103,7 +165,8 @@
 		min-width: 3rem;
 		max-width: 10rem;
 		flex: 1 1 auto;
-		border: 1px solid color-mix(in srgb, var(--hero-composer-glow-color) 22%, var(--border-soft));
+		border: 1px solid
+			color-mix(in srgb, var(--hero-composer-glow-color) 22%, var(--border-soft));
 		border-radius: 6px;
 		background: color-mix(in srgb, var(--hero-composer-glow-color) 6%, transparent);
 		box-shadow: none;
@@ -113,6 +176,9 @@
 		border-color: color-mix(in srgb, var(--hero-composer-glow-color) 54%, var(--border-soft));
 		background: color-mix(in srgb, var(--hero-composer-glow-color) 18%, var(--panel-bg));
 		box-shadow: 0 0 8px var(--hero-composer-glow-soft);
+	}
+	.panel-tab.web-tab {
+		min-width: 6rem;
 	}
 
 	.panel-tab-button {
@@ -138,6 +204,76 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.tab-status {
+		display: inline-flex;
+		flex-shrink: 0;
+		width: 14px;
+		height: 14px;
+		margin-right: 3px;
+		align-items: center;
+		color: var(--text-soft);
+	}
+	.status-description {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+	}
+	.tab-status.failed {
+		color: var(--status-error);
+	}
+	.loading-icon {
+		display: inline-flex;
+		color: var(--accent);
+		animation: tab-loading 1s linear infinite;
+	}
+	.audio-slot {
+		display: inline-grid;
+		place-items: center;
+		width: 22px;
+		flex-shrink: 0;
+	}
+	.tab-audio {
+		display: inline-grid;
+		place-items: center;
+		border: 0;
+		border-radius: 4px;
+		width: 22px;
+		height: 22px;
+		padding: 0;
+		background: transparent;
+		color: var(--accent);
+		cursor: pointer;
+	}
+	.tab-audio.muted {
+		color: var(--text-muted);
+	}
+	.tab-audio:hover {
+		background: color-mix(in srgb, var(--text-main) 10%, transparent);
+	}
+	.tab-audio:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
+	}
+	.tab-audio:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	@keyframes tab-loading {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.loading-icon {
+			animation: none;
+		}
 	}
 
 	.panel-tab-close {
@@ -184,7 +320,8 @@
 		flex-shrink: 0;
 		width: 26px;
 		height: 26px;
-		border: 1px dashed color-mix(in srgb, var(--hero-composer-glow-color) 28%, var(--border-soft));
+		border: 1px dashed
+			color-mix(in srgb, var(--hero-composer-glow-color) 28%, var(--border-soft));
 		border-radius: 6px;
 		background: transparent;
 		color: var(--text-muted);

--- a/cometline/src/lib/components/WorkspacePanel.svelte
+++ b/cometline/src/lib/components/WorkspacePanel.svelte
@@ -15,7 +15,7 @@
 		SquareTerminal
 	} from '@lucide/svelte';
 	import { tick, untrack } from 'svelte';
-	import { SvelteMap } from 'svelte/reactivity';
+	import { webTabActivity } from '$lib/workspace/web-tab-activity.svelte';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
 	import FileTreeBrowser from '$lib/components/FileTreeBrowser.svelte';
 	import PanelTabStrip from '$lib/components/PanelTabStrip.svelte';
@@ -52,7 +52,6 @@
 		revert: () => void;
 	} | null>(null);
 	let dirtyByPath = $state<Record<string, boolean>>({});
-	const webSurfaces = new SvelteMap<string, ReturnType<typeof WorkspaceWebSurface>>();
 	let panelFocusEl = $state<HTMLDivElement | null>(null);
 	let searchCaretWrap = $state<HTMLDivElement | null>(null);
 	let searchCaretEl = $state<HTMLSpanElement | null>(null);
@@ -123,7 +122,7 @@
 	const activeWebTabKey = $derived(
 		panelSessionKey && panelUrlTabId ? `${panelSessionKey}:${panelUrlTabId}` : null
 	);
-	const webSurfaceRef = $derived(activeWebTabKey ? webSurfaces.get(activeWebTabKey) : undefined);
+	const webSurfaceRef = $derived(activeWebTabKey ? webTabActivity.get(activeWebTabKey)?.surface : undefined);
 	const canGoBack = $derived(webSurfaceRef?.pageState?.canGoBack ?? false);
 	const canGoForward = $derived(webSurfaceRef?.pageState?.canGoForward ?? false);
 	const pageTitle = $derived(panelUrlTabMeta[panelUrlTabId ?? '']?.title ?? '');
@@ -277,7 +276,7 @@
 		const sessionId = panelSessionKey;
 		const surface = webSurfaceRef;
 		const context = await surface?.captureContext();
-		if (context && sessionId === panelSessionKey && key && webSurfaces.get(key) === surface) {
+		if (context && sessionId === panelSessionKey && key && webTabActivity.get(key)?.surface === surface) {
 			shellStore.addWebContextForActive(context);
 		}
 	}
@@ -285,7 +284,7 @@
 	async function resolvePageContext(source: string) {
 		const matches = webTabs.filter((tab) => tab.sessionId === panelSessionKey && tab.url === source);
 		const tab = matches.find((tab) => tab.key === activeWebTabKey) ?? matches[0];
-		return tab ? ((await webSurfaces.get(tab.key)?.captureContext(source)) ?? null) : null;
+		return tab ? ((await webTabActivity.get(tab.key)?.surface.captureContext(source)) ?? null) : null;
 	}
 
 	function captureFileContext(filePath: string) {
@@ -756,7 +755,7 @@
 					<button
 						type="button"
 						class="icon-button"
-						disabled={capturingContext}
+						disabled={capturingContext || !webSurfaceRef?.pageState?.ready}
 						onclick={() => void capturePageContext()}
 						aria-label="Add page to chat context"
 						title="Add page to next message"
@@ -811,6 +810,8 @@
 						tabs={panelUrlTabs}
 						activeId={panelUrlTabId}
 						ariaLabel="Open pages"
+						webStatusFor={(id) => webTabActivity.get(`${panelSessionKey}:${id}`)?.surface.pageState}
+						onToggleMute={(id) => webTabActivity.get(`${panelSessionKey}:${id}`)?.surface.toggleAudioMuted()}
 						labelFor={urlTabLabel}
 						titleFor={(id) => {
 							const url = panelUrlTabMeta[id]?.url ?? id;
@@ -971,9 +972,9 @@
 					aria-hidden={!active}
 				>
 					<WorkspaceWebSurface
-						bind:this={() => webSurfaces.get(tab.key), (surface) => {
-							if (surface) webSurfaces.set(tab.key, surface);
-							else webSurfaces.delete(tab.key);
+						bind:this={() => webTabActivity.get(tab.key)?.surface, (surface) => {
+							if (surface) webTabActivity.set(tab.key, { sessionId: tab.sessionId, tabId: tab.id, surface });
+							else webTabActivity.delete(tab.key);
 						}}
 						url={tab.url}
 						sessionKey={tab.key}

--- a/cometline/src/lib/components/WorkspacePanel.svelte.test.ts
+++ b/cometline/src/lib/components/WorkspacePanel.svelte.test.ts
@@ -16,6 +16,7 @@ import WorkspacePanel from './WorkspacePanel.svelte';
 import { shellStore } from '$lib/stores/shell.svelte';
 import { sessionStore } from '$lib/stores/session.svelte';
 import { deliverWindowSyncFromPeer } from '$lib/window-sync';
+import { webTabActivity } from '$lib/workspace/web-tab-activity.svelte';
 
 const session: Session = {
 	id: 'web-lifecycle',
@@ -42,6 +43,7 @@ function attachGuest(container: HTMLElement, url: string) {
 	expect(el).toBeDefined();
 	let requestedUrl = el.src;
 	const srcWrites = vi.fn();
+	let muted = false;
 	Object.defineProperty(el, 'src', {
 		configurable: true,
 		get: () => requestedUrl,
@@ -59,6 +61,12 @@ function attachGuest(container: HTMLElement, url: string) {
 		canGoForward: vi.fn(() => false),
 		getURL: vi.fn(() => url),
 		getTitle: vi.fn(() => ''),
+		isLoadingMainFrame: vi.fn(() => true),
+		isCurrentlyAudible: vi.fn(() => false),
+		isAudioMuted: vi.fn(() => muted),
+		setAudioMuted: vi.fn((value: boolean) => {
+			muted = value;
+		}),
 		executeJavaScript: vi.fn(async () => ({
 			url,
 			title: 'Captured page',
@@ -66,6 +74,7 @@ function attachGuest(container: HTMLElement, url: string) {
 		}))
 	};
 	Object.assign(el, native);
+	el.dispatchEvent(new Event('dom-ready'));
 	return {
 		el,
 		...native,
@@ -74,6 +83,7 @@ function attachGuest(container: HTMLElement, url: string) {
 			native.getURL.mockReturnValue(nextUrl);
 			native.getTitle.mockReturnValue(title);
 			el.dispatchEvent(new Event('did-navigate'));
+			el.dispatchEvent(new Event('did-stop-loading'));
 			await tick();
 		}
 	};
@@ -92,6 +102,7 @@ describe('WorkspacePanel web tab lifetimes', () => {
 		shellStore.clearWorkspacePanelForSession(session.id);
 		shellStore.clearWorkspacePanelForSession('other-session');
 		sessionStore.selectSession(null);
+		vi.useRealTimers();
 	});
 
 	it('retains each guest across tab switches and only destroys the closed tab', async () => {
@@ -348,4 +359,154 @@ describe('WorkspacePanel web tab lifetimes', () => {
 			expect(shellStore.workspaceWebTabs).toEqual([]);
 		}
 	);
+
+	it('shows only audible media and mutes a background tab without changing selection or focus', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://music.example');
+		const { container, queryByRole, getByRole } = render(WorkspacePanel);
+		await tick();
+		const music = attachGuest(container, 'https://music.example');
+		await music.navigate('https://music.example', 'Music');
+		music.el.dispatchEvent(new Event('media-started-playing'));
+		await tick();
+		expect(queryByRole('button', { name: 'Mute Music' })).toBeNull();
+
+		music.isCurrentlyAudible.mockReturnValue(true);
+		music.el.dispatchEvent(new Event('media-started-playing'));
+		shellStore.openWorkspacePanelUrlForActive('https://foreground.example');
+		await tick();
+		const foreground = attachGuest(container, 'https://foreground.example');
+		await foreground.navigate('https://foreground.example', 'Foreground');
+		shellStore.setFocusedPane('chat');
+		const focusRequest = shellStore.composerFocusRequest.id;
+		const mute = getByRole('button', { name: 'Mute Music' });
+		await fireEvent.mouseDown(mute);
+		await fireEvent.click(mute);
+		expect(music.setAudioMuted).toHaveBeenCalledWith(true);
+		expect(foreground.setAudioMuted).not.toHaveBeenCalled();
+		expect(shellStore.workspacePanelUrl).toBe('https://foreground.example');
+		expect(shellStore.focusedPane).toBe('chat');
+		expect(shellStore.composerFocusRequest.id).toBe(focusRequest);
+		expect(getByRole('button', { name: 'Unmute Music' })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		await fireEvent.click(getByRole('button', { name: 'Unmute Music' }));
+		expect(music.setAudioMuted).toHaveBeenLastCalledWith(false);
+		expect(getByRole('button', { name: 'Mute Music' })).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+	});
+
+	it('detects Web Audio without media events and stops polling after the tab closes', async () => {
+		vi.useFakeTimers();
+		shellStore.openWorkspacePanelUrlForActive('https://audio.example');
+		const [tabId] = shellStore.workspacePanelUrlTabs;
+		const { container, queryByRole, getByRole } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://audio.example');
+		await guest.navigate('https://audio.example', 'Audio');
+		guest.isCurrentlyAudible.mockReturnValue(true);
+		await vi.advanceTimersByTimeAsync(750);
+		expect(getByRole('button', { name: 'Mute Audio' })).toBeTruthy();
+		guest.isCurrentlyAudible.mockReturnValue(false);
+		guest.el.dispatchEvent(new Event('media-paused'));
+		await tick();
+		expect(queryByRole('button', { name: 'Mute Audio' })).toBeNull();
+		shellStore.closeUrlTabForActive(tabId);
+		await tick();
+		const checks = guest.isCurrentlyAudible.mock.calls.length;
+		await vi.advanceTimersByTimeAsync(1500);
+		expect(guest.isCurrentlyAudible).toHaveBeenCalledTimes(checks);
+		expect(webTabActivity.size).toBe(0);
+	});
+
+	it('delays the main-frame spinner and keeps audio visible independently', async () => {
+		vi.useFakeTimers();
+		shellStore.openWorkspacePanelUrlForActive('https://example.com');
+		const { container, getByRole } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://example.com');
+		await guest.navigate('https://example.com', 'Example');
+		guest.isLoadingMainFrame.mockReturnValue(false);
+		guest.el.dispatchEvent(new Event('did-start-loading'));
+		await vi.advanceTimersByTimeAsync(200);
+		expect(getByRole('tab', { name: 'Example' })).not.toHaveAttribute('aria-describedby');
+		guest.isCurrentlyAudible.mockReturnValue(true);
+		guest.el.dispatchEvent(new Event('media-started-playing'));
+		guest.el.dispatchEvent(
+			Object.assign(new Event('did-start-navigation'), {
+				isMainFrame: true,
+				isInPlace: false
+			})
+		);
+		await vi.advanceTimersByTimeAsync(149);
+		expect(getByRole('tab', { name: 'Example' })).not.toHaveAttribute('aria-describedby');
+		await vi.advanceTimersByTimeAsync(1);
+		expect(getByRole('tab', { name: 'Example' })).toHaveAccessibleDescription('Loading page');
+		expect(getByRole('button', { name: 'Mute Example' })).toBeTruthy();
+		guest.el.dispatchEvent(new Event('did-stop-loading'));
+		await tick();
+		expect(getByRole('tab', { name: 'Example' })).not.toHaveAttribute('aria-describedby');
+	});
+
+	it('ignores subframe failures and aborted navigation, but exposes real page failures', async () => {
+		shellStore.openWorkspacePanelUrlForActive('https://example.com');
+		const { container, getByRole } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://example.com');
+		await guest.navigate('https://example.com', 'Example');
+		for (const details of [
+			{ isMainFrame: false, errorCode: -105 },
+			{ isMainFrame: true, errorCode: -3 }
+		]) {
+			guest.el.dispatchEvent(Object.assign(new Event('did-fail-load'), details));
+		}
+		await tick();
+		expect(getByRole('tab', { name: 'Example' })).not.toHaveAttribute('aria-describedby');
+		guest.el.dispatchEvent(
+			Object.assign(new Event('did-fail-load'), {
+				isMainFrame: true,
+				errorCode: -105,
+				errorDescription: 'Name not resolved'
+			})
+		);
+		await tick();
+		expect(getByRole('tab', { name: 'Example' })).toHaveAccessibleDescription(
+			'Name not resolved'
+		);
+		guest.el.dispatchEvent(
+			Object.assign(new Event('did-start-navigation'), {
+				isMainFrame: true,
+				isInPlace: false
+			})
+		);
+		await tick();
+		expect(getByRole('tab', { name: 'Example' })).not.toHaveAttribute('aria-describedby');
+	});
+
+	it('clears audio activity and polling when a guest process exits', async () => {
+		vi.useFakeTimers();
+		shellStore.openWorkspacePanelUrlForActive('https://music.example');
+		const { container, getByRole, queryByRole } = render(WorkspacePanel);
+		await tick();
+		const guest = attachGuest(container, 'https://music.example');
+		await guest.navigate('https://music.example', 'Music');
+		guest.isCurrentlyAudible.mockReturnValue(true);
+		guest.el.dispatchEvent(new Event('media-started-playing'));
+		await tick();
+		expect(getByRole('button', { name: 'Mute Music' })).toBeTruthy();
+		guest.el.dispatchEvent(new Event('render-process-gone'));
+		await tick();
+		expect(queryByRole('button', { name: 'Mute Music' })).toBeNull();
+		expect(getByRole('tab', { name: 'Music' })).toHaveAccessibleDescription(
+			'Page stopped unexpectedly. Reload to try again.'
+		);
+		expect(getByRole('button', { name: 'Add page to chat context' })).toBeDisabled();
+		const checks = guest.isCurrentlyAudible.mock.calls.length;
+		await vi.advanceTimersByTimeAsync(1500);
+		expect(guest.isCurrentlyAudible).toHaveBeenCalledTimes(checks);
+		await fireEvent.click(getByRole('button', { name: 'Reload page' }));
+		expect(guest.reload).toHaveBeenCalledOnce();
+	});
 });

--- a/cometline/src/lib/components/WorkspaceWebSurface.svelte
+++ b/cometline/src/lib/components/WorkspaceWebSurface.svelte
@@ -12,6 +12,10 @@
 		canGoForward(): boolean;
 		getURL(): string;
 		getTitle(): string;
+		isLoadingMainFrame(): boolean;
+		isCurrentlyAudible(): boolean;
+		isAudioMuted(): boolean;
+		setAudioMuted(muted: boolean): void;
 		executeJavaScript<T = unknown>(code: string, userGesture?: boolean): Promise<T>;
 	};
 
@@ -52,14 +56,58 @@
 	let loadedSessionKey: string | null = null;
 	let cachedContext = $state<CachedPageContext | null>(null);
 	let captureRun = 0;
+	let loadingTimer: ReturnType<typeof setTimeout> | null = null;
 	export const pageState = $state({
 		url: '',
 		title: '',
 		canGoBack: false,
 		canGoForward: false,
 		loading: false,
+		showLoading: false,
+		loadError: null as string | null,
+		ready: false,
+		mediaPlaying: false,
+		audible: false,
+		muted: false,
 		capturing: false
 	});
+
+	function setLoading(loading: boolean) {
+		pageState.loading = loading;
+		if (loading) {
+			pageState.loadError = null;
+			if (!loadingTimer && !pageState.showLoading) {
+				loadingTimer = setTimeout(() => {
+					loadingTimer = null;
+					pageState.showLoading = true;
+				}, 150);
+			}
+		} else {
+			if (loadingTimer) clearTimeout(loadingTimer);
+			loadingTimer = null;
+			pageState.showLoading = false;
+		}
+	}
+
+	function syncAudio() {
+		if (!webviewEl || !pageState.ready) return;
+		try {
+			pageState.muted = webviewEl.isAudioMuted();
+			pageState.audible = !pageState.muted && webviewEl.isCurrentlyAudible();
+		} catch {
+			pageState.audible = false;
+		}
+	}
+
+	export function toggleAudioMuted() {
+		if (!webviewEl || !pageState.ready) return;
+		try {
+			webviewEl.setAudioMuted(!webviewEl.isAudioMuted());
+			syncAudio();
+		} catch {
+			// The guest may have exited between the pointer event and the native call.
+		}
+	}
 
 	function currentUrl() {
 		const fallback = url ?? '';
@@ -72,53 +120,93 @@
 
 	function publishNavigationState() {
 		const el = webviewEl;
-		if (!el) return;
+		if (!el || !pageState.ready) return;
 		try {
-			pageState.title = el.getTitle() || '';
+			Object.assign(pageState, {
+				title: el.getTitle() || '',
+				url: currentUrl(),
+				canGoBack: el.canGoBack(),
+				canGoForward: el.canGoForward()
+			});
 		} catch {
-			pageState.title = '';
+			return;
 		}
-		Object.assign(pageState, {
-			url: currentUrl(),
-			canGoBack: el.canGoBack(),
-			canGoForward: el.canGoForward()
-		});
 		// Loading events can still report the old document after a new src was requested.
 		if (pageState.url === loadedUrl) onNavigationState(pageState);
 	}
 
 	function attachWebview(el: WebviewElement) {
 		el.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-popups allow-forms');
+		let audioTimer: ReturnType<typeof setInterval> | null = null;
+		const onDomReady = () => {
+			pageState.ready = true;
+			syncAudio();
+			// Web Audio and mute changes do not always emit media playback events.
+			if (!audioTimer) audioTimer = setInterval(syncAudio, 750);
+			publishNavigationState();
+		};
+		const onMediaStarted = () => {
+			pageState.mediaPlaying = true;
+			syncAudio();
+		};
+		const onMediaPaused = () => {
+			pageState.mediaPlaying = false;
+			syncAudio();
+		};
+		const onStartNavigation = (
+			event: Event & { isMainFrame?: boolean; isInPlace?: boolean }
+		) => {
+			if (event.isMainFrame && !event.isInPlace) setLoading(true);
+		};
+		const onRenderProcessGone = () => {
+			captureRun += 1;
+			pageState.ready = false;
+			pageState.audible = false;
+			pageState.mediaPlaying = false;
+			setLoading(false);
+			pageState.loadError = 'Page stopped unexpectedly. Reload to try again.';
+			if (audioTimer) clearInterval(audioTimer);
+			audioTimer = null;
+		};
 		const handleFocus = () => onFocus();
-		const rememberGuestLocation = () => {
-			loadedUrl = currentUrl();
+		const rememberGuestLocation = (event: Event & { url?: string }) => {
+			loadedUrl = event.url || currentUrl();
 			loadedSessionKey = sessionKey;
 		};
-		const onNavigate = () => {
-			rememberGuestLocation();
+		const onNavigate = (event: Event & { url?: string }) => {
+			rememberGuestLocation(event);
 			publishNavigationState();
 		};
-		const onInPageNavigate = () => {
-			pageState.loading = false;
-			rememberGuestLocation();
-			publishNavigationState();
-		};
-		const onStartLoading = (event: Event & { isMainFrame?: boolean }) => {
+		const onInPageNavigate = (event: Event & { url?: string; isMainFrame?: boolean }) => {
 			if (event.isMainFrame === false) return;
-			pageState.loading = true;
+			rememberGuestLocation(event);
+			publishNavigationState();
+		};
+		const onStartLoading = () => {
+			if (!pageState.ready) return;
+			try {
+				if (el.isLoadingMainFrame()) setLoading(true);
+			} catch {
+				return;
+			}
 			publishNavigationState();
 		};
 		const onStopLoading = () => {
-			pageState.loading = false;
+			setLoading(false);
 			publishNavigationState();
 		};
 		const onFrameFinishLoad = (event: Event & { isMainFrame?: boolean }) => {
-			if (event.isMainFrame === false) return;
-			pageState.loading = false;
+			if (!event.isMainFrame) return;
+			setLoading(false);
 			publishNavigationState();
 		};
-		const onFailLoad = () => {
-			pageState.loading = false;
+		const onFailLoad = (
+			event: Event & { isMainFrame?: boolean; errorCode?: number; errorDescription?: string }
+		) => {
+			if (!event.isMainFrame || event.errorCode === -3) return;
+			setLoading(false);
+			pageState.loadError =
+				event.errorDescription || 'Could not load this page. Reload to try again.';
 			publishNavigationState();
 		};
 		const onTitleUpdated = (event: Event & { title?: string }) => {
@@ -139,9 +227,18 @@
 		el.addEventListener('page-title-updated', onTitleUpdated);
 		el.addEventListener('new-window', handleNewWindow);
 		el.addEventListener('focus', handleFocus);
+		el.addEventListener('dom-ready', onDomReady);
+		el.addEventListener('did-start-navigation', onStartNavigation);
+		el.addEventListener('media-started-playing', onMediaStarted);
+		el.addEventListener('media-paused', onMediaPaused);
+		el.addEventListener('render-process-gone', onRenderProcessGone);
 
 		return () => {
 			captureRun += 1;
+			pageState.ready = false;
+			pageState.audible = false;
+			setLoading(false);
+			if (audioTimer) clearInterval(audioTimer);
 			el.removeEventListener('did-navigate', onNavigate);
 			el.removeEventListener('did-navigate-in-page', onInPageNavigate);
 			el.removeEventListener('did-start-loading', onStartLoading);
@@ -151,6 +248,11 @@
 			el.removeEventListener('page-title-updated', onTitleUpdated);
 			el.removeEventListener('new-window', handleNewWindow);
 			el.removeEventListener('focus', handleFocus);
+			el.removeEventListener('dom-ready', onDomReady);
+			el.removeEventListener('did-start-navigation', onStartNavigation);
+			el.removeEventListener('media-started-playing', onMediaStarted);
+			el.removeEventListener('media-paused', onMediaPaused);
+			el.removeEventListener('render-process-gone', onRenderProcessGone);
 			try {
 				el.stop();
 			} catch {
@@ -160,19 +262,33 @@
 	}
 
 	export function navigateBack(): boolean {
-		if (!webviewEl?.canGoBack()) return false;
-		webviewEl.goBack();
-		return true;
+		try {
+			if (!pageState.ready || !webviewEl?.canGoBack()) return false;
+			webviewEl.goBack();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	export function navigateForward(): boolean {
-		if (!webviewEl?.canGoForward()) return false;
-		webviewEl.goForward();
-		return true;
+		try {
+			if (!pageState.ready || !webviewEl?.canGoForward()) return false;
+			webviewEl.goForward();
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	export function reload() {
-		webviewEl?.reload();
+		try {
+			setLoading(true);
+			webviewEl?.reload();
+		} catch {
+			setLoading(false);
+			pageState.loadError = 'Could not reload this page. Try again.';
+		}
 	}
 
 	export function focus() {
@@ -184,7 +300,8 @@
 		const el = webviewEl;
 		const capturedSessionKey = sessionKey;
 		const expectedUrl = source ?? currentUrl();
-		if (!el || !capturedSessionKey || !expectedUrl || pageState.capturing) return null;
+		if (!el || !pageState.ready || !capturedSessionKey || !expectedUrl || pageState.capturing)
+			return null;
 		if (source && currentUrl() !== expectedUrl) return null;
 
 		const cached = cachedContext;
@@ -194,7 +311,12 @@
 			cached.url === expectedUrl &&
 			Date.now() - cached.capturedAt < PAGE_CONTEXT_CACHE_TTL_MS
 		) {
-			return { kind: 'page', title: cached.title, source: cached.url, content: cached.content };
+			return {
+				kind: 'page',
+				title: cached.title,
+				source: cached.url,
+				content: cached.content
+			};
 		}
 
 		const run = ++captureRun;
@@ -214,7 +336,8 @@
 			);
 			const pageUrl = String(page?.url || currentUrl()).trim();
 			const content = String(page?.content || '').trim();
-			if (run !== captureRun || pageUrl !== expectedUrl || !pageUrl.startsWith('http')) return null;
+			if (run !== captureRun || pageUrl !== expectedUrl || !pageUrl.startsWith('http'))
+				return null;
 			if (!content) return null;
 			const context = {
 				kind: 'page' as const,
@@ -222,7 +345,12 @@
 				source: pageUrl,
 				content
 			};
-			cachedContext = { sessionKey: capturedSessionKey, url: pageUrl, ...context, capturedAt: Date.now() };
+			cachedContext = {
+				sessionKey: capturedSessionKey,
+				url: pageUrl,
+				...context,
+				capturedAt: Date.now()
+			};
 			return context;
 		} catch (error) {
 			if (run !== captureRun) return null;
@@ -243,6 +371,7 @@
 		const el = webviewEl;
 		if (!el || !url || !sessionKey) return;
 		if (loadedSessionKey === sessionKey && loadedUrl === url) return;
+		untrack(() => setLoading(true));
 		el.src = url;
 		loadedSessionKey = sessionKey;
 		loadedUrl = url;

--- a/cometline/src/lib/components/sidebar/SessionAudioBadge.svelte
+++ b/cometline/src/lib/components/sidebar/SessionAudioBadge.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import type { Session } from '$lib/types';
+	import { navigateToSession } from '$lib/actions/navigate-to-session';
+	import { sessionStore } from '$lib/stores/session.svelte';
+	import { shellStore } from '$lib/stores/shell.svelte';
+	import { isNarrowViewport } from '$lib/layout/narrow-viewport';
+	import { webTabActivity, type WebTabActivity } from '$lib/workspace/web-tab-activity.svelte';
+	import AudioActivityIcon from '../AudioActivityIcon.svelte';
+	import { portal } from '../portal';
+	import { clampTooltipPosition } from '../tooltip-position';
+
+	let { session, tabs }: { session: Session; tabs: WebTabActivity[] } = $props();
+	let trigger = $state<HTMLButtonElement | null>(null);
+	let menu = $state<HTMLDivElement | null>(null);
+	let open = $state(false);
+	let placed = $state(false);
+	let top = $state(0);
+	let left = $state(0);
+	let error = $state('');
+	const menuId = $props.id();
+	const allMuted = $derived(tabs.every((tab) => tab.surface.pageState.muted));
+	const label = (tab: WebTabActivity) =>
+		tab.surface.pageState.title || tab.surface.pageState.url || 'Web page';
+
+	function close(restoreFocus = false) {
+		open = false;
+		if (restoreFocus && trigger?.isConnected) trigger.focus({ preventScroll: true });
+	}
+
+	async function showChooser() {
+		open = true;
+		placed = false;
+		await tick();
+		if (!open || !menu || !trigger) return;
+		const position = clampTooltipPosition({
+			anchor: trigger.getBoundingClientRect(),
+			tip: menu.getBoundingClientRect(),
+			viewport: { width: window.innerWidth, height: window.innerHeight }
+		});
+		top = position.top;
+		left = position.left;
+		placed = true;
+		menu.querySelector<HTMLButtonElement>('button')?.focus({ preventScroll: true });
+	}
+
+	async function reveal(tab: WebTabActivity) {
+		const key = `${tab.sessionId}:${tab.tabId}`;
+		if (webTabActivity.get(key) !== tab) return;
+		error = '';
+		try {
+			await navigateToSession(session);
+			if (sessionStore.current?.id === tab.sessionId && webTabActivity.get(key) === tab) {
+				shellStore.activateUrlTabForActive(tab.tabId);
+				if (isNarrowViewport()) shellStore.closeSidebar();
+			}
+			close();
+		} catch {
+			error = 'Could not open this tab. Try again.';
+			await showChooser();
+		}
+	}
+
+	function activate() {
+		if (open) close();
+		else if (tabs.length === 1) void reveal(tabs[0]);
+		else void showChooser();
+	}
+
+	function onOutside(event: Event) {
+		const target = event.target;
+		if (open && target instanceof Node && !menu?.contains(target) && !trigger?.contains(target))
+			close();
+	}
+
+	$effect(() => {
+		if (!open) return;
+		const onKey = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				close(true);
+			}
+		};
+		const onResize = () => close();
+		window.addEventListener('pointerdown', onOutside);
+		window.addEventListener('focusin', onOutside);
+		window.addEventListener('keydown', onKey);
+		window.addEventListener('resize', onResize);
+		window.addEventListener('scroll', onOutside, true);
+		return () => {
+			window.removeEventListener('pointerdown', onOutside);
+			window.removeEventListener('focusin', onOutside);
+			window.removeEventListener('keydown', onKey);
+			window.removeEventListener('resize', onResize);
+			window.removeEventListener('scroll', onOutside, true);
+		};
+	});
+</script>
+
+<button
+	bind:this={trigger}
+	type="button"
+	class="audio-badge"
+	class:muted={allMuted}
+	aria-label={`Audio tabs for ${session.title || 'New Chat'}`}
+	aria-haspopup={tabs.length > 1 || open ? 'dialog' : undefined}
+	aria-expanded={open}
+	aria-controls={open ? menuId : undefined}
+	title={`${allMuted ? 'Muted audio' : 'Playing audio'}: ${tabs.map(label).join(', ')}`}
+	onmousedown={(event) => {
+		event.preventDefault();
+		event.stopPropagation();
+	}}
+	onclick={(event) => {
+		event.stopPropagation();
+		activate();
+	}}
+>
+	<AudioActivityIcon muted={allMuted} />
+</button>
+
+{#if open}
+	<div
+		use:portal
+		bind:this={menu}
+		id={menuId}
+		class="audio-chooser"
+		role="dialog"
+		aria-label="Audio tabs"
+		style:top={`${top}px`}
+		style:left={`${left}px`}
+		style:visibility={placed ? 'visible' : 'hidden'}
+	>
+		<p class="heading">Audio tabs</p>
+		{#if error}<p class="error" role="alert">{error}</p>{/if}
+		{#each tabs as tab (tab.tabId)}
+			<div class="audio-row">
+				<button
+					type="button"
+					class="reveal"
+					onclick={() => void reveal(tab)}
+					title={tab.surface.pageState.url}
+				>
+					<span class="page-title">{label(tab)}</span>
+					<span class="page-status"
+						>{tab.surface.pageState.muted ? 'Muted' : 'Playing audio'}</span
+					>
+				</button>
+				<button
+					type="button"
+					class="mute-button"
+					disabled={!tab.surface.pageState.ready}
+					aria-label={`${tab.surface.pageState.muted ? 'Unmute' : 'Mute'} ${label(tab)}`}
+					aria-pressed={tab.surface.pageState.muted}
+					title={tab.surface.pageState.muted ? 'Unmute tab' : 'Mute tab'}
+					onclick={() => tab.surface.toggleAudioMuted()}
+				>
+					<AudioActivityIcon muted={tab.surface.pageState.muted} />
+				</button>
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.audio-badge,
+	.mute-button {
+		display: inline-grid;
+		place-items: center;
+		flex-shrink: 0;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		border: 0;
+		border-radius: 6px;
+		color: var(--accent);
+		background: transparent;
+		cursor: pointer;
+	}
+	.audio-badge.muted {
+		color: var(--text-muted);
+	}
+	.audio-badge:hover,
+	.mute-button:hover,
+	.reveal:hover {
+		background: color-mix(in srgb, var(--text-main) 8%, transparent);
+	}
+	button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
+	}
+	button:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.audio-chooser {
+		position: fixed;
+		z-index: 100;
+		width: min(280px, calc(100vw - 16px));
+		max-height: min(320px, calc(100dvh - 16px));
+		overflow-y: auto;
+		box-sizing: border-box;
+		padding: 8px;
+		border: 1px solid var(--border-soft);
+		border-radius: 10px;
+		background: var(--panel-bg);
+		box-shadow: var(--shadow-card);
+	}
+	.heading {
+		margin: 2px 8px 6px;
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+	.audio-row {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+	.reveal {
+		min-width: 0;
+		flex: 1;
+		display: grid;
+		gap: 2px;
+		padding: 8px;
+		border: 0;
+		border-radius: 6px;
+		text-align: left;
+		color: var(--text-main);
+		background: transparent;
+		cursor: pointer;
+	}
+	.page-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 12px;
+	}
+	.page-status {
+		font-size: 10px;
+		color: var(--text-muted);
+	}
+	.error {
+		color: var(--status-error);
+		font-size: 12px;
+		margin: 8px;
+	}
+</style>

--- a/cometline/src/lib/components/sidebar/SessionRow.svelte
+++ b/cometline/src/lib/components/sidebar/SessionRow.svelte
@@ -6,6 +6,8 @@
 	import { chatStore } from '$lib/stores/chat.svelte';
 	import { terminalStore } from '$lib/stores/terminal.svelte';
 	import { unreadSessionOutputStore } from '$lib/stores/unread-session-output.svelte';
+	import { webTabActivity } from '$lib/workspace/web-tab-activity.svelte';
+	import SessionAudioBadge from './SessionAudioBadge.svelte';
 
 	let {
 		session,
@@ -38,6 +40,13 @@
 	} = $props();
 
 	let streaming = $derived(session.running || chatStore.isStreamingFor(session.id));
+	const audioTabs = $derived(
+		[...webTabActivity.values()].filter(
+			(tab) =>
+				tab.sessionId === session.id &&
+				(tab.surface.pageState?.audible || tab.surface.pageState?.muted)
+		)
+	);
 	let terminalRunning = $derived(terminalStore.isRunning(session.id));
 	let unread = $derived(unreadSessionOutputStore.isUnread(session.id));
 	let failed = $derived(chatStore.hasRunError(session.id));
@@ -83,22 +92,25 @@
 	class:selected
 	class:streaming={streaming && !selected}
 	class:has-actions={showActions}
+	class:has-audio={audioTabs.length > 0}
 	role="group"
 	oncontextmenu={handleContextMenu}
 >
 	<button class="session-row" onclick={onSelect} ondblclick={handleDblClick}>
 		<span class="session-title-row">
 			<span class="session-activity" aria-label={activityLabel}>
-				<span
-					class:active={streaming}
-					class:error={failed}
-					class:terminal={terminalRunning && !failed}
-					class:unread={unread && !failed && !streaming}
-					class="session-streaming"
-					title={activityLabel}
-					>{#if terminalRunning && !failed}<span class="terminal-marker">t</span
-						>{/if}</span
-				>
+				{#if audioTabs.length === 0}
+					<span
+						class:active={streaming}
+						class:error={failed}
+						class:terminal={terminalRunning && !failed}
+						class:unread={unread && !failed && !streaming}
+						class="session-streaming"
+						title={activityLabel}
+						>{#if terminalRunning && !failed}<span class="terminal-marker">t</span
+							>{/if}</span
+					>
+				{/if}
 			</span>
 			<span class="session-title">{sessionDisplayTitle(session.title)}</span>
 		</span>
@@ -108,6 +120,9 @@
 			<span class="session-workspace">{workspaceLabel(session.workspace_path)}</span>
 		{/if}
 	</button>
+	{#if audioTabs.length > 0}
+		<div class="session-audio"><SessionAudioBadge {session} tabs={audioTabs} /></div>
+	{/if}
 	{#if showActions}
 		<div class="session-actions">
 			{#if showPin}
@@ -191,6 +206,17 @@
 
 	.session-row-wrap.has-actions .session-row {
 		padding-right: 58px;
+	}
+	/* Share the first title line's indicator slot, not the hover-action area. */
+	.session-audio {
+		position: absolute;
+		left: 8px;
+		top: 6px;
+		width: 10px;
+		height: calc(13px * 1.35);
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.session-row-wrap.selected .session-title {
@@ -332,5 +358,10 @@
 	.pin-session:disabled,
 	.delete-session:disabled {
 		opacity: 0.35;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.session-streaming.active {
+			animation: none;
+		}
 	}
 </style>

--- a/cometline/src/lib/components/sidebar/SessionRow.svelte.test.ts
+++ b/cometline/src/lib/components/sidebar/SessionRow.svelte.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, within } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '$lib/types';
+
+const { navigateToSession } = vi.hoisted(() => ({ navigateToSession: vi.fn() }));
+vi.mock('$lib/actions/navigate-to-session', () => ({ navigateToSession }));
+vi.mock('$lib/stores/chat.svelte', () => ({
+	chatStore: { isStreamingFor: () => false, hasRunError: () => false }
+}));
+
+import SessionRow from './SessionRow.svelte';
+import { sessionStore } from '$lib/stores/session.svelte';
+import { shellStore } from '$lib/stores/shell.svelte';
+import { webTabActivity, type WebTabActivity } from '$lib/workspace/web-tab-activity.svelte';
+
+const session: Session = {
+	id: 'audio-session',
+	workspace_id: 'repo',
+	workspace_path: '/repo',
+	title: 'Audio session',
+	model_id: 'model',
+	provider_id: 'provider',
+	status: 'active',
+	origin: 'user',
+	agent_mode: 'auto',
+	pinned: false,
+	running: true,
+	created_at: 0,
+	updated_at: 0,
+	token_usage: { input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0 }
+};
+
+function addAudioTab(title: string) {
+	const url = `https://${title.toLowerCase()}.example`;
+	shellStore.openWorkspacePanelUrl(url, session.id);
+	const tab = shellStore.workspaceWebTabs.find((tab) => tab.url === url)!;
+	const pageState = $state({
+		url,
+		title,
+		canGoBack: false,
+		canGoForward: false,
+		loading: false,
+		showLoading: false,
+		loadError: null,
+		ready: true,
+		mediaPlaying: true,
+		audible: true,
+		muted: false,
+		capturing: false
+	});
+	const surface: WebTabActivity['surface'] = {
+		pageState,
+		navigateBack: vi.fn(() => false),
+		navigateForward: vi.fn(() => false),
+		reload: vi.fn(),
+		focus: vi.fn(),
+		captureContext: vi.fn(async () => null),
+		toggleAudioMuted: vi.fn(() => {
+			pageState.muted = !pageState.muted;
+			pageState.audible = !pageState.muted;
+		})
+	};
+	const entry = { sessionId: session.id, tabId: tab.id, surface };
+	webTabActivity.set(tab.key, entry);
+	return { ...entry, key: tab.key };
+}
+
+describe('SessionRow audio indicator', () => {
+	beforeEach(() => {
+		webTabActivity.clear();
+		shellStore.clearWorkspacePanelForSession(session.id);
+		sessionStore.selectSession({ ...session, id: 'other-session' });
+		navigateToSession.mockReset();
+		navigateToSession.mockImplementation(async (target: Session) => {
+			sessionStore.selectSession(target);
+			shellStore.requestComposerFocus(target.id);
+		});
+	});
+	afterEach(() => {
+		cleanup();
+		webTabActivity.clear();
+		shellStore.clearWorkspacePanelForSession(session.id);
+		sessionStore.selectSession(null);
+		vi.restoreAllMocks();
+	});
+
+	it('replaces the existing dot with audio instead of showing both indicators', async () => {
+		const tab = addAudioTab('Music');
+		const onSelect = vi.fn();
+		const { container, getByRole } = render(SessionRow, {
+			session,
+			onSelect,
+			onDelete: vi.fn(),
+			onPin: vi.fn(),
+			onContextMenu: vi.fn()
+		});
+		const badge = getByRole('button', { name: 'Audio tabs for Audio session' });
+		expect(badge.closest('.session-audio')).not.toBeNull();
+		expect(badge.closest('.session-actions')).toBeNull();
+		expect(badge.closest('.session-row')).toBeNull();
+		expect(container.querySelector('.session-row-wrap')).toHaveClass('has-audio');
+		expect(container.querySelector('.session-streaming')).toBeNull();
+		await fireEvent.click(badge);
+		expect(navigateToSession).toHaveBeenCalledWith(session);
+		expect(onSelect).not.toHaveBeenCalled();
+		expect(shellStore.workspacePanelUrlTabId).toBe(tab.tabId);
+		expect(shellStore.focusedPane).toBe('web');
+	});
+
+	it('opens an audio chooser with keyboard focus and mutes without navigating', async () => {
+		const music = addAudioTab('Music');
+		addAudioTab('Video');
+		shellStore.setFocusedPane('chat');
+		const { getByRole, queryByRole } = render(SessionRow, {
+			session,
+			onSelect: vi.fn(),
+			onDelete: vi.fn(),
+			onPin: vi.fn(),
+			onContextMenu: vi.fn()
+		});
+		const badge = getByRole('button', { name: 'Audio tabs for Audio session' });
+		await fireEvent.click(badge);
+		const chooser = getByRole('dialog', { name: 'Audio tabs' });
+		expect(within(chooser).getAllByRole('button')[0]).toHaveFocus();
+		await fireEvent.click(within(chooser).getByRole('button', { name: 'Mute Music' }));
+		expect(music.surface.toggleAudioMuted).toHaveBeenCalledOnce();
+		expect(within(chooser).getByRole('button', { name: 'Unmute Music' })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect(navigateToSession).not.toHaveBeenCalled();
+		expect(shellStore.focusedPane).toBe('chat');
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(queryByRole('dialog')).toBeNull();
+		expect(badge).toHaveFocus();
+	});
+
+	it('keeps muted controls available and restores the dot after all audio tabs close', async () => {
+		const music = addAudioTab('Music');
+		const video = addAudioTab('Video');
+		const { container, getByRole, queryByRole } = render(SessionRow, {
+			session,
+			onSelect: vi.fn(),
+			onDelete: vi.fn(),
+			onPin: vi.fn(),
+			onContextMenu: vi.fn()
+		});
+		music.surface.toggleAudioMuted();
+		video.surface.toggleAudioMuted();
+		await tick();
+		const badge = getByRole('button', { name: 'Audio tabs for Audio session' });
+		expect(badge).toHaveClass('muted');
+		await fireEvent.click(badge);
+		expect(getByRole('dialog')).toBeTruthy();
+		webTabActivity.clear();
+		await tick();
+		expect(queryByRole('dialog')).toBeNull();
+		expect(queryByRole('button', { name: 'Audio tabs for Audio session' })).toBeNull();
+		expect(container.querySelector('.session-row-wrap')).not.toHaveClass('has-audio');
+		expect(container.querySelector('.session-streaming')).toHaveClass('active');
+	});
+
+	it('closes the chooser on an outside click without selecting the session', async () => {
+		addAudioTab('Music');
+		addAudioTab('Video');
+		const onSelect = vi.fn();
+		const { getByRole, queryByRole } = render(SessionRow, {
+			session,
+			onSelect,
+			onDelete: vi.fn(),
+			onPin: vi.fn(),
+			onContextMenu: vi.fn()
+		});
+		await fireEvent.click(getByRole('button', { name: 'Audio tabs for Audio session' }));
+		await fireEvent.pointerDown(document.body);
+		expect(queryByRole('dialog')).toBeNull();
+		expect(onSelect).not.toHaveBeenCalled();
+		expect(navigateToSession).not.toHaveBeenCalled();
+	});
+
+	it('dismisses the narrow sidebar when revealing a playing tab', async () => {
+		addAudioTab('Music');
+		shellStore.openSidebar();
+		const media = window.matchMedia('(max-width: 900px)');
+		vi.spyOn(window, 'matchMedia').mockReturnValue({ ...media, matches: true });
+		const { getByRole } = render(SessionRow, {
+			session,
+			onSelect: vi.fn(),
+			onDelete: vi.fn(),
+			onPin: vi.fn(),
+			onContextMenu: vi.fn()
+		});
+		await fireEvent.click(getByRole('button', { name: 'Audio tabs for Audio session' }));
+		expect(shellStore.sidebarOpen).toBe(false);
+		expect(shellStore.workspacePanelUrl).toBe('https://music.example');
+	});
+});

--- a/cometline/src/lib/workspace/web-tab-activity.svelte.ts
+++ b/cometline/src/lib/workspace/web-tab-activity.svelte.ts
@@ -1,0 +1,16 @@
+import { SvelteMap } from 'svelte/reactivity';
+import type WorkspaceWebSurface from '$lib/components/WorkspaceWebSurface.svelte';
+
+export type WebTabStatus = Pick<
+	ReturnType<typeof WorkspaceWebSurface>['pageState'],
+	'showLoading' | 'loadError' | 'audible' | 'muted' | 'ready'
+>;
+
+export type WebTabActivity = {
+	sessionId: string;
+	tabId: string;
+	surface: ReturnType<typeof WorkspaceWebSurface>;
+};
+
+// References to live guests only. Binding teardown removes entries; nothing is persisted.
+export const webTabActivity = new SvelteMap<string, WebTabActivity>();


### PR DESCRIPTION
## Background

Persistent web tabs need clear loading feedback and a way to identify and mute background audio. The sidebar should show audio in the existing left-side dot position, not beside the hover-only pin and delete actions, with only one status indicator visible at a time.

[270aaeb](https://github.com/Cometline/cometline/commit/270aaebaa868dd64e9309a1535a0fef1350f6fbf): Add delayed main-frame loading indicators, navigation-error feedback, and native audibility/mute tracking for each live guest. Web tabs can be muted without switching tabs or moving pane focus; the sidebar audio indicator reveals a single playing tab or opens a chooser for multiple tabs. Audio replaces the original status dot while present, muted controls remain available, and reduced-motion preferences are respected without introducing notification sounds.

make check passed, including Go tests, type checking, lint, and 1,087 Vitest tests. The renderer production build also passed. Regression coverage includes silent media, Web Audio detection, background muting, polling cleanup, guest crashes, single-indicator rendering, keyboard dismissal, and narrow-sidebar navigation. Native audio behavior is simulated in automated tests and still benefits from an Electron playback smoke test.

This PR is stacked on #136 so the diff contains only the activity UI feature, building on the persistent guests from #135.

### Reference

[Persistent web-tab lifetimes](https://github.com/Cometline/cometline/pull/135)
[Stack base: postmortem removal](https://github.com/Cometline/cometline/pull/136)